### PR TITLE
Display notes in NSTextView and make links clickable

### DIFF
--- a/MeetingBar/Extensions/String.swift
+++ b/MeetingBar/Extensions/String.swift
@@ -150,3 +150,25 @@ extension String {
         return attributedString
     }
 }
+
+extension NSAttributedString {
+    func withLinksEnabled() -> NSAttributedString {
+        let linkDetectionRegexPattern = #"(http|ftp|https)://([\w_-]+(?:(?:\.[\w_-]+)+))([\w.,@?^=%&:/~+#-]*[\w@?^=%&/~+#-])?"#
+        guard let regex = try? NSRegularExpression(pattern: linkDetectionRegexPattern, options: .caseInsensitive) else {
+            return self
+        }
+
+        let newAttributedString = NSMutableAttributedString(attributedString: self)
+        for match in regex.matches(in: self.string, range: NSRange(location: 0, length: self.string.utf16.count)) {
+            guard let range = Range(match.range, in: self.string) else {
+                continue
+            }
+            let urlString = String(self.string[range])
+            guard let url = URL(string: urlString) else {
+                continue
+            }
+            newAttributedString.addAttribute(.link, value: url, range: match.range)
+        }
+        return NSAttributedString(attributedString: newAttributedString)
+    }
+}

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -869,7 +869,8 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
                     NSAttributedString.Key.font: NSFont.systemFont(ofSize: 14)
                 ],
                 maxWidth: 300.0
-            ).withLinksEnabled()
+            )
+            .withLinksEnabled()
         )
         textView.backgroundColor = .clear
         textView.textColor = .textColor

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -779,9 +779,8 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
                 if !notes.isEmpty {
                     eventMenu.addItem(withTitle: "status_bar_submenu_notes_title".loco(), action: nil, keyEquivalent: "")
                     let item = eventMenu.addItem(withTitle: "", action: nil, keyEquivalent: "")
-                    let paragraphStyle = NSMutableParagraphStyle()
-                    paragraphStyle.lineBreakMode = NSLineBreakMode.byWordWrapping
-                    item.attributedTitle = notes.splitWithNewLineAttributedString(with: [NSAttributedString.Key.paragraphStyle: paragraphStyle], maxWidth: 300.0)
+                    item.view = getNotesView(notes: notes)
+
                     eventMenu.addItem(NSMenuItem.separator())
                 }
             }
@@ -852,6 +851,36 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
         } else {
             eventItem.toolTip = event.title
         }
