### PR TITLE
Added check for event URL field

### DIFF
--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -387,6 +387,9 @@ func getMeetingLink(_ event: EKEvent) -> (service: MeetingServices, url: URL)? {
     if let location = event.location {
         linkFields.append(location)
     }
+    if let url = event.url {
+        linkFields.append(url.absoluteString)
+    }
     if let notes = event.notes {
         linkFields.append(notes)
     }


### PR DESCRIPTION
### Status
READY

### Description
I don't think this is optimal, but it's simple. Using URL from EKCalendarItem, adds url.absoluteString to linkFields, which is then converted back again. I prefer to leave Zoom links in this field.

### Steps to Test or Reproduce
Tested both a Zoom and a Google Meet link in URL field (3rd field from bottom) in macOS 10.15.6 calendar 