### PR TITLE
feat(events): allow to hide events without a meeting service

### DIFF
--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -25,6 +25,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
     var allDayEventsObserver: DefaultsObservation?
     var allDayEventsWithLinkOnlyObserver: DefaultsObservation?
+    var eventsWithLinkOnlyObserver: DefaultsObservation?
+
     var titleLengthObserver: DefaultsObservation?
     var timeFormatObserver: DefaultsObservation?
 
@@ -135,7 +137,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
         self.showEventDetailsObserver = Defaults.observe(.showEventDetails) { change in
             NSLog("Change showEventDetails from \(change.oldValue) to \(change.newValue)")
-            self.statusBarItem.updateMenu()
+            if change.oldValue != change.newValue {
+                self.statusBarItem.updateMenu()
+            }
         }
 
         self.showEventEndDateObserver = Defaults.observe(.showEventEndDate) { change in
@@ -193,6 +197,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         allDayEventsWithLinkOnlyObserver = Defaults.observe(.allDayEventsWithLinkOnly) { change in
             NSLog("Change allDayEventsWithLinkOnly from \(change.oldValue) to \(change.newValue)")
+            self.statusBarItem.updateMenu()
+        }
+
+        eventsWithLinkOnlyObserver = Defaults.observe(.eventsWithLinkOnly) { change in
+            NSLog("Change eventsWithLinkOnly from \(change.oldValue) to \(change.newValue)")
+            self.statusBarItem.updateTitle()
             self.statusBarItem.updateMenu()
         }
 

--- a/MeetingBar/DefaultsKeys.swift
+++ b/MeetingBar/DefaultsKeys.swift
@@ -70,6 +70,9 @@ extension Defaults.Keys {
     // show all day events only when they have a meeting link
     static let allDayEventsWithLinkOnly = Key<Bool>("allDayEventsWithLinkOnly", default: false)
 
+    // show non all day events only when they have a meeting link
+    static let eventsWithLinkOnly = Key<Bool>("eventsWithLinkOnly", default: false)
+
     // show the end date of a meeting in the meetingbar for each event entry
     static let showEventEndDate = Key<Bool>("showEventEndDate", default: true)
 

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -37,6 +37,7 @@ extension EKEventStore {
         var filteredCalendarEvents = [EKEvent]()
 
         let allDayLinksOnly = Defaults[.allDayEventsWithLinkOnly]
+        let eventsWithLinksOnly = Defaults[.eventsWithLinkOnly]
 
         for calendarEvent in calendarEvents {
             if calendarEvent.isAllDay {
@@ -50,7 +51,15 @@ extension EKEventStore {
                     }
                 }
             } else {
-                filteredCalendarEvents.append(calendarEvent)
+                if eventsWithLinksOnly {
+                    let result = getMeetingLink(calendarEvent)
+
+                    if result?.url != nil {
+                        filteredCalendarEvents.append(calendarEvent)
+                    }
+                } else {
+                    filteredCalendarEvents.append(calendarEvent)
+                }
             }
         }
 

--- a/MeetingBar/PreferencesView.swift
+++ b/MeetingBar/PreferencesView.swift
@@ -240,6 +240,8 @@ struct Menu: View {
     @Default(.pastEventsAppereance) var pastEventsAppereance
     @Default(.allDayEvents) var allDayEvents
     @Default(.allDayEventsWithLinkOnly) var allDayEventsWithLinkOnly
+    @Default(.eventsWithLinkOnly) var eventsWithLinkOnly
+
 
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -263,9 +265,20 @@ struct Menu: View {
                     Text(String(Int(menuEventTitleLength)))
                 }
                 Group {
+                    HStack {
+                        Picker("Time format:", selection: $timeFormat) {
+                            Text("12-hour (AM/PM)").tag(TimeFormat.am_pm)
+                            Text("24-hour").tag(TimeFormat.military)
+                        }
+                    }
+
                     Toggle("Show event end date", isOn: $showEventEndDate)
                     Toggle("Show event icon", isOn: $showMeetingServiceIcon)
                     Toggle("Show event details as submenu", isOn: $showEventDetails)
+
+                    Text("Hide events").font(.headline).bold().padding(10)
+
+                    Toggle("Show (non all day) events with meeting links only", isOn: $eventsWithLinkOnly)
 
                     HStack {
                         Toggle("Show all day events", isOn: $allDayEvents)
@@ -290,12 +303,6 @@ struct Menu: View {
                             Text("show").tag(PastEventsAppereance.show_active)
                             Text("show as inactive").tag(PastEventsAppereance.show_inactive)
                             Text("hide").tag(PastEventsAppereance.hide)
-                        }
-                    }
-                    HStack {
-                        Picker("Time format:", selection: $timeFormat) {
-                            Text("12-hour (AM/PM)").tag(TimeFormat.am_pm)
-                            Text("24-hour").tag(TimeFormat.military)
                         }
                     }
                 }


### PR DESCRIPTION
- the user can now hide meetings without any online meeting at all
- the default settings is off, so meetings without any online meeting link are displayed

KNOWN ISSUE: the menubar next event is not updated correctly

