### PR TITLE
Open ZoomGov meetings in the Zoom app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 ## Version 3.5.0 (WIP)
 > unreleased
 
+* Fixed opening ZoomGov links in the native app
+
 ## Version 3.4.0
 > (released 12th May 2021)
 * 📋 New view of notes in the event submenu with selectable text and clickable links

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -227,7 +227,7 @@ func openMeetingURL(_ service: MeetingServices?, _ url: URL, _ browser: Browser?
             url.openIn(browser: browser ?? systemDefaultBrowser)
         }
 
-    case .zoom:
+    case .zoom, .zoomgov:
         if Defaults[.useAppForZoomLinks] {
             let urlString = url.absoluteString.replacingOccurrences(of: "?", with: "&").replacingOccurrences(of: "/j/", with: "/join?confno=")
             var zoomAppUrl = URLComponents(url: URL(string: urlString)!, resolvingAgainstBaseURL: false)!


### PR DESCRIPTION
### Status
READY

### Description
Fixed opening ZoomGov links in the native app

## Checklist
- [x] Localized
- [x] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
Click on a meeting with a ZoomGov link