### PR TITLE
Fix casing in Zoom subdomains breaking regex

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -20,7 +20,7 @@ struct TitleTruncationRules {
 struct LinksRegex {
     let meet = try! NSRegularExpression(pattern: #"https?://meet.google.com/[a-z-]+"#)
     let hangouts = try! NSRegularExpression(pattern: #"https?://hangouts.google.com/[^\s]*"#)
-    let zoom = try! NSRegularExpression(pattern: #"https?:\/\/(?:[a-z0-9-.]+)?zoom.(?:us|com.cn)\/(?:j|my)\/[0-9a-zA-Z?=.]*"#)
+    let zoom = try! NSRegularExpression(pattern: #"https?:\/\/(?:[a-zA-Z0-9-.]+)?zoom.(?:us|com.cn)\/(?:j|my)\/[0-9a-zA-Z?=.]*"#)
 
 
     /**


### PR DESCRIPTION
### Status
**READY**

### Description
My company has a cased subdomain whose meeting location were not being picked up by Meeting Bar. Follow up to https://github.com/leits/MeetingBar/discussions/234.

### Steps to Test or Reproduce
Use a prefix like `https://Test.zoom.us/j/` in the meeting location field. The prior regex would not pick this up.
