### PR TITLE
feat(meeting-service): support zoom native links

### DIFF
--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -384,7 +384,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             openEvent(nextEvent)
         } else {
             NSLog("No next event")
-            sendNotification("There are no next meetings today", "Woohoo! It's time to make cocoa")
+            sendNotification(title: "There are no next meetings today", text: "Woohoo! It's time to make cocoa", subtitle: "")
             return
         }
     }

--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -384,7 +384,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             openEvent(nextEvent)
         } else {
             NSLog("No next event")
-            sendNotification(title: "There are no next meetings today", text: "Woohoo! It's time to make cocoa", subtitle: "")
+            sendNotification(title: "There are no next meetings today", text: "Woohoo! It's time to make cocoa")
             return
         }
     }

--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -26,7 +26,14 @@ struct TitleTruncationRules {
 struct LinksRegex {
     let meet = try! NSRegularExpression(pattern: #"https://meet.google.com/[a-z-]+"#)
     let hangouts = try! NSRegularExpression(pattern: #"https://hangouts.google.com/[^\s]*"#)
+
     let zoom = try! NSRegularExpression(pattern: #"https://([a-z0-9-.]+)?zoom.(us|com.cn)/j/[^\s]*"#)
+
+    /**
+     * Examples:
+     * - zoom native links: zoommtg://zoom.us/join?confno=92333341349&uname=Person&pwd=123456
+     */
+    let zoom_native = try! NSRegularExpression(pattern: #"zoommtg://([a-z0-9-.]+)?zoom.(us|com.cn)/join[^\s]*"#)
     let teams = try! NSRegularExpression(pattern: #"https://teams.microsoft.com/l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+"#)
     let webex = try! NSRegularExpression(pattern: #"https://([a-z0-9.]+)?webex.com/[^\s]*"#)
     let jitsi = try! NSRegularExpression(pattern: #"https://meet.jit.si/[^\s]*"#)
@@ -86,6 +93,7 @@ enum MeetingServices: String, Codable, CaseIterable {
     case meet = "Google Meet"
     case hangouts = "Google Hangouts"
     case zoom = "Zoom"
+    case zoom_native = "Zoom native"
     case teams = "Microsoft Teams"
     case webex = "Cisco Webex"
     case jitsi = "Jitsi"

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -28,7 +28,7 @@ func openLinkInChrome(_ link: URL) {
             NSLog("Open \(link) in Chrome")
         } else {
             NSLog("Can't open \(link) in Chrome: \(String(describing: error?.localizedDescription))")
-            sendNotification("Oops! Unable to open the link in Chrome", "Make sure you have Chrome installed, or change the browser in the preferences.")
+            sendNotification(title: "Oops! Unable to open the link in Chrome", text: "Make sure you have Chrome installed, or change the browser in the preferences.")
             _ = openLinkInDefaultBrowser(link)
         }
     }
@@ -42,7 +42,7 @@ func openLinkInChromium(_ link: URL) {
             NSLog("Open \(link) in Chromium")
         } else {
             NSLog("Can't open \(link) in Chromium: \(String(describing: error?.localizedDescription))")
-            sendNotification("Oops! Unable to open the link in Chromium", "Make sure you have Chromium installed, or change the browser in the preferences.")
+            sendNotification(title: "Oops! Unable to open the link in Chromium", text: "Make sure you have Chromium installed, or change the browser in the preferences.")
             _ = openLinkInDefaultBrowser(link)
         }
     }

--- a/MeetingBar/Notifications.swift
+++ b/MeetingBar/Notifications.swift
@@ -37,7 +37,7 @@ func registerNotificationCategories() {
     notificationCenter.setNotificationCategories([eventCategory])
 }
 
-func sendNotification(_ title: String, _ text: String) {
+func sendNotification(title: String, text: String, subtitle: String = "") {
     requestNotificationAuthorization() // By the apple best practices
 
     NSLog("Send notification: \(title) - \(text)")
@@ -46,6 +46,9 @@ func sendNotification(_ title: String, _ text: String) {
     let content = UNMutableNotificationContent()
     content.title = title
     content.body = text
+    if !subtitle.isEmpty {
+        content.subtitle = subtitle
+    }
 
     let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
     let request = UNNotificationRequest(identifier: UUID().uuidString, content: content, trigger: trigger)

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -277,7 +277,6 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
             withTitle: dateTitle,
             action: nil,
             keyEquivalent: ""
-
         )
         titleItem.attributedTitle = NSAttributedString(string: dateTitle, attributes: [NSAttributedString.Key.font: NSFont.boldSystemFont(ofSize: 13)])
         titleItem.isEnabled = false
@@ -291,7 +290,6 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
                 withTitle: "Nothing for \(title.lowercased())",
                 action: nil,
                 keyEquivalent: ""
-
             )
             item.isEnabled = false
         }
@@ -325,7 +323,7 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
             image!.size = NSSize(width: 16, height: 17.8)
 
         // tested and verified
-        case .some(.zoom), .some(.zoomgov):
+        case .some(.zoom), .some(.zoomgov), .some(.zoom_native):
             image = NSImage(named: "zoom_icon")!
             image!.size = NSSize(width: 16, height: 16)
 
@@ -800,14 +798,14 @@ func openEvent(_ event: EKEvent) {
                 let task = try! NSUserAppleScriptTask(url: url)
                 task.execute { error in
                     if let error = error {
-                        sendNotification("AppleScript return error", error.localizedDescription)
+                        sendNotification(title: "AppleScript return error", text: error.localizedDescription)
                     }
                 }
             }
         }
         openMeetingURL(service, url)
     } else {
-        sendNotification("Epp! Can't join the \(eventTitle)", "Link not found, or your meeting service is not yet supported")
+        sendNotification(title: "Epp! Can't join the \(eventTitle)", text: "Link not found, or your meeting service is not yet supported")
     }
 }
 
@@ -840,7 +838,7 @@ func openMeetingURL(_ service: MeetingServices?, _ url: URL) {
             teamsAppURL.scheme = "msteams"
             let result = openLinkInDefaultBrowser(teamsAppURL.url!)
             if !result {
-                sendNotification("Oops! Unable to open the link in Microsoft Teams app", "Make sure you have Microsoft Teams app installed, or change the app in the preferences.")
+                sendNotification(title: "Oops! Unable to open the link in Microsoft Teams app", text: "Make sure you have Microsoft Teams app installed, or change the app in the preferences.")
                 _ = openLinkInDefaultBrowser(url)
             }
         } else {
@@ -853,11 +851,21 @@ func openMeetingURL(_ service: MeetingServices?, _ url: URL) {
             zoomAppUrl.scheme = "zoommtg"
             let result = openLinkInDefaultBrowser(zoomAppUrl.url!)
             if !result {
-                sendNotification("Oops! Unable to open the link in Zoom app", "Make sure you have Zoom app installed, or change the app in the preferences.")
+                sendNotification(title: "Oops! Unable to open the link in Zoom app", text: "Make sure you have Zoom app installed, or change the app in the preferences.")
                 _ = openLinkInDefaultBrowser(url)
             }
         } else {
             _ = openLinkInDefaultBrowser(url)
+        }
+    case .zoom_native:
+        let result = openLinkInDefaultBrowser(url)
+        if !result {
+            sendNotification(title: "Oops! Unable to open the native link in Zoom app", text: "Make sure you have Zoom app installed, or change the app in the preferences.", subtitle: url.absoluteString)
+
+            let urlString = url.absoluteString.stringByReplacingFirstOccurrenceOfString(target: "&", withString: "?").replacingOccurrences(of: "/join?confno=", with: "/j/")
+            var zoomBrowserUrl = URLComponents(url: URL(string: urlString)!, resolvingAgainstBaseURL: false)!
+            zoomBrowserUrl.scheme = "https"
+            _ = openLinkInDefaultBrowser(zoomBrowserUrl.url!)
         }
     case .facetime:
         NSWorkspace.shared.open(URL(string: "facetime://" + url.absoluteString)!)

--- a/MeetingBar/String.swift
+++ b/MeetingBar/String.swift
@@ -10,34 +10,42 @@ import Foundation
 
 extension String {
     enum TruncationPosition {
-           case head
-           case middle
-           case tail
-       }
+        case head
+        case middle
+        case tail
+    }
 
     /*
      Truncates the string to the specified length number of characters and appends an optional trailing string if longer.
      - Parameter length: Desired maximum lengths of a string
      - Parameter trailing: A 'String' that will be appended after the truncation.
-
+     
      - Returns: 'String' object.
      */
-   func trunc(limit: Int, position: TruncationPosition = .tail, leader: String = "...") -> String {
-       guard self.count > limit else {
+    func trunc(limit: Int, position: TruncationPosition = .tail, leader: String = "...") -> String {
+        guard self.count > limit else {
+            return self
+        }
+
+        switch position {
+        case .head:
+            return leader + self.suffix(limit)
+        case .middle:
+            let headCharactersCount = Int(ceil(Float(limit - leader.count) / 2.0))
+
+            let tailCharactersCount = Int(floor(Float(limit - leader.count) / 2.0))
+
+            return "\(self.prefix(headCharactersCount))\(leader)\(self.suffix(tailCharactersCount))"
+        case .tail:
+            return self.prefix(limit) + leader
+        }
+    }
+
+
+    func stringByReplacingFirstOccurrenceOfString( target: String, withString replaceString: String ) -> String {
+        if let range = self.range(of: target) {
+            return self.replacingCharacters(in: range, with: replaceString)
+        }
         return self
-       }
-
-       switch position {
-       case .head:
-           return leader + self.suffix(limit)
-       case .middle:
-           let headCharactersCount = Int(ceil(Float(limit - leader.count) / 2.0))
-
-           let tailCharactersCount = Int(floor(Float(limit - leader.count) / 2.0))
-
-           return "\(self.prefix(headCharactersCount))\(leader)\(self.suffix(tailCharactersCount))"
-       case .tail:
-           return self.prefix(limit) + leader
-       }
-   }
+    }
 }


### PR DESCRIPTION


### Status
**READY**

### Description
- zoom native links with scheme zoommtg scheme are now recognized.
- the url will be passed directly to be opened- the url will not be modified.
- the zoom native service will get the same icon in the toolbar

### Steps to Test or Reproduce
Include a sample zoommtg-link, e.g. zoommtg://zoom.us/join?confno=92333341349&uname=Person&pwd=123456 into a calendar event.
The event is recognized as zoom meeting

![image](https://user-images.githubusercontent.com/3872101/103957112-4b701b00-514a-11eb-9552-45ef77331a62.png)