+    }
+
+    private func getNotesView(notes: String) -> NSView {
+        // Create views
+        let paddingView = NSView()
+        let textView = NSTextView()
+        paddingView.addSubview(textView)
+
+        // Text styling
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = NSLineBreakMode.byWordWrapping
+        textView.textStorage?.setAttributedString(notes.splitWithNewLineAttributedString(with: [NSAttributedString.Key.paragraphStyle: paragraphStyle], maxWidth: 300.0).withLinksEnabled())
+        textView.backgroundColor = .clear
+        textView.textColor = .lightGray
+
+        // Adjust frame layout for padding
+        if let textContainer = textView.textContainer {
+            textView.layoutManager?.ensureLayout(for: textContainer)
+            if let frame = textView.layoutManager?.usedRect(for: textContainer) {
+                textView.frame = NSRect(x: 10.0, y: 0.0, width: frame.width, height: frame.height)
+                paddingView.frame = NSRect(x: 0.0, y: 0.0, width: frame.width + 10, height: frame.height)
+            } else {
+                // Backup layout if we couldn't calculate frame
+                textView.autoresizingMask = [.width, .height]
+            }
+        } else {
+            // Backup layout if we couldn't calculate frame
+            textView.autoresizingMask = [.width, .height]
+        }
+        return paddingView
     }
 
     /**

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -862,16 +862,26 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
         // Text styling
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.lineBreakMode = NSLineBreakMode.byWordWrapping
-        textView.textStorage?.setAttributedString(notes.splitWithNewLineAttributedString(with: [NSAttributedString.Key.paragraphStyle: paragraphStyle], maxWidth: 300.0).withLinksEnabled())
+        textView.textStorage?.setAttributedString(
+            notes.splitWithNewLineAttributedString(
+                with: [
+                    NSAttributedString.Key.paragraphStyle: paragraphStyle,
+                    NSAttributedString.Key.font: NSFont.systemFont(ofSize: 14)
+                ],
+                maxWidth: 300.0
+            ).withLinksEnabled()
+        )
         textView.backgroundColor = .clear
-        textView.textColor = .lightGray
+        textView.textColor = .textColor
 
         // Adjust frame layout for padding
         if let textContainer = textView.textContainer {
             textView.layoutManager?.ensureLayout(for: textContainer)
             if let frame = textView.layoutManager?.usedRect(for: textContainer) {
+                // There's 10pt of padding seemingly built into the left side,
+                // no such thing on the right so we go 20pt to match the left side
                 textView.frame = NSRect(x: 10.0, y: 0.0, width: frame.width, height: frame.height)
-                paddingView.frame = NSRect(x: 0.0, y: 0.0, width: frame.width + 10, height: frame.height)
+                paddingView.frame = NSRect(x: 0.0, y: 0.0, width: frame.width + 20, height: frame.height)
             } else {
                 // Backup layout if we couldn't calculate frame
                 textView.autoresizingMask = [.width, .height]

--- a/MeetingBarTests/StringExtensionsTests.swift
+++ b/MeetingBarTests/StringExtensionsTests.swift
@@ -11,7 +11,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -25,7 +25,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -39,7 +39,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -53,7 +53,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -67,7 +67,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -81,7 +81,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -95,7 +95,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -109,7 +109,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -123,7 +123,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -137,7 +137,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)
@@ -151,7 +151,7 @@ class StringExtensionsTests: XCTestCase {
         let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
         let resultString = testString.withLinksEnabled()
 
-        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+        resultString.enumerateAttributes(in: expectedRange) { attrDict, range, _ in
             if let linkAttr = attrDict[.link] as? URL {
                 XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
                 XCTAssert(linkAttr.absoluteString == urlString)

--- a/MeetingBarTests/StringExtensionsTests.swift
+++ b/MeetingBarTests/StringExtensionsTests.swift
@@ -1,0 +1,161 @@
+import Foundation
+import XCTest
+
+@testable import MeetingBar
+
+class StringExtensionsTests: XCTestCase {
+    // MARK: withLinksEnabled
+    func testLinkDetectionPicksUpHttpDotComLinks() throws {
+        let urlString = "http://example.com"
+        let testString = NSAttributedString(string: "\(urlString)")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpHttpDotComLinksSubstring() throws {
+        let urlString = "http://example.com"
+        let testString = NSAttributedString(string: "prefix \(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpHttpDotComLinksSubstringNoSpacePrefix() throws {
+        let urlString = "http://example.com"
+        let testString = NSAttributedString(string: "prefix\(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpHttpDotComLinksSubstringWithQueryParams() throws {
+        let urlString = "http://example.com?exampleParam=true&anotherParam=12498"
+        let testString = NSAttributedString(string: "prefix \(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpHttpsDotComLinks() throws {
+        let urlString = "https://example.com"
+        let testString = NSAttributedString(string: "\(urlString)")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpHttpsDotComLinksSubstring() throws {
+        let urlString = "https://example.com"
+        let testString = NSAttributedString(string: "prefix \(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpHttpsDotComLinksSubstringNoSpacePrefix() throws {
+        let urlString = "https://example.com"
+        let testString = NSAttributedString(string: "prefix\(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpHttpsDotComLinksSubstringWithQueryParams() throws {
+        let urlString = "https://example.com?exampleParam=true&anotherParam=12498"
+        let testString = NSAttributedString(string: "prefix \(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpHttpsDotIoLinksSubstringWithQueryParams() throws {
+        let urlString = "https://example.io?exampleParam=true&anotherParam=12498"
+        let testString = NSAttributedString(string: "prefix \(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpIPAddressLinksSubstring() throws {
+        let urlString = "https://127.0.0.1"
+        let testString = NSAttributedString(string: "prefix \(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+
+    func testLinkDetectionPicksUpIPAddressLinksSubstringWithPort() throws {
+        let urlString = "https://127.0.0.1:9001"
+        let testString = NSAttributedString(string: "prefix \(urlString) suffix")
+        let expectedRange = NSRange(location: 0, length: testString.string.utf16.count)
+        let resultString = testString.withLinksEnabled()
+
+        resultString.enumerateAttributes(in: expectedRange) { (attrDict, range, shouldStop) in
+            if let linkAttr = attrDict[.link] as? URL {
+                XCTAssert(expectedRange.intersection(range)?.length ?? 0 > 0)
+                XCTAssert(linkAttr.absoluteString == urlString)
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Status
**READY**

Needs styling tweaks and probably some cleanup to your repo standards.

### Description
Adds clickable links to notes.  Uses an NSTextView to render the attributed strings.  Links are detected with a decent looking regex I pulled from stack overflow.

We can totally clean this up a bit more, and the text formatting isn't perfect yet, but I'd like your input there on what font and colors might match best.  The view itself seems to follow the same rendering as the attributed title of the menu item this replaced (see screenshot).  I added 10pt of padding to each side which seems to match up pretty well but can be tweaked.

Future work might be to pull links from HTML notes in the calendar events too (or just render the notes as HTML in the first place).

### Steps to Test or Reproduce
Run and navigate to a notes section with links in it!
<img width="730" alt="Screen Shot 2021-05-05 at 1 54 48 PM" src="https://user-images.githubusercontent.com/6633472/117218625-582f1380-adb8-11eb-85cb-b9f6112fc980.png">

