### PR TITLE
Move browser link opening into URL extension

### DIFF
--- a/MeetingBar.xcodeproj/project.pbxproj
+++ b/MeetingBar.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		40DC7051250E5DB500217DD9 /* AutoLauncher.app in CopyFiles */ = {isa = PBXBuildFile; fileRef = 40DC7040250E5B9C00217DD9 /* AutoLauncher.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		40DC7054250E5E1000217DD9 /* ServiceManagement.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40DC7053250E5E1000217DD9 /* ServiceManagement.framework */; };
 		40E60313250E81EA005986C7 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 40E60312250E81EA005986C7 /* main.swift */; };
+		A7B68FA325CDE9E200CA3A68 /* URL.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7B68FA225CDE9E200CA3A68 /* URL.swift */; };
 		E249D534259BBC3800429BF1 /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = E249D533259BBC3800429BF1 /* String.swift */; };
 /* End PBXBuildFile section */
 
@@ -86,6 +87,7 @@
 		40DC704C250E5BB100217DD9 /* AutoLauncher.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = AutoLauncher.entitlements; sourceTree = "<group>"; };
 		40DC7053250E5E1000217DD9 /* ServiceManagement.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ServiceManagement.framework; path = System/Library/Frameworks/ServiceManagement.framework; sourceTree = SDKROOT; };
 		40E60312250E81EA005986C7 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
+		A7B68FA225CDE9E200CA3A68 /* URL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URL.swift; sourceTree = "<group>"; };
 		E249D533259BBC3800429BF1 /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
 		E2AE715525AA54A600D3C7CF /* DevTeamOverride.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DevTeamOverride.xcconfig; sourceTree = "<group>"; };
 		E4DD0F0A2529D0D20029E395 /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 				140D84402493B8030055E1CE /* KeyboardShortcutsNames.swift */,
 				140D843E2493B7CB0055E1CE /* DefaultsKeys.swift */,
 				E249D533259BBC3800429BF1 /* String.swift */,
+				A7B68FA225CDE9E200CA3A68 /* URL.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -371,6 +374,7 @@
 				1452C9D825AF889A00C46CDF /* WelcomeScreen.swift in Sources */,
 				1452C9BC25AF5D8700C46CDF /* Shared.swift in Sources */,
 				1452C9D225AF86E700C46CDF /* AdvancedTab.swift in Sources */,
+				A7B68FA325CDE9E200CA3A68 /* URL.swift in Sources */,
 				1452C9DC25AF88EF00C46CDF /* AccessScreen.swift in Sources */,
 				1452C9C625AF85B400C46CDF /* ServicesTab.swift in Sources */,
 				140D843F2493B7CB0055E1CE /* DefaultsKeys.swift in Sources */,

--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -396,7 +396,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     func openEventInCalendar(sender: NSMenuItem) {
         if let identifier = sender.representedObject as? String {
             let url = URL(string: "ical://ekevent/\(identifier)")!
-            _ = openLinkInDefaultBrowser(url)
+            url.openInDefaultBrowser()
         }
     }
 

--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -201,13 +201,41 @@ public enum AutoLauncher {
     static let bundleIdentifier: String = "leits.MeetingBar.AutoLauncher"
 }
 
