### PR TITLE
fix(icons): try to fix the unconstrained size in big sur #171

### DIFF
--- a/MeetingBar/Views/Preferences/AppearanceTab.swift
+++ b/MeetingBar/Views/Preferences/AppearanceTab.swift
@@ -37,25 +37,25 @@ struct StatusBarSection: View {
             HStack {
                 Picker("Icon", selection: $eventTitleIconFormat) {
                     HStack {
-                        Image(nsImage: NSImage(named: EventTitleIconFormat.calendar.rawValue)!).resizable()
+                        Image(nsImage: getImage(iconName: EventTitleIconFormat.calendar.rawValue)).resizable()
                             .frame(width: 16.0, height: 16.0)
                         Text("\u{00A0}Calendar icon")
                     }.tag(EventTitleIconFormat.calendar)
 
                     HStack {
-                        Image(nsImage: NSImage(named: EventTitleIconFormat.appicon.rawValue)!).resizable()
-                                .frame(width: 16.0, height: 16.0)
+                        Image(nsImage: getImage(iconName: EventTitleIconFormat.appicon.rawValue)).resizable()
+                            .frame(width: 16.0, height: 16.0)
                         Text("\u{00A0}App icon")
                     }.tag(EventTitleIconFormat.appicon)
 
                     HStack {
-                        Image(nsImage: NSImage(named: EventTitleIconFormat.eventtype.rawValue)!).resizable()
-                                .frame(width: 16.0, height: 16.0)
+                        Image(nsImage: getImage(iconName: EventTitleIconFormat.eventtype.rawValue)).resizable()
+                            .frame(width: 16.0, height: 16.0)
                         Text("\u{00A0}Event specific icon (e.g. MS Teams)")
                     }.tag(EventTitleIconFormat.eventtype)
 
                     HStack {
-                        Image(nsImage: NSImage(named: EventTitleIconFormat.none.rawValue)!).resizable()
+                        Image(nsImage: getImage(iconName: EventTitleIconFormat.none.rawValue)).resizable()
                             .frame(width: 16.0, height: 16.0)
                         Text("\u{00A0}No icon")
                     }.tag(EventTitleIconFormat.none)
@@ -80,6 +80,12 @@ struct StatusBarSection: View {
                 }
             }
         }.padding(.horizontal, 10)
+    }
+
+    func getImage(iconName: String) -> NSImage {
+        let icon = NSImage(named: iconName)
+        icon!.size = NSSize(width: 16, height: 16)
+        return icon!
     }
 }
 


### PR DESCRIPTION

### Status
**READY**

### Description
This PR should fix hopefully the issue 171. 

### Steps to Test or Reproduce

- Test with Big Sur
- Navigate to the preference dialog and open Apperance tab
- Click on the dropdown icon in the statusbar section

Due to usage of Catalina I cannot test it, but in other areas we also have set a size, so this will probably fix it.
