### PR TITLE
Add Google Account Detection

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -110,3 +110,7 @@ enum JoinEventNotificationTime: Int, Codable {
     case minuteBefore = 60
     case fiveMinuteBefore = 300
 }
+
+struct GoogleRegex {
+    static let emailAddress = try! NSRegularExpression(pattern: #""mailto:(.+@.+)""#)
+}

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Andrii Leitsius. All rights reserved.
 //
 import Cocoa
+import EventKit
 
 func getMatch(text: String, regex: NSRegularExpression) -> String? {
     let resultsIterator = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
@@ -73,6 +74,18 @@ func getRegexForService(_ service: MeetingServices) -> NSRegularExpression? {
         if child.label == String(describing: service) {
             return (child.value as! NSRegularExpression)
         }
+    }
+    return nil
+}
+
+func getGmailAccount(_ event: EKEvent) -> String? {
+    // Hacky and likely to break, but should work until Apple changes something
+    let regex = GoogleRegex.emailAddress
+    let text = event.calendar.source.description
+    let resultsIterator = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+    let resultsMap = resultsIterator.map { String(text[Range($0.range(at: 1), in: text)!]) }
+    if !resultsMap.isEmpty {
+        return resultsMap.first
     }
     return nil
 }

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -394,7 +394,13 @@ func getMeetingLink(_ event: EKEvent) -> (service: MeetingServices, url: URL)? {
     for field in linkFields {
         for service in MeetingServices.allCases {
             if let regex = getRegexForService(service) {
-                if let link = getMatch(text: field, regex: regex) {
+                if var link = getMatch(text: field, regex: regex) {
+                    if service == .meet,
+                        let account = getGmailAccount(event),
+                        let urlEncodedAccount = account.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
+                        link += "?authuser=\(urlEncodedAccount)"
+                    }
+                    
                     if let url = URL(string: link) {
                         return (service, url)
                     }


### PR DESCRIPTION
### Status
**READY**

### Description
Add the capability to detect Google Account (would like to test this on more accounts, works on the 3 accounts I have currently).
When opening a Google Meet link, it ill add `authuser` parameter with the detected account.
Fixes #24 and #34 

### Steps to Test or Reproduce

1. Have 2 different Google Accounts, and select `A` as default in Google
2. Open a Meeting for account B
3. You will have to change account

### Notes
This solution is Hacky and likely to break with an update, but doesn't use any private API, so it should be fine if you want to release MeetingBar in the macOS Store
