### PR TITLE
Fix printin optional string as event status

### DIFF
--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -225,8 +225,16 @@ class StatusBarItemControler {
                     status = " 👎 Canceled"
                 case .tentative:
                     status = " ☝️ Tentative"
+                case .pending:
+                    status = " ⏳ Pending"
+                case .unknown:
+                    status = " ❔ Unknown"
                 default:
-                    status = " ❔ (\(String(describing: eventStatus))))"
+                    if let eventStatus = eventStatus {
+                        status = " ❔ (\(String(describing: eventStatus)))"
+                    } else {
+                        status = " ❔ (Unknown)"
+                    }
                 }
                 eventMenu.addItem(withTitle: "Status: \(status)", action: nil, keyEquivalent: "")
                 eventMenu.addItem(NSMenuItem.separator())


### PR DESCRIPTION
Fixes #77 

### Description
Fix issue #77 adding more cases to the switch statement and verifying the variables nullability state before parsing it to String

### Steps to Test or Reproduce
Any meeting with status different of Accepted, Canceled or Tentative was causing this unexpected behaviour
