### PR TITLE
Add ability to ignore events

### DIFF
--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -27,6 +27,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     var disablePastEventObserver: DefaultsObservation?
     var declinedEventsAppereanceObserver: DefaultsObservation?
     var showEventsForPeriodObserver: DefaultsObservation?
+    var ignoredCalendarItemIDsObserver: DefaultsObservation?
+    var ignoredEventIDsObserver: DefaultsObservation?
 
     var preferencesWindow: NSWindow!
 
@@ -129,7 +131,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
                 NSLog("Changed showEventsForPeriod from \(change.oldValue) to \(change.newValue)")
                 self.statusBarItem.updateMenu()
             }
-
+            self.ignoredCalendarItemIDsObserver = Defaults.observe(.ignoredCalendarItemIDs) { change in
+                NSLog("Changed ignoredCalendarItemIDs from \(change.oldValue) to \(change.newValue)")
+                self.statusBarItem.updateMenu()
+                self.statusBarItem.updateTitle()
+            }
+            self.ignoredEventIDsObserver = Defaults.observe(.ignoredCalendarItemIDs) { change in
+                NSLog("Changed ignoredEventIDs from \(change.oldValue) to \(change.newValue)")
+                self.statusBarItem.updateMenu()
+                self.statusBarItem.updateTitle()
+            }
         }
     }
 
@@ -235,6 +246,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         preferencesWindow.center()
         preferencesWindow.orderFrontRegardless()
