### PR TITLE
Fix installation instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Integrated with 20+ meeting services so you can quickly join meetings from event
 
 1. Install:
   * From the [App Store](https://apps.apple.com/us/app/id1532419400)
-  * From homebrew `brew cask install meetingbar`
+  * From homebrew `brew install --cask meetingbar`
   * Manual download the [latest version](https://github.com/leits/MeetingBar/releases/latest/download/MeetingBar.dmg)
 2. Make sure your calendar synchronized to macOS calendar or [add a calendar account](https://support.apple.com/guide/calendar/add-or-delete-calendar-accounts-icl4308d6701/mac).
 3. Open the app and go through the onboarding.


### PR DESCRIPTION
### Status
**READY**

### Description
Fix error when installing using latest Homebrew. Just fix README.md.

Here is screenshot:

![Calling brew cask install is disabled](https://user-images.githubusercontent.com/8146876/103058060-891a6300-45e4-11eb-82a9-5be4913c841c.png)


### Steps to Test or Reproduce
Run `brew cask install meetingbar` and `brew install --cask meetingbar` in the terminal.
