### PR TITLE
Fix/skype selfhosted regex

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -51,7 +51,7 @@ struct LinksRegex {
     let facebook_workspace = try! NSRegularExpression(pattern: #"https://([a-z0-9-.]+)?workplace.com/[^\s]"#)
     let skype = try! NSRegularExpression(pattern: #"https://join.skype.com/[^\s]*"#)
     let skype4biz = try! NSRegularExpression(pattern: #"https://meet.lync.com/[^\s]*"#)
-    let skype4biz_selfhosted = try! NSRegularExpression(pattern: #"https://meet|join\.[^\s]*"#)
+    let skype4biz_selfhosted = try! NSRegularExpression(pattern: #"https:\/\/(meet|join)\.[^\s]*\/[a-z0-9.]+/meet\/[A-Za-z0-9./]+"#)
     let lifesize = try! NSRegularExpression(pattern: #"https://call.lifesizecloud.com/[^\s]*"#)
 }
 


### PR DESCRIPTION
### Status
**READY**

### Description
The skype selfhosted regex was not working as expected.
It does not match this example url:
https://join.xxx.com/xxx.de/meet/xxx.xxx.xxx/LVBCZ5QT

### Steps to Test or Reproduce

- Create a meeting with the mentioned url
- Check if meetingbar is recognizing the url as meeting service
- With this regex change meetingbar will detect the link as meeting...
