### PR TITLE
various UX improvements:

### DIFF
--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -24,13 +24,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     var showMeetingServiceIconObserver: DefaultsObservation?
 
     var allDayEventsObserver: DefaultsObservation?
-    var allDayEventsWithLinkOnlyObserver: DefaultsObservation?
-    var eventsWithLinkOnlyObserver: DefaultsObservation?
 
     var titleLengthObserver: DefaultsObservation?
     var timeFormatObserver: DefaultsObservation?
 
     var eventTitleFormatObserver: DefaultsObservation?
+    var eventTitleLayoutObserver: DefaultsObservation?
+    var eventTimeFormatObserver: DefaultsObservation?
+
     var eventTitleIconFormatObserver: DefaultsObservation?
 
     var shortenEventTitleObserver: DefaultsObservation?
@@ -134,11 +135,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         NotificationCenter.default.addObserver(self, selector: #selector(AppDelegate.eventStoreChanged), name: .EKEventStoreChanged, object: statusBarItem.eventStore)
 
-        self.selectedCalendarIDsObserver = Defaults.observe(.selectedCalendarIDs) { change in
-            NSLog("Changed selectedCalendarIDs from \(change.oldValue) to \(change.newValue)")
-            self.statusBarItem.loadCalendars()
-        }
-        self.showEventDetailsObserver = Defaults.observe(.showEventDetails) { change in
+
+        showEventDetailsObserver = Defaults.observe(.showEventDetails) { change in
             NSLog("Change showEventDetails from \(change.oldValue) to \(change.newValue)")
             if change.oldValue != change.newValue {
                 self.statusBarItem.updateMenu()
@@ -146,50 +144,48 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
 
 
-        self.shortenEventTitleObserver = Defaults.observe(.shortenEventTitle) { change in
+        shortenEventTitleObserver = Defaults.observe(.shortenEventTitle) { change in
             NSLog("Change shortenEventTitle from \(change.oldValue) to \(change.newValue)")
             if change.oldValue != change.newValue {
                 self.statusBarItem.updateMenu()
             }
         }
 
-        self.menuEventTitleLengthObserver = Defaults.observe(.menuEventTitleLength) { change in
+        menuEventTitleLengthObserver = Defaults.observe(.menuEventTitleLength) { change in
             NSLog("Change menuEventTitleLengthObserver from \(change.oldValue) to \(change.newValue)")
             if change.oldValue != change.newValue {
                 self.statusBarItem.updateMenu()
             }
         }
 
-        self.showEventEndDateObserver = Defaults.observe(.showEventEndDate) { change in
+        showEventEndDateObserver = Defaults.observe(.showEventEndDate) { change in
             NSLog("Change showEventEndDate from \(change.oldValue) to \(change.newValue)")
             if change.oldValue != change.newValue {
                 self.statusBarItem.updateMenu()
             }
         }
 
-        self.timeFormatObserver = Defaults.observe(.timeFormat) { change in
-            NSLog("Change timeFormat from \(change.oldValue) to \(change.newValue)")
-            self.statusBarItem.updateMenu()
-        }
-        self.eventTitleFormatObserver = Defaults.observe(.eventTitleFormat) { change in
-            NSLog("Changed eventTitleFormat from \(String(describing: change.oldValue)) to \(String(describing: change.newValue))")
-            self.statusBarItem.updateTitle()
+        eventTitleLayoutObserver = Defaults.observe(.eventTitleLayout) { change in
+            NSLog("Changed eventTitleLayout from \(String(describing: change.oldValue)) to \(String(describing: change.newValue))")
+            if change.oldValue != change.newValue {
+                self.statusBarItem.updateTitle()
+            }
         }
 
-        self.titleLengthObserver = Defaults.observe(.titleLength) { change in
+        eventTimeFormatObserver = Defaults.observe(.eventTimeFormat) { change in
+            NSLog("Changed eventTimeFormat from \(String(describing: change.oldValue)) to \(String(describing: change.newValue))")
+            if change.oldValue != change.newValue {
+                self.statusBarItem.updateTitle()
+            }
+        }
+
+        titleLengthObserver = Defaults.observe(.titleLength) { change in
             NSLog("Changed titleLength from \(change.oldValue) to \(change.newValue)")
             self.statusBarItem.updateTitle()
         }
-        self.disablePastEventObserver = Defaults.observe(.disablePastEvents) { change in
+
+        disablePastEventObserver = Defaults.observe(.disablePastEvents) { change in
             NSLog("Changed disablePastEvents from \(String(describing: change.oldValue)) to \(String(describing: change.newValue))")
-            self.statusBarItem.updateMenu()
-        }
-        self.declinedEventsAppereanceObserver = Defaults.observe(.declinedEventsAppereance) { change in
-            NSLog("Changed declinedEventsAppereance from \(change.oldValue) to \(change.newValue)")
-            self.statusBarItem.updateMenu()
-        }
-        self.showEventsForPeriodObserver = Defaults.observe(.showEventsForPeriod) { change in
-            NSLog("Changed showEventsForPeriod from \(change.oldValue) to \(change.newValue)")
             self.statusBarItem.updateMenu()
         }
 
@@ -198,10 +194,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             NSLog("Changed selectedCalendarIDs from \(change.oldValue) to \(change.newValue)")
             self.statusBarItem.loadCalendars()
         }
-        showEventDetailsObserver = Defaults.observe(.showEventDetails) { change in
-            NSLog("Change showEventDetails from \(change.oldValue) to \(change.newValue)")
-            self.statusBarItem.updateMenu()
-        }
+
 
         showMeetingServiceIconObserver = Defaults.observe(.showMeetingServiceIcon) { change in
             NSLog("Change showMeetingServiceIcon from \(change.oldValue) to \(change.newValue)")
@@ -210,16 +203,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
 
         allDayEventsObserver = Defaults.observe(.allDayEvents) { change in
             NSLog("Change allDayEvents from \(change.oldValue) to \(change.newValue)")
-            self.statusBarItem.updateMenu()
-        }
-
-        allDayEventsWithLinkOnlyObserver = Defaults.observe(.allDayEventsWithLinkOnly) { change in
-            NSLog("Change allDayEventsWithLinkOnly from \(change.oldValue) to \(change.newValue)")
-            self.statusBarItem.updateMenu()
-        }
-
-        eventsWithLinkOnlyObserver = Defaults.observe(.eventsWithLinkOnly) { change in
-            NSLog("Change eventsWithLinkOnly from \(change.oldValue) to \(change.newValue)")
             self.statusBarItem.updateTitle()
             self.statusBarItem.updateMenu()
         }
@@ -238,10 +221,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             self.statusBarItem.updateTitle()
         }
 
-        titleLengthObserver = Defaults.observe(.titleLength) { change in
-            NSLog("Changed titleLength from \(change.oldValue) to \(change.newValue)")
-            self.statusBarItem.updateTitle()
-        }
+
         pastEventsAppereanceObserver = Defaults.observe(.pastEventsAppereance) { change in
             NSLog("Changed pastEventsAppereance from \(change.oldValue) to \(change.newValue)")
             self.statusBarItem.updateMenu()
@@ -425,7 +405,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             preferencesWindow.close()
         }
         preferencesWindow = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 600, height: 650),
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 550),
             styleMask: [.closable, .titled, .resizable],
             backing: .buffered,
             defer: false

--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -118,7 +118,7 @@ enum AuthResult {
 }
 
 /**
- * 
+ * the icon to display in the status bar
  */
 enum EventTitleIconFormat: String, Codable, CaseIterable {
     case calendar = "iconCalendar"
@@ -129,14 +129,36 @@ enum EventTitleIconFormat: String, Codable, CaseIterable {
     case none = "no_online_session"
 }
 
+/**
+ * the layout of the event title in the status bar
+ */
+enum EventTitleLayout: String, Codable, CaseIterable {
+    case onerow = "1 row"
+    case tworow = "2 rows"
+}
+
 enum EventTitleFormat: String, Codable, CaseIterable {
     case show
     case dot
     case none
 }
 
+/**
+ * format for time in statusbar - can be shown or be hidden
+ */
+enum EventTimeFormat: String, Codable, CaseIterable {
+    case show
+    case hide
+}
+
 enum DeclinedEventsAppereance: String, Codable, CaseIterable {
     case strikethrough
+    case hide
+}
+
+enum AlldayEventsAppereance: String, Codable, CaseIterable {
+    case show
+    case show_with_meeting_link_only
     case hide
 }
 

--- a/MeetingBar/DefaultsKeys.swift
+++ b/MeetingBar/DefaultsKeys.swift
@@ -24,9 +24,11 @@ extension Defaults.Keys {
     // Status Bar Appearance
     static let showEventTitleInStatusBar = Key<Bool?>("showEventTitleInStatusBar") // Backward compatibility
     static let eventTitleFormat = Key<EventTitleFormat>("eventTitleFormat", default: .show)
-    static let eventTitleIconFormat = Key<EventTitleIconFormat>("eventTitleIconFormat", default: .none)
+    static let eventTimeFormat = Key<EventTimeFormat>("eventTimeFormat", default: .show)
 
+    static let eventTitleIconFormat = Key<EventTitleIconFormat>("eventTitleIconFormat", default: .none)
     static let titleLength = Key<Double>("titleLength", default: TitleLengthLimits.max)
+    static let eventTitleLayout = Key<EventTitleLayout>("eventTitleLayout", default: .onerow)
 
     // Menu Appearance
     // if the event title in the menu should be shortened or not -> the length will be stored in field menuEventTitleLength
@@ -69,12 +71,7 @@ extension Defaults.Keys {
     static let bookmarkMeetingURL5 = Key<String>("bookmarkMeetingURL5", default: "")
 
     // show all day events - by default true
-    static let allDayEvents = Key<Bool>("allDayEvents", default: true)
-    // show all day events only when they have a meeting link
-    static let allDayEventsWithLinkOnly = Key<Bool>("allDayEventsWithLinkOnly", default: false)
-
-    // show non all day events only when they have a meeting link
-    static let eventsWithLinkOnly = Key<Bool>("eventsWithLinkOnly", default: false)
+    static let allDayEvents = Key<AlldayEventsAppereance>("allDayEvents", default: AlldayEventsAppereance.show)
 
     // show the end date of a meeting in the meetingbar for each event entry
     static let showEventEndDate = Key<Bool>("showEventEndDate", default: true)

--- a/MeetingBar/EventStore.swift
+++ b/MeetingBar/EventStore.swift
@@ -29,21 +29,20 @@ extension EKEventStore {
     func loadEventsForDate(calendars: [EKCalendar], date: Date) -> [EKEvent] {
         let dayMidnight = Calendar.current.startOfDay(for: date)
         let nextDayMidnight = Calendar.current.date(byAdding: .day, value: 1, to: dayMidnight)!
-        let showAllDayEvents = Defaults[.allDayEvents]
+
+        let showAlldayEvents: Bool = Defaults[.allDayEvents] == AlldayEventsAppereance.show
 
         let predicate = predicateForEvents(withStart: dayMidnight, end: nextDayMidnight, calendars: calendars)
-        let calendarEvents = events(matching: predicate).filter { ($0.isAllDay && showAllDayEvents) || Calendar.current.isDate($0.startDate, inSameDayAs: dayMidnight) }
+        let calendarEvents = events(matching: predicate).filter { ($0.isAllDay && showAlldayEvents) || Calendar.current.isDate($0.startDate, inSameDayAs: dayMidnight) }
 
         var filteredCalendarEvents = [EKEvent]()
 
-        let allDayLinksOnly = Defaults[.allDayEventsWithLinkOnly]
-        let eventsWithLinksOnly = Defaults[.eventsWithLinkOnly]
 
         for calendarEvent in calendarEvents {
             if calendarEvent.isAllDay {
-                if showAllDayEvents && !allDayLinksOnly {
+                if Defaults[.allDayEvents] == AlldayEventsAppereance.show {
                     filteredCalendarEvents.append(calendarEvent)
-                } else if showAllDayEvents && allDayLinksOnly {
+                } else if Defaults[.allDayEvents] == AlldayEventsAppereance.show_with_meeting_link_only {
                     let result = getMeetingLink(calendarEvent)
 
                     if result?.url != nil {
@@ -51,15 +50,7 @@ extension EKEventStore {
                     }
                 }
             } else {
-                if eventsWithLinksOnly {
-                    let result = getMeetingLink(calendarEvent)
-
-                    if result?.url != nil {
-                        filteredCalendarEvents.append(calendarEvent)
-                    }
-                } else {
-                    filteredCalendarEvents.append(calendarEvent)
-                }
+                 filteredCalendarEvents.append(calendarEvent)
             }
         }
 

--- a/MeetingBar/PreferencesView.swift
+++ b/MeetingBar/PreferencesView.swift
@@ -16,11 +16,12 @@ struct PreferencesView: View {
         VStack {
             TabView {
                 General().tabItem { Text("General") }
+                Events().tabItem { Text("Events") }
                 StatusBar().tabItem { Text("Statusbar") }
                 Menu().tabItem { Text("Menu") }
                 Configuration().tabItem { Text("Services") }
-                Calendars().tabItem { Text("Calendars") }
                 Bookmark().tabItem { Text("Bookmarks") }
+                Calendars().tabItem { Text("Calendars") }
                 Advanced().tabItem { Text("Advanced") }
             }
         }.padding()
@@ -101,7 +102,7 @@ struct Calendars: View {
                     }
                 Spacer()
             }
-        }.onAppear { self.loadCalendarList() }
+        }.onAppear { self.loadCalendarList() }.padding()
     }
 
     func loadCalendarList() {
@@ -198,23 +199,21 @@ struct General: View {
 struct StatusBar: View {
     @Default(.eventTitleIconFormat) var eventTitleIconFormat
     @Default(.eventTitleFormat) var eventTitleFormat
+    @Default(.eventTimeFormat) var eventTimeFormat
+    @Default(.eventTitleLayout) var eventTitleLayout
 
     @Default(.titleLength) var titleLength
+
 
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
             Text("Status bar").font(.headline).bold()
             Section {
-                Text("Next event").font(.subheadline).bold()
                 HStack {
-                    Text("Sample")
-
-                    HStack {
-                        Image(nsImage: generateTitleIconSample(eventTitleIconFormat))
-                        Text(generateTitleSample(eventTitleFormat, Int(titleLength)))
-                        Spacer()
-                    }.padding(.all, 10)
-                    .border(Color.gray, width: 3)
+                    Picker("Layout", selection: $eventTitleLayout) {
+                        Text("One row").tag(EventTitleLayout.onerow)
+                        Text("Two rows").tag(EventTitleLayout.tworow)
+                    }
                 }
 
                 HStack {
@@ -250,7 +249,6 @@ struct StatusBar: View {
                             Text("\u{00A0}Event specific icon (e.g. MS Teams)")
                         }.tag(EventTitleIconFormat.eventtype)
 
-
                         HStack {
                             Image(nsImage: NSImage(named: EventTitleIconFormat.none.rawValue)!).resizable()
                                 .frame(width: 16.0, height: 16.0)
@@ -263,9 +261,28 @@ struct StatusBar: View {
                     Picker("Title", selection: $eventTitleFormat) {
                         Text("event title").tag(EventTitleFormat.show)
                         Text("dot (•)").tag(EventTitleFormat.dot)
-                        Text("-").tag(EventTitleFormat.none)
+                        Text("hide").tag(EventTitleFormat.none)
                     }
                 }
+                HStack {
+                    Picker("Time", selection: $eventTimeFormat) {
+                        Text("show").tag(EventTimeFormat.show)
+                        Text("hide").tag(EventTimeFormat.hide)
+                    }
+                }
+                Divider()
+
+                HStack {
+                    Text("Sample")
+
+                    HStack {
+                        Image(nsImage: generateTitleIconSample(eventTitleIconFormat))
+                        Text(generateTitleSample(eventTitleFormat, Int(titleLength)))
+                        Spacer()
+                    }.padding(.all, 10)
+                    .border(Color.gray, width: 3)
+                }
+
 
 
                 HStack {
@@ -274,8 +291,54 @@ struct StatusBar: View {
                     Text("55")
                 }.disabled(eventTitleFormat != EventTitleFormat.show)
 
-
                 Text("Tip: If the app disappears from the status bar, make the length shorter").foregroundColor(Color.gray)
+            }.padding(.horizontal, 10)
+
+            Spacer()
+        }.padding()
+    }
+}
+
+struct Events: View {
+    @Default(.declinedEventsAppereance) var declinedEventsAppereance
+    @Default(.personalEventsAppereance) var personalEventsAppereance
+    @Default(.pastEventsAppereance) var pastEventsAppereance
+    @Default(.allDayEvents) var allDayEvents
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 15) {
+            Text("Events").font(.headline).bold()
+            Section {
+                Group {
+                    HStack {
+                        Picker("All day events:", selection: $allDayEvents) {
+                            Text("show all").tag(AlldayEventsAppereance.show)
+                            Text("show all with meeting link").tag(AlldayEventsAppereance.show_with_meeting_link_only)
+                            Text("hide all").tag(AlldayEventsAppereance.hide)
+                        }
+                    }
+
+                    HStack {
+                        Picker("Past events:", selection: $pastEventsAppereance) {
+                            Text("show").tag(PastEventsAppereance.show_active)
+                            Text("show as inactive").tag(PastEventsAppereance.show_inactive)
+                            Text("hide").tag(PastEventsAppereance.hide)
+                        }
+                    }
+                    HStack {
+                        Picker("Declined events:", selection: $declinedEventsAppereance) {
+                            Text("show with strikethrough").tag(DeclinedEventsAppereance.strikethrough)
+                            Text("hide").tag(DeclinedEventsAppereance.hide)
+                        }
+                    }
+                    HStack {
+                        Picker("Events without guests:", selection: $personalEventsAppereance) {
+                            Text("show").tag(PastEventsAppereance.show_active)
+                            Text("show as inactive").tag(PastEventsAppereance.show_inactive)
+                            Text("hide").tag(PastEventsAppereance.hide)
+                        }
+                    }
+                }
             }.padding(.horizontal, 10)
 
             Spacer()
@@ -290,13 +353,6 @@ struct Menu: View {
     @Default(.showEventEndDate) var showEventEndDate
     @Default(.showEventDetails) var showEventDetails
     @Default(.showMeetingServiceIcon) var showMeetingServiceIcon
-    @Default(.declinedEventsAppereance) var declinedEventsAppereance
-    @Default(.personalEventsAppereance) var personalEventsAppereance
-    @Default(.pastEventsAppereance) var pastEventsAppereance
-    @Default(.allDayEvents) var allDayEvents
-    @Default(.allDayEventsWithLinkOnly) var allDayEventsWithLinkOnly
-    @Default(.eventsWithLinkOnly) var eventsWithLinkOnly
-
 
     var body: some View {
         VStack(alignment: .leading, spacing: 15) {
@@ -330,36 +386,6 @@ struct Menu: View {
                     Toggle("Show event end date", isOn: $showEventEndDate)
                     Toggle("Show event icon", isOn: $showMeetingServiceIcon)
                     Toggle("Show event details as submenu", isOn: $showEventDetails)
-
-                    Text("Hide events").font(.headline).bold().padding(10)
-
-                    Toggle("Show (non all day) events with meeting links only", isOn: $eventsWithLinkOnly)
-
-                    HStack {
-                        Toggle("Show all day events", isOn: $allDayEvents)
-                        Toggle("... with meeting links only", isOn: ($allDayEventsWithLinkOnly)).disabled(!$allDayEvents.wrappedValue)
-                    }
-
-                    HStack {
-                        Picker("Past events:", selection: $pastEventsAppereance) {
-                            Text("show").tag(PastEventsAppereance.show_active)
-                            Text("show as inactive").tag(PastEventsAppereance.show_inactive)
-                            Text("hide").tag(PastEventsAppereance.hide)
-                        }
-                    }
-                    HStack {
-                        Picker("Declined events:", selection: $declinedEventsAppereance) {
-                            Text("show with strikethrough").tag(DeclinedEventsAppereance.strikethrough)
-                            Text("hide").tag(DeclinedEventsAppereance.hide)
-                        }
-                    }
-                    HStack {
-                        Picker("Events without guests:", selection: $personalEventsAppereance) {
-                            Text("show").tag(PastEventsAppereance.show_active)
-                            Text("show as inactive").tag(PastEventsAppereance.show_inactive)
-                            Text("hide").tag(PastEventsAppereance.hide)
-                        }
-                    }
                 }
             }.padding(.horizontal, 10)
 
@@ -375,7 +401,7 @@ struct Configuration: View {
     @Default(.useAppForTeamsLinks) var useAppForTeamsLinks
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 15) {
+        VStack {
             Section {
                 Picker(selection: $useChromeForMeetLinks, label: Text("Open Meet links in").frame(width: 150, alignment: .leading)) {
                     Text("Default Browser").tag(ChromeExecutable.defaultBrowser)
@@ -403,6 +429,7 @@ struct Configuration: View {
                 Text("Create meetings in").frame(width: 150, alignment: .leading)
                 CreateMeetingServicePicker()
             }.padding(.horizontal, 10)
+            Spacer()
         }.padding()
     }
 }


### PR DESCRIPTION
- support one or two-row status bar rendering
- separate preferences menu into several tabs, e.g. for visibility of events
- allow to display or hide the title in the status bar
- allow to display or hide event time in the status bar
- avoid flickering updating the status menu when it is open by rendering in the main thread
- fix layout in the menu for 12-hour format
