### PR TITLE
Proposal: Small language tweak for date header

### DIFF
--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -111,7 +111,7 @@ class StatusBarItemControler {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = "E, d MMM"
         let dateString = dateFormatter.string(from: date)
-        let dateTitle = "\(title) events (\(dateString)):"
+        let dateTitle = "\(title) (\(dateString)):"
         let titleItem = self.item.menu!.addItem(
             withTitle: dateTitle,
             action: nil,


### PR DESCRIPTION
### Status
**READY**

### Description
The menu section of "Today meeting ($date)" is a little quirky from a grammatical perspective. Ideally, it would read "Today*’s* meeting" (or 'meetings'). 

To sidestep this, a proposal for your consideration:
• Remove the word "meeting" -- that way it's `Today ($date)` or `Tomorrow ($date)`. The word "meeting" is probably unnecessary since users know the list contains meetings in the first place :)  Plus, this sidesteps needing to pluralize the word "meeting" based on how many there are. 

If you're interested, here's a super tiny PR to that effect :)
