### PR TITLE
Add support for using the Chrome Canary browser

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -213,6 +213,7 @@ public enum AutoLauncher {
 
 enum Browser: String, Codable, CaseIterable {
     case chrome = "Google Chrome"
+    case chromeCanary = "Google Chrome Canary"
     case firefox = "Firefox"
     case safari = "Safari"
     case chromium = "Chromium"
@@ -226,6 +227,9 @@ enum Browser: String, Codable, CaseIterable {
         switch self {
         case .chrome:
             return URL(fileURLWithPath: "/Applications/Google Chrome.app")
+
+        case .chromeCanary:
+            return URL(fileURLWithPath: "/Applications/Google Chrome Canary.app")
 
         case .firefox:
             return URL(fileURLWithPath: "/Applications/Firefox.app")


### PR DESCRIPTION
### Status
**READY**

### Description
I have Chrome Canary installed, but not Chrome. This PR enables using Chrome Canary as a browser for various meetings. 

### Steps to Test or Reproduce
* Run MeetingBar
* Select **Google Chrome Canary** in the Services tab for one of the services
* Schedule a meeting on said service
* When meeting time arrives, select the meeting from MeetingBar to join it 
Note that you join with Chrome Canary (if installed)