### PR TITLE
Enable convenient dev team identifier override for contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 .DS_Store
 .DS_Store?
 
+# Development Team override
+XCConfig/DevTeamOverride.xcconfig
+
 # XCode generated files
 MeetingBar.xcodeproj/project.xcworkspace/xcuserdata/*
 MeetingBar.xcodeproj/xcuserdata/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 
-# Contributing to Transcriptase
+# Contributing to MeetingBar
 We love your input! We want to make contributing to this project as easy and transparent as possible, whether it's:
 
 - Reporting a bug
@@ -25,6 +25,12 @@ We use GitHub issues to track public bugs. Report a bug by [opening a new issue]
 - Notes (possibly including why you think this might be happening, or stuff you tried that didn't work)
 
 People *love* thorough bug reports. I'm not even kidding.
+
+## Building locally
+To build MeetingBar on your computer, you need to configure the project to use your own Apple-supplied development team. You can do this *without making changes to the Xcode project*, by creating the plain-text file `XCConfig/DevTeamOverride.xcconfig` containing the following:
+```
+DEVELOPMENT_TEAM = <your development team id here>"
+```
 
 ## License
 By contributing, you agree that your contributions will be licensed under its Apache License 2.0.

--- a/MeetingBar.xcodeproj/project.pbxproj
+++ b/MeetingBar.xcodeproj/project.pbxproj
@@ -65,6 +65,9 @@
 		40DC704C250E5BB100217DD9 /* AutoLauncher.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AutoLauncher.entitlements; sourceTree = "<group>"; };
 		40DC7053250E5E1000217DD9 /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
 		40E60312250E81EA005986C7 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		E4DD0F0A2529D0D20029E395 /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
+		E4DD0F0B2529D0D20029E395 /* Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Project.xcconfig; sourceTree = "<group>"; };
+		E4DD0F0C2529D0D20029E395 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -102,6 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				14158D3A246C65AD0006436C /* README.md */,
+				E4DD0F092529D0D20029E395 /* XCConfig */,
 				144C017B2462D0C3000C9FFC /* MeetingBar */,
 				40DC7041250E5B9C00217DD9 /* AutoLauncher */,
 				144C017A2462D0C3000C9FFC /* Products */,
@@ -163,6 +167,16 @@
 				40DC7053250E5E1000217DD9 /* ServiceManagement.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		E4DD0F092529D0D20029E395 /* XCConfig */ = {
+			isa = PBXGroup;
+			children = (
+				E4DD0F0B2529D0D20029E395 /* Project.xcconfig */,
+				E4DD0F0A2529D0D20029E395 /* Project-Release.xcconfig */,
+				E4DD0F0C2529D0D20029E395 /* Project-Debug.xcconfig */,
+			);
+			path = XCConfig;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -333,6 +347,7 @@
 /* Begin XCBuildConfiguration section */
 		144C018A2462D0C5000C9FFC /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E4DD0F0C2529D0D20029E395 /* Project-Debug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -396,6 +411,7 @@
 		};
 		144C018B2462D0C5000C9FFC /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = E4DD0F0A2529D0D20029E395 /* Project-Release.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -461,7 +477,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 100;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = KGH289N6T8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = MeetingBar/Info.plist;
@@ -488,7 +503,6 @@
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 100;
 				DEVELOPMENT_ASSET_PATHS = "";
-				DEVELOPMENT_TEAM = KGH289N6T8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				INFOPLIST_FILE = MeetingBar/Info.plist;
@@ -513,7 +527,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = KGH289N6T8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = AutoLauncher/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -536,7 +549,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
-				DEVELOPMENT_TEAM = KGH289N6T8;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = AutoLauncher/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ If you have some installation problems or some other questions please check the 
 
 If the service you use isn't supported, add a comment [here](https://github.com/leits/MeetingBar/issues/62).
 
+## Contribute
+
+Read more [here](CONTRIBUTING.md) about how to contribute to MeetingBar.
+
 ## Support the creator
 
 ❤️ Love this project? Support @leits's FOSS on [Patreon](https://www.patreon.com/meetingbar)

--- a/XCConfig/Project-Debug.xcconfig
+++ b/XCConfig/Project-Debug.xcconfig
@@ -1,0 +1,1 @@
+#include "Project.xcconfig"

--- a/XCConfig/Project-Release.xcconfig
+++ b/XCConfig/Project-Release.xcconfig
@@ -1,0 +1,1 @@
+#include "Project.xcconfig"

--- a/XCConfig/Project.xcconfig
+++ b/XCConfig/Project.xcconfig
@@ -1,0 +1,2 @@
+DEVELOPMENT_TEAM = KGH289N6T8
+#include? "DevTeamOverride.xcconfig"


### PR DESCRIPTION
### Status
**READY**

### Description
The goal of this PR is to make it easier for contributors to set up code signing under a personal development team, without having to dirty up the project files.

I did this by removing the existing dev team identifier `KGH289N6T8` from the xcode project, instead configuring it in an xccconfig file, with "optional include" of a developer-provided xcconfig file `DevTeamOverride.xcconfig` (included in `.gitignore`)

A contributor should add his or her dev team identifier in the `DevTeamOverride.xcconfig`, and reopen/clean the project to use it.

I hope this is clear.

PS. Similar idea used here:
https://github.com/Ranchero-Software/NetNewsWire/blob/main/README.md
