### PR TITLE
Fix HTML test

### DIFF
--- a/MeetingBar/Extensions/String.swift
+++ b/MeetingBar/Extensions/String.swift
@@ -51,8 +51,8 @@ extension String {
 
     /// A Boolean value indicating whether the string contains HTML tags.
     var containsHTML: Bool {
-        let htmlTest = NSPredicate(format: "SELF MATCHES %@", #"</?[A-z][ \t\S]*>"#)
-        return htmlTest.evaluate(with: self)
+        let htmlRange = self.range(of: #"</?[A-z][ \t\S]*>"#, options: .regularExpression)
+        return htmlRange != nil
     }
 
     /// Returns a version of the string with all HTML tags removed, if any.


### PR DESCRIPTION
@leits @jgoldhammer Sorry for the delay. This took me a bit to find out in which occasions this actually occurs. :D


### Status
**READY**

### Description
This replaces the HTML detection from #144 (based on `NSPredicate`) with Swift's `range(of:options:)` (mentioned in https://github.com/leits/MeetingBar/pull/144#issuecomment-759088414) as the `NSPredicate` one doesn't seem to work ~reliably~ when Google's wiggly line is present. `range(of:options:)` seems to be able to handle this well.

Tbh, I'm not sure why they behave differently. I know they use a different unicode engine (which e.g. count non-printing characters differently), but I don't see why this would cause the test to fail. I rather suspect a different regex engine, but that's just a guess.

### Steps to Test or Reproduce
1. Create two Google calendar events with some HTML description (`<b>Foobar</b>` is enough)
	a. First event: don't add a video call
	b. Second event: add a video call, so Google appends the wiggly line: `-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-`
(alternatively manually create them in Calendar.app, just make sure one has the wiggly line)
2. Notice that the HTML test with `NSPredicate` doesn't work on the event with the wiggly line.
3. Try with the `range(of:options:)` version, and see both work.

