### PR TITLE
Fix URLs for Firefox and Microsoft Edge

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -227,10 +227,10 @@ enum Browser: String, Codable, CaseIterable {
             return URL(fileURLWithPath: "/Applications/Chromium.app")
 
         case .edge:
-            return URL(fileURLWithPath: "/Applications/Firefox.app")
+            return URL(fileURLWithPath: "/Applications/Microsoft Edge.app")
 
         case .firefox:
-            return URL(fileURLWithPath: "/Applications/Microsoft Edge.app")
+            return URL(fileURLWithPath: "/Applications/Firefox.app")
 
         case .opera:
             return URL(fileURLWithPath: "/Applications/Opera.app")


### PR DESCRIPTION
### Status
**READY**

### Description
The URLs to open `Firefox` and `Microsoft Edge` are switched. This PR assigns the correct URLs to the correct App.

### Steps to Test or Reproduce
Switch the browser in the Service settings tab and verify links are opened in the correct browser.

<img width="703" alt="Screenshot 2021-02-08 at 18 14 20" src="https://user-images.githubusercontent.com/1497750/107256202-7a272d00-6a39-11eb-9aeb-6a3d5f1d07ee.png">

