### PR TITLE
Truncate whitespace

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -13,6 +13,11 @@ struct TitleLengthLimits {
     static let max = 55.0
 }
 
+struct TitleTruncationRules {
+    static let excludeAtEnds = CharacterSet.whitespacesAndNewlines
+            .union(CharacterSet.punctuationCharacters)
+}
+
 struct LinksRegex {
     let meet = try! NSRegularExpression(pattern: #"https://meet.google.com/[a-z-]+"#)
     let hangouts = try! NSRegularExpression(pattern: #"https://hangouts.google.com/[^\s]*"#)

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -54,7 +54,7 @@ func generateTitleSample(_ titleFormat: EventTitleFormat, _ offset: Int) -> Stri
     switch titleFormat {
     case .show:
         title = "An event with an excessively sizeable 55-character title"
-        let index = title.index(title.startIndex, offsetBy: offset, limitedBy: title.endIndex)
+        let index = title.index(title.startIndex, offsetBy: offset - 1, limitedBy: title.endIndex)
         title = String(title[...(index ?? title.endIndex)])
         if offset < (title.count - 1) {
             title += "..."

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -56,6 +56,7 @@ func generateTitleSample(_ titleFormat: EventTitleFormat, _ offset: Int) -> Stri
         title = "An event with an excessively sizeable 55-character title"
         let index = title.index(title.startIndex, offsetBy: offset - 1, limitedBy: title.endIndex)
         title = String(title[...(index ?? title.endIndex)])
+                .trimmingCharacters(in: TitleTruncationRules.excludeAtEnds)
         if offset < (title.count - 1) {
             title += "..."
         }

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -19,7 +19,7 @@ class StatusBarItemControler {
 
     init() {
         item = NSStatusBar.system.statusItem(
-            withLength: NSStatusItem.variableLength
+                withLength: NSStatusItem.variableLength
         )
         let statusBarMenu = NSMenu(title: "MeetingBar in Status Bar Menu")
         item.menu = statusBarMenu
@@ -100,17 +100,17 @@ class StatusBarItemControler {
             let nextEvent = eventStore.getNextEvent(calendars: calendars)
             if nextEvent != nil {
                 let joinItem = item.menu!.addItem(
-                    withTitle: "Join next event meeting",
-                    action: #selector(AppDelegate.joinNextMeeting),
-                    keyEquivalent: ""
+                        withTitle: "Join next event meeting",
+                        action: #selector(AppDelegate.joinNextMeeting),
+                        keyEquivalent: ""
                 )
                 joinItem.setShortcut(for: .joinEventShortcut)
             }
         }
         let createItem = item.menu!.addItem(
-            withTitle: "Create meeting",
-            action: #selector(AppDelegate.createMeeting),
-            keyEquivalent: ""
+                withTitle: "Create meeting",
+                action: #selector(AppDelegate.createMeeting),
+                keyEquivalent: ""
         )
         createItem.setShortcut(for: .createMeetingShortcut)
     }
@@ -124,20 +124,22 @@ class StatusBarItemControler {
         let dateString = dateFormatter.string(from: date)
         let dateTitle = "\(title) (\(dateString)):"
         let titleItem = item.menu!.addItem(
-            withTitle: dateTitle,
-            action: nil,
-            keyEquivalent: ""
+                withTitle: dateTitle,
+                action: nil,
+                keyEquivalent: ""
         )
         titleItem.attributedTitle = NSAttributedString(string: dateTitle, attributes: [NSAttributedString.Key.font: NSFont.boldSystemFont(ofSize: 13)])
         titleItem.isEnabled = false
 
         // Events
-        let sortedEvents = events.sorted { $0.startDate < $1.startDate }
+        let sortedEvents = events.sorted {
+            $0.startDate < $1.startDate
+        }
         if sortedEvents.isEmpty {
             let item = self.item.menu!.addItem(
-                withTitle: "Nothing for \(title.lowercased())",
-                action: nil,
-                keyEquivalent: ""
+                    withTitle: "Nothing for \(title.lowercased())",
+                    action: nil,
+                    keyEquivalent: ""
             )
             item.isEnabled = false
         }
@@ -182,15 +184,15 @@ class StatusBarItemControler {
         // Event Item
         let itemTitle = "\(eventStartTime) - \(eventTitle)"
         let eventItem = item.menu!.addItem(
-            withTitle: itemTitle,
-            action: #selector(AppDelegate.clickOnEvent(sender:)),
-            keyEquivalent: ""
+                withTitle: itemTitle,
+                action: #selector(AppDelegate.clickOnEvent(sender:)),
+                keyEquivalent: ""
         )
 
         if eventStatus == .declined {
             eventItem.attributedTitle = NSAttributedString(
-                string: itemTitle,
-                attributes: [NSAttributedString.Key.strikethroughStyle: NSUnderlineStyle.thick.rawValue]
+                    string: itemTitle,
+                    attributes: [NSAttributedString.Key.strikethroughStyle: NSUnderlineStyle.thick.rawValue]
             )
         }
         if event.endDate < now {
@@ -285,7 +287,9 @@ class StatusBarItemControler {
             // Attendees
             if event.hasAttendees {
                 let attendees: [EKParticipant] = event.attendees ?? []
-                let count = attendees.filter { $0.participantType == .person }.count
+                let count = attendees.filter {
+                    $0.participantType == .person
+                }.count
                 let sortedAttendees = attendees.sorted {
                     if $0.participantRole.rawValue != $1.participantRole.rawValue {
                         return $0.participantRole.rawValue < $1.participantRole.rawValue
@@ -342,14 +346,14 @@ class StatusBarItemControler {
 
     func createPreferencesSection() {
         item.menu!.addItem(
-            withTitle: "Preferences",
-            action: #selector(AppDelegate.openPrefecencesWindow),
-            keyEquivalent: ","
+                withTitle: "Preferences",
+                action: #selector(AppDelegate.openPrefecencesWindow),
+                keyEquivalent: ","
         )
         item.menu!.addItem(
-            withTitle: "Quit",
-            action: #selector(AppDelegate.quit),
-            keyEquivalent: "q"
+                withTitle: "Quit",
+                action: #selector(AppDelegate.quit),
+                keyEquivalent: "q"
         )
     }
 }
@@ -360,10 +364,12 @@ func createEventStatusString(_ event: EKEvent) -> String {
     var eventTitle: String
     switch Defaults[.eventTitleFormat] {
     case .show:
-        eventTitle = String(event.title ?? "No title").trimmingCharacters(in: .whitespaces)
+        eventTitle = String(event.title ?? "No title")
+                .trimmingCharacters(in: TitleTruncationRules.excludeAtEnds)
         if eventTitle.count > Int(Defaults[.titleLength]) {
-            let index = eventTitle.index(eventTitle.startIndex, offsetBy: Int(Defaults[.titleLength]))
+            let index = eventTitle.index(eventTitle.startIndex, offsetBy: Int(Defaults[.titleLength]) - 1)
             eventTitle = String(eventTitle[...index])
+                    .trimmingCharacters(in: TitleTruncationRules.excludeAtEnds)
             eventTitle += "..."
         }
     case .dot:


### PR DESCRIPTION
Previously, if you had a meeting called "ABC DEF GHI" and truncated it to four characters long, it would appear as `ABC ...`. Now it shows as `ABC...`, which is the expected behavior.

This commit also fixes a bug that caused names to be truncated to one character longer than the length slider's actual position (`String.index`'s `offsetBy` parameter is funky).

### Status
**READY**

### Description
It's common to have long meeting names on your calendar, and many users with smaller screens will want to use the truncation setting. It works pretty well, but it looks a bit weird when there's whitespace or other punctuation before the ellipsis. This PR updates the truncation behavior to be more consistent with what users expect to see.

### Steps to Test or Reproduce
Create a calendar event with a long name and try dragging the length slider in MeetingBar's preferences. Make sure the observed length matches up with the slider's position and that whitespace is truncated as expected.
