### PR TITLE
Fix Facebook Workplace links redirecting to Facebook profiles

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -49,7 +49,7 @@ struct LinksRegex {
     let starleaf = try! NSRegularExpression(pattern: #"https://meet.starleaf.com/[^\s]*"#)
     let duo = try! NSRegularExpression(pattern: #"https://duo.app.goo.gl/[^\s]*"#)
     let voov = try! NSRegularExpression(pattern: #"https://voovmeeting.com/[^\s]*"#)
-    let facebook_workspace = try! NSRegularExpression(pattern: #"https://([a-z0-9-.]+)?workplace.com/[^\s]"#)
+    let facebook_workspace = try! NSRegularExpression(pattern: #"https://([a-z0-9-.]+)?workplace.com/[^\s]+"#)
     let skype = try! NSRegularExpression(pattern: #"https://join.skype.com/[^\s]*"#)
     let skype4biz = try! NSRegularExpression(pattern: #"https://meet.lync.com/[^\s]*"#)
     let skype4biz_selfhosted = try! NSRegularExpression(pattern: #"https:\/\/(meet|join)\.[^\s]*\/[a-z0-9.]+/meet\/[A-Za-z0-9./]+"#)


### PR DESCRIPTION
The regex for Facebook Workplace links were only capturing the first letter after `*.workplace.com/`. This was leading to Facebook profiles being opened for Facebook employees instead of meeting links. This commit matches the entire URL and redirects to the correct meeting URL.

### Status
*READY*

### Description
The regex was only matching the first letter after `*.workplace.com`. This meant that meeting links were being redirected to `*.workplace.com/g` (instead of `*.workplace.com/groupcall`) or `*.workplace.com/m` (instead of `*.workplace.com/meeting`. For Facebook employees, who access Workplace at fb.workplace.com, this was redirecting to facebook.com/g or facebook.com/m instead of the meeting.

### Steps to Test or Reproduce
1. As a Facebook employee, create a Workplace meeting.
2. Open that meeting in MeetingBar and observe as you are redirected to facebook.com/g or facebook.com/m.
3. Add in custom RegEx `https://([a-z0-9-.]+)?workplace.com\/[^\s]+`
4. Open the same meeting and observe that the link is opened correctly.