-enum ChromeExecutable: String, Codable, CaseIterable {
+enum Browser: String, Codable, CaseIterable {
+    case brave = "Brave"
     case chrome = "Google Chrome"
     case chromium = "Chromium"
-    case firefox = "Firefox"
     case edge = "Microsoft Edge"
-    case brave = "Brave"
-    case vivaldi = "Vivaldi"
+    case firefox = "Firefox"
     case opera = "Opera"
+    case vivaldi = "Vivaldi"
     case defaultBrowser = "Default Browser"
+
+    var url: URL? {
+        switch self {
+        case .brave:
+            return URL(fileURLWithPath: "/Applications/Brave Browser.app")
+
+        case .chrome:
+            return URL(fileURLWithPath: "/Applications/Google Chrome.app")
+
+        case .chromium:
+            return URL(fileURLWithPath: "/Applications/Chromium.app")
+
+        case .edge:
+            return URL(fileURLWithPath: "/Applications/Firefox.app")
+
+        case .firefox:
+            return URL(fileURLWithPath: "/Applications/Microsoft Edge.app")
+
+        case .opera:
+            return URL(fileURLWithPath: "/Applications/Opera.app")
+
+        case .vivaldi:
+            return URL(fileURLWithPath: "/Applications/Vivaldi.app")
+
+        default:
+            return nil
+        }
+    }
 }

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -67,7 +67,7 @@ extension Defaults.Keys {
     // custom url to create meetings
     static let createMeetingServiceUrl = Key<String>("createMeetingServiceUrl", default: "")
 
-    static let browserForMeetLinks = Key<ChromeExecutable>("browserForMeetLinks", default: .defaultBrowser)
+    static let browserForMeetLinks = Key<Browser>("browserForMeetLinks", default: .defaultBrowser)
 
     static let useChromeForMeetLinks = Key<Bool?>("useChromeForMeetLinks") // Backward compatibility
     static let useAppForZoomLinks = Key<Bool>("useAppForZoomLinks", default: false)

--- a/MeetingBar/Extensions/URL.swift
+++ b/MeetingBar/Extensions/URL.swift
@@ -1,0 +1,41 @@
+//
+//  URL.swift
+//  MeetingBar
+//
+//  Created by 0bmxa on 2021-02-05.
+//  Copyright © 2021 MeetingBar. All rights reserved.
+//
+
+import AppKit
+
+extension URL {
+    func openIn(browser: Browser) {
+        guard let browserURL = browser.url else {
+            self.openInDefaultBrowser()
+            return
+        }
+        let browserName = browser.rawValue
+
+        let configuration = NSWorkspace.OpenConfiguration()
+        NSWorkspace.shared.open([self], withApplicationAt: browserURL, configuration: configuration) { app, error in
+            guard app != nil else {
+                NSLog("Can't open \(self) in \(browserName): \(String(describing: error?.localizedDescription))")
+                sendNotification(title: "Oops! Unable to open the link in \(browserName)", text: "Make sure you have \(browserName) installed, or change the browser in preferences.")
+                self.openInDefaultBrowser()
+                return
+            }
+            NSLog("Opening \(self) in \(browserName)")
+        }
+    }
+
+    @discardableResult
+    func openInDefaultBrowser() -> Bool {
+        let result = NSWorkspace.shared.open(self)
+        if result {
+            NSLog("Opening \(self) in default browser")
+        } else {
+            NSLog("Can't open \(self) in default browser")
+        }
+        return result
+    }
+}

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -25,113 +25,6 @@ func getMatch(text: String, regex: NSRegularExpression) -> String? {
     return nil
 }
 
-func openLinkInChrome(_ link: URL) {
-    let configuration = NSWorkspace.OpenConfiguration()
-    let chromeUrl = URL(fileURLWithPath: "/Applications/Google Chrome.app")
-    NSWorkspace.shared.open([link], withApplicationAt: chromeUrl, configuration: configuration) { app, error in
-        if app != nil {
-            NSLog("Open \(link) in Chrome")
-        } else {
-            NSLog("Can't open \(link) in Chrome: \(String(describing: error?.localizedDescription))")
-            sendNotification(title: "Oops! Unable to open the link in Chrome", text: "Make sure you have Chrome installed, or change the browser in the preferences.")
-            _ = openLinkInDefaultBrowser(link)
-        }
-    }
-}
-
-func openLinkInChromium(_ link: URL) {
-    let configuration = NSWorkspace.OpenConfiguration()
-    let chromiumUrl = URL(fileURLWithPath: "/Applications/Chromium.app")
-    NSWorkspace.shared.open([link], withApplicationAt: chromiumUrl, configuration: configuration) { app, error in
-        if app != nil {
-            NSLog("Open \(link) in Chromium")
-        } else {
-            NSLog("Can't open \(link) in Chromium: \(String(describing: error?.localizedDescription))")
-            sendNotification(title: "Oops! Unable to open the link in Chromium", text: "Make sure you have Chromium installed, or change the browser in the preferences.")
-            _ = openLinkInDefaultBrowser(link)
-        }
-    }
-}
-
-func openLinkInFirefox(_ link: URL) {
-    let configuration = NSWorkspace.OpenConfiguration()
-    let firefoxUrl = URL(fileURLWithPath: "/Applications/Firefox.app")
-    NSWorkspace.shared.open([link], withApplicationAt: firefoxUrl, configuration: configuration) { app, error in
-        if app != nil {
-            NSLog("Open \(link) in Firefox")
-        } else {
-            NSLog("Can't open \(link) in Firefox: \(String(describing: error?.localizedDescription))")
-            sendNotification(title: "Oops! Unable to open the link in Firefox", text: "Make sure you have Firefox installed, or change the browser in the preferences.")
-            _ = openLinkInDefaultBrowser(link)
-        }
-    }
-}
-
-func openLinkInEdge(_ link: URL) {
-    let configuration = NSWorkspace.OpenConfiguration()
-    let edgeUrl = URL(fileURLWithPath: "/Applications/Microsoft Edge.app")
-    NSWorkspace.shared.open([link], withApplicationAt: edgeUrl, configuration: configuration) { app, error in
-        if app != nil {
-            NSLog("Open \(link) in Edge")
-        } else {
-            NSLog("Can't open \(link) in Edge: \(String(describing: error?.localizedDescription))")
-            sendNotification(title: "Oops! Unable to open the link in Edge", text: "Make sure you have Edge installed, or change the browser in the preferences.")
-            _ = openLinkInDefaultBrowser(link)
-        }
-    }
-}
-
-func openLinkInBrave(_ link: URL) {
-    let configuration = NSWorkspace.OpenConfiguration()
-    let braveUrl = URL(fileURLWithPath: "/Applications/Brave Browser.app")
-    NSWorkspace.shared.open([link], withApplicationAt: braveUrl, configuration: configuration) { app, error in
-        if app != nil {
-            NSLog("Open \(link) in Brave")
-        } else {
-            NSLog("Can't open \(link) in Brave: \(String(describing: error?.localizedDescription))")
-            sendNotification(title: "Oops! Unable to open the link in Brave", text: "Make sure you have Brave installed, or change the browser in the preferences.")
-            _ = openLinkInDefaultBrowser(link)
-        }
-    }
-}
-
-func openLinkInVivaldi(_ link: URL) {
-    let configuration = NSWorkspace.OpenConfiguration()
-    let vivaldiUrl = URL(fileURLWithPath: "/Applications/Vivaldi.app")
-    NSWorkspace.shared.open([link], withApplicationAt: vivaldiUrl, configuration: configuration) { app, error in
-        if app != nil {
-            NSLog("Open \(link) in Vivaldi")
-        } else {
-            NSLog("Can't open \(link) in Vivaldi: \(String(describing: error?.localizedDescription))")
-            sendNotification(title: "Oops! Unable to open the link in Vivaldi", text: "Make sure you have Vivaldi installed, or change the browser in the preferences.")
-            _ = openLinkInDefaultBrowser(link)
-        }
-    }
-}
-
-func openLinkInOpera(_ link: URL) {
-    let configuration = NSWorkspace.OpenConfiguration()
-    let operaUrl = URL(fileURLWithPath: "/Applications/Opera.app")
-    NSWorkspace.shared.open([link], withApplicationAt: operaUrl, configuration: configuration) { app, error in
-        if app != nil {
-            NSLog("Open \(link) in Opera")
-        } else {
-            NSLog("Can't open \(link) in Opera: \(String(describing: error?.localizedDescription))")
-            sendNotification(title: "Oops! Unable to open the link in Opera", text: "Make sure you have Opera installed, or change the browser in the preferences.")
-            _ = openLinkInDefaultBrowser(link)
-        }
-    }
-}
-
-func openLinkInDefaultBrowser(_ link: URL) -> Bool {
-    let result = NSWorkspace.shared.open(link)
-    if result {
-        NSLog("Open \(link) in default browser")
-    } else {
-        NSLog("Can't open \(link) in default browser")
-    }
-    return result
-}
 
 func cleanUpNotes(_ notes: String) -> String {
     let zoomSeparator = "\n──────────"
@@ -200,7 +93,7 @@ func getGmailAccount(_ event: EKEvent) -> String? {
 }
 
 func emailMe() {
-    _ = openLinkInDefaultBrowser(Links.emailMe)
+    Links.emailMe.openInDefaultBrowser()
 }
 
 func getMeetingLink(_ event: EKEvent) -> (service: MeetingServices?, url: URL)? {

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -853,58 +853,43 @@ func getEventParticipantStatus(_ event: EKEvent) -> EKParticipantStatus? {
 func openMeetingURL(_ service: MeetingServices?, _ url: URL) {
     switch service {
     case .meet:
-        switch Defaults[.browserForMeetLinks] {
-        case .chrome:
-            openLinkInChrome(url)
-        case .chromium:
-            openLinkInChromium(url)
-        case .firefox:
-            openLinkInFirefox(url)
-        case .edge:
-            openLinkInEdge(url)
-        case .brave:
-            openLinkInBrave(url)
-        case .vivaldi:
-            openLinkInVivaldi(url)
-        case .opera:
-            openLinkInOpera(url)
-        default:
-            _ = openLinkInDefaultBrowser(url)
-        }
+        let browser = Defaults[.browserForMeetLinks]
+        url.openIn(browser: browser)
+
     case .teams:
         if Defaults[.useAppForTeamsLinks] {
             var teamsAppURL = URLComponents(url: url, resolvingAgainstBaseURL: false)!
             teamsAppURL.scheme = "msteams"
-            let result = openLinkInDefaultBrowser(teamsAppURL.url!)
+            let result = teamsAppURL.url!.openInDefaultBrowser()
             if !result {
                 sendNotification(title: "Oops! Unable to open the link in Microsoft Teams app", text: "Make sure you have Microsoft Teams app installed, or change the app in the preferences.")
-                _ = openLinkInDefaultBrowser(url)
+                url.openInDefaultBrowser()
             }
         } else {
-            _ = openLinkInDefaultBrowser(url)
+            url.openInDefaultBrowser()
         }
     case .zoom:
         if Defaults[.useAppForZoomLinks] {
             let urlString = url.absoluteString.replacingOccurrences(of: "?", with: "&").replacingOccurrences(of: "/j/", with: "/join?confno=")
             var zoomAppUrl = URLComponents(url: URL(string: urlString)!, resolvingAgainstBaseURL: false)!
             zoomAppUrl.scheme = "zoommtg"
-            let result = openLinkInDefaultBrowser(zoomAppUrl.url!)
+            let result = zoomAppUrl.url!.openInDefaultBrowser()
             if !result {
                 sendNotification(title: "Oops! Unable to open the link in Zoom app", text: "Make sure you have Zoom app installed, or change the app in the preferences.")
-                _ = openLinkInDefaultBrowser(url)
+                url.openInDefaultBrowser()
             }
         } else {
-            _ = openLinkInDefaultBrowser(url)
+            url.openInDefaultBrowser()
         }
     case .zoom_native:
-        let result = openLinkInDefaultBrowser(url)
+        let result = url.openInDefaultBrowser()
         if !result {
             sendNotification(title: "Oops! Unable to open the native link in Zoom app", text: "Make sure you have Zoom app installed, or change the app in the preferences.", subtitle: url.absoluteString)
 
             let urlString = url.absoluteString.replacingFirstOccurrence(of: "&", with: "?").replacingOccurrences(of: "/join?confno=", with: "/j/")
             var zoomBrowserUrl = URLComponents(url: URL(string: urlString)!, resolvingAgainstBaseURL: false)!
             zoomBrowserUrl.scheme = "https"
-            _ = openLinkInDefaultBrowser(zoomBrowserUrl.url!)
+            zoomBrowserUrl.url!.openInDefaultBrowser()
         }
     case .facetime:
         NSWorkspace.shared.open(URL(string: "facetime://" + url.absoluteString)!)
@@ -913,6 +898,6 @@ func openMeetingURL(_ service: MeetingServices?, _ url: URL) {
     case .phone:
         NSWorkspace.shared.open(URL(string: "tel://" + url.absoluteString)!)
     default:
-        _ = openLinkInDefaultBrowser(url)
+        url.openInDefaultBrowser()
     }
 }

--- a/MeetingBar/Views/Preferences/GeneralTab.swift
+++ b/MeetingBar/Views/Preferences/GeneralTab.swift
@@ -55,12 +55,12 @@ struct ShortcutsSection: View {
 
     func openAboutThisApp() {
         NSLog("Open AboutThisApp")
-        _ = openLinkInDefaultBrowser(Links.aboutThisApp)
+        Links.aboutThisApp.openInDefaultBrowser()
     }
 
     func openSupportTheCreator() {
         NSLog("Open SupportTheCreator")
-        _ = openLinkInDefaultBrowser(Links.supportTheCreator)
+        Links.supportTheCreator.openInDefaultBrowser()
     }
 }
 
@@ -99,12 +99,12 @@ struct AboutAppSection: View {
 
     func openAboutThisApp() {
         NSLog("Open AboutThisApp")
-        _ = openLinkInDefaultBrowser(Links.aboutThisApp)
+        Links.aboutThisApp.openInDefaultBrowser()
     }
 
     func openManual() {
         NSLog("Open manual")
-        _ = openLinkInDefaultBrowser(Links.manual)
+        Links.manual.openInDefaultBrowser()
     }
 }
 

--- a/MeetingBar/Views/Preferences/ServicesTab.swift
+++ b/MeetingBar/Views/Preferences/ServicesTab.swift
@@ -21,14 +21,9 @@ struct ServicesTab: View {
         VStack {
             Section {
                 Picker(selection: $browserForMeetLinks, label: Text("Open Meet links in").frame(width: 150, alignment: .leading)) {
-                    Text("Default Browser").tag(ChromeExecutable.defaultBrowser)
-                    Text("Chrome").tag(ChromeExecutable.chrome)
-                    Text("Chromium").tag(ChromeExecutable.chromium)
-                    Text("Firefox").tag(ChromeExecutable.firefox)
-                    Text("Microsoft Edge").tag(ChromeExecutable.edge)
-                    Text("Brave").tag(ChromeExecutable.brave)
-                    Text("Vivaldi").tag(ChromeExecutable.vivaldi)
-                    Text("Opera").tag(ChromeExecutable.opera)
+                    ForEach(Browser.allCases, id: \.self) { (browser: Browser) in
+                        Text(browser.rawValue).tag(browser)
+                    }
                 }
                 Picker(selection: $useAppForZoomLinks, label: Text("Open Zoom links in").frame(width: 150, alignment: .leading)) {
                     Text("Default Browser").tag(false)


### PR DESCRIPTION
### Status
**READY**

### Description
Hello @leits @jgoldhammer!
Not the most important update, but I felt there's a bit much in the global namespace, so I started moving some helper functions out of there. 

Specifically:
- Added an URL extension, with `openIn(browser:)` and `openInDefaultBrowser()`
- Replaced all `openLinkIn` helpers to use those two
- Renamed `ChromeExecutable` to `Browser` (does that mess with Defaults?)
- Added url property to `Browser`
- Made the list in `ServicesTab` dynamic

If you like this (and if I find time) I'd potentially look into some more options to clean up the global scope a bit. Let me know what you think!

### Steps to Test or Reproduce
- Test that link opening still works
- Test that the Meet browser from Defaults still works
- Look at the code and let me know if you think that's a good idea and the direction you want to go in!

