### PR TITLE
always open "my" zoom links in browser (for now)

### DIFF
--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -240,6 +240,9 @@ func openMeetingURL(_ service: MeetingServices?, _ url: URL, _ browser: Browser?
 
     case .zoom:
         if Defaults[.useAppForZoomLinks] {
+            if url.absoluteString.contains("/my/") {
+                url.openIn(browser: browser ?? systemDefaultBrowser)
+            }
             let urlString = url.absoluteString.replacingOccurrences(of: "?", with: "&").replacingOccurrences(of: "/j/", with: "/join?confno=")
             var zoomAppUrl = URLComponents(url: URL(string: urlString)!, resolvingAgainstBaseURL: false)!
             zoomAppUrl.scheme = "zoommtg"


### PR DESCRIPTION
a quick and dirty fix for personal "my" zoom links (https://support.zoom.us/hc/en-us/articles/201362843-Personal-meeting-ID-PMI-and-personal-link) to always be opened in the browser. with the current state of the app these type of zoom links cannot be opened directly in app (as described in issues https://github.com/leits/MeetingBar/issues/208 and https://github.com/leits/MeetingBar/issues/164). this resolves the strange behaviour described in https://github.com/leits/MeetingBar/issues/208 and at least gives some support for "my" zoom links until these are hopefully fully supported to be opened directly in app some time in the future