### PR TITLE
Feat/206 Temporarily Hide Meeting Name

### DIFF
--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -37,6 +37,8 @@ extension Defaults.Keys {
     static let titleLength = Key<Double?>("titleLength", default: nil) // Backward compatibility
     static let statusbarEventTitleLength = Key<Int>("statusbarEventTitleLength", default: statusbarEventTitleLengthLimits.max)
 
+    static let hideMeetingNames = Key<Bool>("hideMeetingNames", default: false)
+
     // Menu Appearance
     // if the event title in the menu should be shortened or not -> the length will be stored in field menuEventTitleLength
     static let shortenEventTitle = Key<Bool>("shortenEventTitle", default: false)

--- a/MeetingBar/Extensions/KeyboardShortcutsNames.swift
+++ b/MeetingBar/Extensions/KeyboardShortcutsNames.swift
@@ -13,4 +13,5 @@ extension KeyboardShortcuts.Name {
     static let openMenuShortcut = Self("openMenuShortcut")
     static let joinEventShortcut = Self("joinEventShortcut")
     static let openClipboardShortcut = Self("openClipboardShortcut")
+    static let toggleMeetingNameVisibilityShortcut = Self("toggleMeetingNameVisibilityShortcut")
 }

--- a/MeetingBar/Notifications.swift
+++ b/MeetingBar/Notifications.swift
@@ -137,7 +137,11 @@ func scheduleEventNotification(_ event: EKEvent) {
     let center = UNUserNotificationCenter.current()
 
     let content = UNMutableNotificationContent()
-    content.title = event.title
+    if Defaults[.hideMeetingNames] {
+        content.title = "general_meeting".loco()
+    } else {
+        content.title = event.title
+    }
     content.body = "notifications_event_start_soon_body".loco()
     content.categoryIdentifier = "EVENT"
     content.sound = UNNotificationSound.default

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "general_add" = "Add";
 "general_delete" = "Delete";
 "general_save" = "Save";
+"general_meeting" = "Meeting";
 
 "create_meeting_error_title" = "Cannot create new meeting";
 "create_meeting_error_message" = "Custom url \"%@\" is missing or invalid. Please enter a value in the app preferences.";
@@ -46,6 +47,7 @@
 "preferences_general_shortcut_create_meeting" = "Create meeting:";
 "preferences_general_shortcut_join_next" = "Join next event meeting:";
 "preferences_general_shortcut_join_from_clipboard" = "Join meeting from clipboard:";
+"preferences_general_shortcut_toggle_meeting_name_visibility" = "Toggle meeting name visibility:";
 "preferences_general_meeting_bar_description" = "MeetingBar is open-source app created by Andrii Leitsius\nThe app aims to make your experience with online meetings smoother and easier";
 "preferences_general_external_patronage" = "Patronage";
 "preferences_general_external_gitHub" = "GitHub";
@@ -187,6 +189,8 @@
 "status_bar_submenu_attendees_status_tentative" = " [tentative]";
 "status_bar_submenu_attendees_status_unknown" = " [?]";
 "status_bar_submenu_open_in_calendar" = "Open in Calendar App";
+"status_bar_show_meeting_names" = "Show meeting names";
+"status_bar_hide_meeting_names" = "Hide meeting names";
 "status_bar_preferences" = "Preferences";
 "status_bar_quit" = "Quit MeetingBar";
 "status_bar_no_title" = "No title";

--- a/MeetingBar/Resources /Localization /ru.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ru.lproj/Localizable.strings
@@ -12,6 +12,7 @@
 "general_add" = "Добавить";
 "general_delete" = "Удалить";
 "general_save" = "Сохранить";
+"general_meeting" = "событие";
 
 "create_meeting_error_title" = "Невозможно создать новое событие";
 "create_meeting_error_message" = "Пользовательский URL \"%@\" отсутствует или недействителен. Пожалуйста, исправьте url в настройках приложения.";
@@ -46,6 +47,7 @@
 "preferences_general_shortcut_create_meeting" = "Создать событие:";
 "preferences_general_shortcut_join_next" = "Присоединиться к следующему событию:";
 "preferences_general_shortcut_join_from_clipboard" = "Присоединиться к событию из буфера обмена:";
+"preferences_general_shortcut_toggle_meeting_name_visibility" = "Переключить видимость названия события:";
 "preferences_general_meeting_bar_description" = "MeetingBar - это приложение с открытым исходным кодом, созданное Andrii Leitsius.\nПриложение призвано сделать ваши онлайн-встречи более спокойными и легкими.";
 "preferences_general_external_patronage" = "Patronage";
 "preferences_general_external_gitHub" = "GitHub";
@@ -187,6 +189,8 @@
 "status_bar_submenu_attendees_status_tentative" = " [Возможно]";
 "status_bar_submenu_attendees_status_unknown" = " [?]";
 "status_bar_submenu_open_in_calendar" = "Открыть в приложении \"Календарь\"";
+"status_bar_show_meeting_names" = "Показать названия событий";
+"status_bar_hide_meeting_names" = "Скрыть названия событий";
 "status_bar_preferences" = "Настройки";
 "status_bar_quit" = "Выйти из MeetingBar";
 "status_bar_no_title" = "Без названия";

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -841,6 +841,16 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
             keyEquivalent: ","
         )
 
+        let toggleMeetingNameVisibilityItem = NSMenuItem()
+        if Defaults[.hideMeetingNames] {
+            toggleMeetingNameVisibilityItem.title = "status_bar_show_meeting_names".loco()
+        } else {
+            toggleMeetingNameVisibilityItem.title = "status_bar_hide_meeting_names".loco()
+        }
+        toggleMeetingNameVisibilityItem.action = #selector(AppDelegate.toggleMeetingNameVisibility)
+        toggleMeetingNameVisibilityItem.setShortcut(for: .toggleMeetingNameVisibilityShortcut)
+        self.statusItemMenu.addItem(toggleMeetingNameVisibilityItem)
+
         self.statusItemMenu.addItem(
             withTitle: "status_bar_quit".loco(),
             action: #selector(AppDelegate.quit),
@@ -879,7 +889,11 @@ func createEventStatusString(_ event: EKEvent) -> (String, String) {
     var eventTitle: String
     switch Defaults[.eventTitleFormat] {
     case .show:
-        eventTitle = shortenTitleForSystembar(title: event.title)
+        if Defaults[.hideMeetingNames] {
+            eventTitle = "general_meeting".loco()
+        } else {
+            eventTitle = shortenTitleForSystembar(title: event.title)
+        }
     case .dot:
         eventTitle = "•"
     case .none:

--- a/MeetingBar/Views/Preferences/GeneralTab.swift
+++ b/MeetingBar/Views/Preferences/GeneralTab.swift
@@ -70,6 +70,10 @@ struct ShortcutsSection: View {
                 Text("preferences_general_shortcut_join_from_clipboard".loco())
                 KeyboardShortcuts.Recorder(for: .openClipboardShortcut)
             }
+            VStack {
+                Text("preferences_general_shortcut_toggle_meeting_name_visibility".loco())
+                KeyboardShortcuts.Recorder(for: .toggleMeetingNameVisibilityShortcut)
+            }
         }
     }
 }


### PR DESCRIPTION
### Status
**READY**

### Description
Add functionality requested and discussed in #206 

- Menu item to show/hide meeting names
- Hides meeting names in notifications
- Adds keyboard shortcut selection for feature to preferences
- Russian localization for new strings

There is some overlap with the ability to change status bar title display in Preferences/Appearances, however, I think this feature is distinct because it is meant for temporary use (like wanting to hide an upcoming job interview while screen sharing) rather than permanent user preferences.