+    }
+
+    @objc func clickIgnoreCalendarItemID(sender: NSMenuItem) {
+        let event: EKEvent = sender.representedObject as! EKEvent
+        NSLog("Click on ignore event (\(String(describing: event.title)))!")
+        Defaults[.ignoredCalendarItemIDs].insert(event.calendarItemIdentifier)
+    }
+
+    @objc func clickUnignoreCalendarItemID(sender: NSMenuItem) {
+        let event: EKEvent = sender.representedObject as! EKEvent
+        NSLog("Click on unignore event (\(String(describing: event.title)))!")
+        Defaults[.ignoredCalendarItemIDs].remove(event.calendarItemIdentifier)
     }
 
     @objc func quit(_: NSStatusBarButton) {

--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -201,7 +201,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         let activity = NSBackgroundActivityScheduler(identifier: "leits.MeetingBar.cleanupignoredevents")
 
         activity.repeats = true
-        activity.interval = 5
+        activity.interval = 60 * 5
         activity.qualityOfService = QualityOfService.userInteractive
 
         activity.schedule { (completion: @escaping NSBackgroundActivityScheduler.CompletionHandler) in

--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -28,7 +28,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     var declinedEventsAppereanceObserver: DefaultsObservation?
     var showEventsForPeriodObserver: DefaultsObservation?
     var ignoredCalendarItemIDsObserver: DefaultsObservation?
-    var ignoredEventIDsObserver: DefaultsObservation?
 
     var preferencesWindow: NSWindow!
 
@@ -133,11 +132,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             }
             self.ignoredCalendarItemIDsObserver = Defaults.observe(.ignoredCalendarItemIDs) { change in
                 NSLog("Changed ignoredCalendarItemIDs from \(change.oldValue) to \(change.newValue)")
-                self.statusBarItem.updateMenu()
-                self.statusBarItem.updateTitle()
-            }
-            self.ignoredEventIDsObserver = Defaults.observe(.ignoredCalendarItemIDs) { change in
-                NSLog("Changed ignoredEventIDs from \(change.oldValue) to \(change.newValue)")
                 self.statusBarItem.updateMenu()
                 self.statusBarItem.updateTitle()
             }

--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -29,6 +29,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     var showEventsForPeriodObserver: DefaultsObservation?
     var ignoredEventIDsObserver: DefaultsObservation?
 
+    var eventAuth: Bool = false
+    var reminderAuth: Bool = false
     var preferencesWindow: NSWindow!
 
     func applicationDidFinishLaunching(_: Notification) {
@@ -39,7 +41,29 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             case .success(let granted):
                 if granted {
                     NSLog("Access to Calendar is granted")
-                    self.setup()
+                    self.eventAuth = true
+                    if self.eventAuth && self.reminderAuth {
+                        self.setup()
+                    }
+                } else {
+                    NSLog("Access to Calendar is denied")
+                    NSApplication.shared.terminate(self)
+                }
+            case .failure(let error):
+                NSLog(error.localizedDescription)
+                NSApplication.shared.terminate(self)
+            }
+        }
+
+        statusBarItem.eventStore.accessCheckReminder { result in
+            switch result {
+            case .success(let granted):
+                if granted {
+                    NSLog("Access to Calendar is granted")
+                    self.reminderAuth = true
+                    if self.eventAuth && self.reminderAuth {
+                        self.setup()
+                    }
                 } else {
                     NSLog("Access to Calendar is denied")
                     NSApplication.shared.terminate(self)

--- a/MeetingBar/DefaultsKeys.swift
+++ b/MeetingBar/DefaultsKeys.swift
@@ -13,7 +13,7 @@ extension Defaults.Keys {
     static let calendarTitle = Key<String>("calendarTitle", default: "") // Backward compatibility
     static let selectedCalendars = Key<[String]>("selectedCalendars", default: []) // Backward compatibility
     static let selectedCalendarIDs = Key<[String]>("selectedCalendarIDs", default: [])
-    static let ignoredCalendarItemIDs = Key<Set<String>>("ignoredCalendarItemIDs", default: [])
+    static let ignoredEventIDs = Key<Set<String>>("ignoredEventIDs", default: [])
 
     static let showEventsForPeriod = Key<ShowEventsForPeriod>("showEventsForPeriod", default: .today)
     static let joinEventNotification = Key<Bool>("joinEventNotification", default: true)

--- a/MeetingBar/DefaultsKeys.swift
+++ b/MeetingBar/DefaultsKeys.swift
@@ -13,6 +13,7 @@ extension Defaults.Keys {
     static let calendarTitle = Key<String>("calendarTitle", default: "") // Backward compatibility
     static let selectedCalendars = Key<[String]>("selectedCalendars", default: []) // Backward compatibility
     static let selectedCalendarIDs = Key<[String]>("selectedCalendarIDs", default: [])
+    static let ignoredCalendarItemIDs = Key<Set<String>>("ignoredCalendarItemIDs", default: [])
 
     static let showEventsForPeriod = Key<ShowEventsForPeriod>("showEventsForPeriod", default: .today)
     static let joinEventNotification = Key<Bool>("joinEventNotification", default: true)

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -31,6 +31,28 @@ extension EKEventStore {
         }
     }
 
+    func accessCheckReminder(_ completion: @escaping (AuthResult) -> Void) {
+        switch EKEventStore.authorizationStatus(for: .reminder) {
+        case .authorized:
+            NSLog("EventStore: reminder already authorized")
+            completion(.success(true))
+        case .denied, .notDetermined:
+            NSLog("EventStore: reminder request access")
+            self.requestAccess(
+                to: .event,
+                completion:
+                { (granted: Bool, error: Error?) -> Void in
+                    if error != nil {
+                        completion(.failure(error!))
+                    } else {
+                        completion(.success(granted))
+                    }
+                })
+        default:
+            completion(.failure(NSError(domain: "Unknown reminder authorization status", code: 0)))
+        }
+    }
+
     func getCalendars(titles: [String] = [], ids: [String] = []) -> [EKCalendar] {
         var matchedCalendars: [EKCalendar] = []
 

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -129,7 +129,6 @@ extension EKEventStore {
     func cleanupIgnoredEvents() {
         let old = Defaults[.ignoredEventIDs]
         let filtered = old.filter {event(withIdentifier: $0) != nil}
-        NSLog("Changing ignored event IDs from \(old) to \(filtered)")
         Defaults[.ignoredEventIDs] = filtered
     }
 }

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -81,7 +81,7 @@ extension EKEventStore {
         for event in nextEvents {
             // Skip event if declined
             if event.isAllDay { continue }
-            if Defaults[.ignoredCalendarItemIDs].contains(event.calendarItemIdentifier) { continue }
+            if Defaults[.ignoredEventIDs].contains(event.eventIdentifier) { continue }
             if let status = getEventStatus(event) {
                 if status == .declined { continue }
             }
@@ -102,5 +102,12 @@ extension EKEventStore {
             }
         }
         return nextEvent
+    }
+
+    func cleanupIgnoredEvents() {
+        let old = Defaults[.ignoredEventIDs]
+        let filtered = old.filter {event(withIdentifier: $0) != nil}
+        NSLog("Changing ignored event IDs from \(old) to \(filtered)")
+        Defaults[.ignoredEventIDs] = filtered
     }
 }

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -106,8 +106,13 @@ extension EKEventStore {
 
     func cleanupIgnoredEvents() {
         let old = Defaults[.ignoredEventIDs]
-        let filtered = old.filter {event(withIdentifier: $0) != nil}
-        NSLog("Changing ignored event IDs from \(old) to \(filtered)")
+        let calendars = getCalendars(ids: Defaults[.selectedCalendarIDs])
+        let now = Date()
+        let startPeriod = Calendar.current.date(byAdding: .day, value: -14, to: now)!
+        let endPeriod = Calendar.current.date(byAdding: .day, value: 14, to: now)!
+        let predicate = self.predicateForEvents(withStart: startPeriod, end: endPeriod, calendars: calendars)
+        let allEvents = Set(self.events(matching: predicate).map { $0.eventIdentifier })
+        let filtered = old.filter {allEvents.contains($0)}
         Defaults[.ignoredEventIDs] = filtered
     }
 }

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -81,6 +81,7 @@ extension EKEventStore {
         for event in nextEvents {
             // Skip event if declined
             if event.isAllDay { continue }
+            if Defaults[.ignoredCalendarItemIDs].contains(event.calendarItemIdentifier) { continue }
             if let status = getEventStatus(event) {
                 if status == .declined { continue }
             }

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -128,13 +128,8 @@ extension EKEventStore {
 
     func cleanupIgnoredEvents() {
         let old = Defaults[.ignoredEventIDs]
-        let calendars = getCalendars(ids: Defaults[.selectedCalendarIDs])
-        let now = Date()
-        let startPeriod = Calendar.current.date(byAdding: .day, value: -14, to: now)!
-        let endPeriod = Calendar.current.date(byAdding: .day, value: 14, to: now)!
-        let predicate = self.predicateForEvents(withStart: startPeriod, end: endPeriod, calendars: calendars)
-        let allEvents = Set(self.events(matching: predicate).map { $0.eventIdentifier })
-        let filtered = old.filter {allEvents.contains($0)}
+        let filtered = old.filter {event(withIdentifier: $0) != nil}
+        NSLog("Changing ignored event IDs from \(old) to \(filtered)")
         Defaults[.ignoredEventIDs] = filtered
     }
 }

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -218,6 +218,8 @@ class StatusBarItemControler {
                     status = " 👎 Canceled"
                 case .tentative:
                     status = " ☝️ Tentative"
+                case .unknown:
+                    status = " ❔ Unknown"
                 default:
                     status = " ❔ (\(String(describing: eventStatus))))"
                 }
@@ -394,14 +396,13 @@ func openEvent(_ event: EKEvent) {
 }
 
 func getEventStatus(_ event: EKEvent) -> EKParticipantStatus? {
-    if event.hasAttendees {
-        if let attendees = event.attendees {
-            if let currentUser = attendees.first(where: { $0.isCurrentUser }) {
-                return currentUser.participantStatus
-            }
-        }
+    guard event.hasAttendees else {
+        return nil
     }
-    return EKParticipantStatus.unknown
+    if let currentUser = event.attendees?.first(where: { $0.isCurrentUser }) {
+        return currentUser.participantStatus
+    }
+    return .unknown
 }
 
 func getMeetingLink(_ event: EKEvent) -> (service: MeetingServices, url: URL)? {

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -309,12 +309,12 @@ class StatusBarItemControler {
             if event.hasRecurrenceRules {
                 // (un)Ignore this event
                 eventMenu.addItem(NSMenuItem.separator())
-                if Defaults[.ignoredCalendarItemIDs].contains(event.calendarItemIdentifier) {
-                    let unignoreMenuItem = NSMenuItem(title: "Unignore this event", action: #selector(AppDelegate.clickUnignoreCalendarItemID(sender:)), keyEquivalent: "")
+                if Defaults[.ignoredEventIDs].contains(event.eventIdentifier) {
+                    let unignoreMenuItem = NSMenuItem(title: "Unignore this event", action: #selector(AppDelegate.clickUnignoreEventID(sender:)), keyEquivalent: "")
                     unignoreMenuItem.representedObject = event
                     eventMenu.addItem(unignoreMenuItem)
                 } else {
-                    let ignoreMenuItem = NSMenuItem(title: "Ignore this event", action: #selector(AppDelegate.clickIgnoreCalendarItemID(sender:)), keyEquivalent: "")
+                    let ignoreMenuItem = NSMenuItem(title: "Ignore this event", action: #selector(AppDelegate.clickIgnoreEventID(sender:)), keyEquivalent: "")
                     ignoreMenuItem.representedObject = event
                     eventMenu.addItem(ignoreMenuItem)
                 }

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -303,6 +303,18 @@ class StatusBarItemControler {
                     item.attributedTitle = NSAttributedString(string: itemTitle, attributes: attributes)
                 }
             }
+
+            // (un)Ignore this event
+            eventMenu.addItem(NSMenuItem.separator())
+            if Defaults[.ignoredCalendarItemIDs].contains(event.calendarItemIdentifier) {
+                let unignoreMenuItem = NSMenuItem(title: "Unignore this event", action: #selector(AppDelegate.clickUnignoreCalendarItemID(sender:)), keyEquivalent: "")
+                unignoreMenuItem.representedObject = event
+                eventMenu.addItem(unignoreMenuItem)
+            } else {
+                let ignoreMenuItem = NSMenuItem(title: "Ignore this event", action: #selector(AppDelegate.clickIgnoreCalendarItemID(sender:)), keyEquivalent: "")
+                ignoreMenuItem.representedObject = event
+                eventMenu.addItem(ignoreMenuItem)
+            }
         }
     }
 

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -304,16 +304,18 @@ class StatusBarItemControler {
                 }
             }
 
-            // (un)Ignore this event
-            eventMenu.addItem(NSMenuItem.separator())
-            if Defaults[.ignoredCalendarItemIDs].contains(event.calendarItemIdentifier) {
-                let unignoreMenuItem = NSMenuItem(title: "Unignore this event", action: #selector(AppDelegate.clickUnignoreCalendarItemID(sender:)), keyEquivalent: "")
-                unignoreMenuItem.representedObject = event
-                eventMenu.addItem(unignoreMenuItem)
-            } else {
-                let ignoreMenuItem = NSMenuItem(title: "Ignore this event", action: #selector(AppDelegate.clickIgnoreCalendarItemID(sender:)), keyEquivalent: "")
-                ignoreMenuItem.representedObject = event
-                eventMenu.addItem(ignoreMenuItem)
+            if event.hasRecurrenceRules {
+                // (un)Ignore this event
+                eventMenu.addItem(NSMenuItem.separator())
+                if Defaults[.ignoredCalendarItemIDs].contains(event.calendarItemIdentifier) {
+                    let unignoreMenuItem = NSMenuItem(title: "Unignore this event", action: #selector(AppDelegate.clickUnignoreCalendarItemID(sender:)), keyEquivalent: "")
+                    unignoreMenuItem.representedObject = event
+                    eventMenu.addItem(unignoreMenuItem)
+                } else {
+                    let ignoreMenuItem = NSMenuItem(title: "Ignore this event", action: #selector(AppDelegate.clickIgnoreCalendarItemID(sender:)), keyEquivalent: "")
+                    ignoreMenuItem.representedObject = event
+                    eventMenu.addItem(ignoreMenuItem)
+                }
             }
         }
     }


### PR DESCRIPTION
Prevents showing ignored events in status bar title and removes them from eligibility for "join next meeting." Note that this operates on calendar items, not specific events, so all future events for that item are also ignored.

### Status
**IN DEVELOPMENT**

### Description
Quick buggy fix of #55 that works for me personally. Introduces an empty `Status: ` with a debug string for events that aren't `Accepted`. Not sure if this approach is the best, just throwing it out there in case anyone finds it useful.

### Steps to Test or Reproduce
![image](https://user-images.githubusercontent.com/9858187/91254194-4e341b80-e727-11ea-828b-53b66c450d9b.png)
![image](https://user-images.githubusercontent.com/9858187/91254207-57bd8380-e727-11ea-84c0-67e30e7d1fd1.png)

