### PR TITLE
Added translation in Japanese

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Version 3.7.0 (WIP)
 > unreleased
+* Added translations into Japanese
 
 ## Version 3.6.0
 > (released 15th Jun 2021)

--- a/MeetingBar.xcodeproj/project.pbxproj
+++ b/MeetingBar.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		E4DD0F0A2529D0D20029E395 /* Project-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Release.xcconfig"; sourceTree = "<group>"; };
 		E4DD0F0B2529D0D20029E395 /* Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Project.xcconfig; sourceTree = "<group>"; };
 		E4DD0F0C2529D0D20029E395 /* Project-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Project-Debug.xcconfig"; sourceTree = "<group>"; };
+		EA04E13F26B2664F00D183B8 /* ja */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ja; path = ja.lproj/Localizable.strings; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -422,6 +423,7 @@
 				hr,
 				"nb-NO",
 				cs,
+				ja,
 			);
 			mainGroup = 144C01702462D0C3000C9FFC;
 			packageReferences = (
@@ -549,6 +551,7 @@
 				14C9A92A269A209C005306DA /* hr */,
 				14C9A92B269A20A1005306DA /* nb-NO */,
 				143E6D6226A0C5E300B3CBEE /* cs */,
+				EA04E13F26B2664F00D183B8 /* ja */,
 			);
 			name = Localizable.strings;
 			sourceTree = "<group>";

--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -353,6 +353,7 @@ enum AppLanguage: String, Codable {
     case french = "fr"
     case czech = "cs"
     case norwegian = "nb-NO"
+    case japanese = "ja"
 }
 
 struct Browser: Encodable, Decodable, Hashable {

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -2,7 +2,7 @@
   Localizable.strings
   MeetingBar
 
-  Created by Sergey Ryazanov on 19.03.2021.
+  Created by Mitsukuni Sato on 29.07.2021.
   Copyright © 2021 Andrii Leitsius. All rights reserved.
 */
 
@@ -15,7 +15,7 @@
 "general_meeting" = "ミーティング";
 
 "create_meeting_error_title" = "新しいミーティングが作成できませんでした";
-"create_meeting_error_message" = "Custom url \"%@\" is missing or invalid. Please enter a value in the app preferences.";
+"create_meeting_error_message" = "カスタムURL %@ がないか、異常です。設定で正しい値を入力してください。";
 "next_meeting_empty_title" = "今日はもうミーティングがありません";
 "next_meeting_empty_message" = "ウオー！ココアを作る時間です";
 
@@ -46,7 +46,7 @@
 "preferences_general_shortcut_join_next" = "次のミーティングに参加:";
 "preferences_general_shortcut_join_from_clipboard" = "クリップボードからミーティングに参加:";
 "preferences_general_shortcut_toggle_meeting_name_visibility" = "ステータスバーのタイトル表示をトグルする:";
-"preferences_general_meeting_bar_description" = "MeetingBar は Andrii Leitsius によって開発されたオープンソースアプリケーションです\nオンラインミーティングをスムーズで簡単なものにすることを目的としています";
+"preferences_general_meeting_bar_description" = "MeetingBar は Andrii Leitsius によって開発されたオープンソースアプリケーションです。オンラインミーティングをスムーズで簡単にすることを目的としています。";
 "preferences_general_external_patronage" = "パトロンになる";
 "preferences_general_external_gitHub" = "GitHub";
 "preferences_general_external_contact" = "お問い合わせ";
@@ -58,7 +58,7 @@
 "preferences_general_patron_thank_for_purchase" = "Thanks! You support MeetingBar for %d Month! 🎉";
 "preferences_general_patron_restore_purchases" = "Restore Purchases";
 "preferences_general_feedback_title" = "質問やフィードバックがあれば、\nお気軽にお問い合わせください:";
-"preferences_general_feedback_email" = "email";
+"preferences_general_feedback_email" = "メール";
 "preferences_general_feedback_twitter" = "twitter";
 "preferences_general_feedback_telegram" = "telegram";
 
@@ -76,7 +76,7 @@
 "preferences_appearance_events_past_title" = "過去のイベント:";
 "preferences_appearance_events_pending_title" = "保留中のイベント";
 "preferences_appearance_events_declined_title" = "不参加にしたイベント:";
-"preferences_appearance_events_value_show" = "表示する";
+"preferences_appearance_events_value_show" = "表示";
 "preferences_appearance_events_value_hide" = "非表示";
 "preferences_appearance_events_value_as_inactive" = "非アクティブとして表示";
 "preferences_appearance_events_value_as_underlined" = "下線を表示";
@@ -146,21 +146,21 @@
 // MARK: - Preferences Bookmarks
 
 "preferences_bookmarks_no_bookmarks_placeholder" = "ブックマークはまだありません";
-"preferences_bookmarks_delete_bookmark_title" = "Delete bookmark?";
-"preferences_bookmarks_delete_bookmark_message" = "Do you want to delete bookmark %@?";
+"preferences_bookmarks_delete_bookmark_title" = "ブックマークの削除";
+"preferences_bookmarks_delete_bookmark_message" = "%@を削除してもよろしいですか？";
 "preferences_bookmarks_add_bookmark_button" = "ブックマークを追加する";
-"preferences_bookmarks_new_bookmark_title" = "New bookmark";
-"preferences_bookmarks_new_bookmark_name" = "Name";
-"preferences_bookmarks_new_bookmark_link_phone" = "Link/Phone";
-"preferences_bookmarks_new_bookmark_service" = "Service";
+"preferences_bookmarks_new_bookmark_title" = "新しいブックマーク";
+"preferences_bookmarks_new_bookmark_name" = "名前";
+"preferences_bookmarks_new_bookmark_link_phone" = "リンク / 電話番号";
+"preferences_bookmarks_new_bookmark_service" = "サービス";
 "preferences_bookmarks_new_bookmark_already_exist" = "A bookmark with this link/phone already exists with the name %@:\n%@";
 "preferences_bookmarks_new_bookmark_error_title" = "Can't add bookmark";
 
 // MARK: - Preferences Calendars
 
-"preferences_calendars_select_calendars_title" = "ステータスバーに表示したいカレンダーの選択";
+"preferences_calendars_select_calendars_title" = "表示するカレンダーの選択";
 "preferences_calendars_add_account_description" = "必要なカレンダーが見当たりませんか？";
-"preferences_calendars_add_account_button" = "アカウントの追加";
+"preferences_calendars_add_account_button" = "アカウントを追加";
 "preferences_calendars_add_account_modal" = "To add external Calendars follow these steps:\n1. Open the default Calendar App\n2. Click 'Add Account' in the menu\n3. Choose and connect your account";
 
 // MARK: - Preferences Advanced
@@ -183,7 +183,7 @@
 
 "status_bar_section_today" = "今日";
 "status_bar_section_tomorrow" = "明日";
-"status_bar_empty_calendar_message" = "Select calendars in preferences\nto see your meetings";
+"status_bar_empty_calendar_message" = "環境設定でカレンダーを選択すると、\nミーティングが表示されます。";
 "status_bar_section_join_next_meeting" = "次のミーティングに参加";
 "status_bar_section_join_from_clipboard" = "クリップボードからミーティングを開く";
 "status_bar_section_join_create_meeting" = "ミーティングを作成";
@@ -194,41 +194,41 @@
 "status_bar_submenu_calendar_title" = "カレンダー: %@";
 "status_bar_submenu_duration_all_day" = "%@ - %@ (%@分)";
 "status_bar_submenu_status_title" = "状態: %@";
-"status_bar_submenu_status_accepted" = " 👍 Accepted";
-"status_bar_submenu_status_canceled" = " 👎 Canceled";
-"status_bar_submenu_status_tentative" = " ☝️ Tentative";
-"status_bar_submenu_status_pending" = " ⏳ Pending";
-"status_bar_submenu_status_unknown" = " ❔ Unknown";
+"status_bar_submenu_status_accepted" = " 👍 参加";
+"status_bar_submenu_status_canceled" = " 👎 不参加";
+"status_bar_submenu_status_tentative" = " ☝️ 仮";
+"status_bar_submenu_status_pending" = " ⏳ 保留";
+"status_bar_submenu_status_unknown" = " ❔ 不明";
 "status_bar_submenu_status_default_extended" = " ❔ (%@)";
-"status_bar_submenu_status_default_simple" = " ❔ (Unknown)";
+"status_bar_submenu_status_default_simple" = " ❔ (不明)";
 "status_bar_submenu_location_title" = "場所:";
 "status_bar_submenu_organizer_title" = "主催者:";
 "status_bar_submenu_notes_title" = "ノート:";
 "status_bar_submenu_attendees_title" = "参加者 (%d)";
-"status_bar_submenu_attendees_no_name" = "No name attendee";
-"status_bar_submenu_attendees_you" = "%@ (you)";
-"status_bar_submenu_attendees_status_tentative" = " [tentative]";
+"status_bar_submenu_attendees_no_name" = "名無しさん";
+"status_bar_submenu_attendees_you" = "%@ (あなた)";
+"status_bar_submenu_attendees_status_tentative" = " [名無しさん]";
 "status_bar_submenu_attendees_status_unknown" = " [?]";
 "status_bar_submenu_open_in_calendar" = "カレンダーアプリで開く";
 "status_bar_submenu_open_in_fantastical" = "Fantastical で開く";
 "status_bar_quick_actions" = "クイックアクション";
 "status_bar_show_meeting_names" = "ミーティング名を表示する";
 "status_bar_hide_meeting_names" = "ミーティング名を隠す";
-"status_bar_whats_new" = "What's new?";
+"status_bar_whats_new" = "お知らせ";
 "status_bar_preferences" = "設定";
 "status_bar_quit" = "MeetingBar を終了";
 "status_bar_no_title" = "タイトルなし";
-"status_bar_event_status_now" = "now (%@ left)";
+"status_bar_event_status_now" = "現在 (残り %@)";
 "status_bar_event_status_in" = "あと%@";
 "status_bar_error_apple_script_title" = "AppleScript return error";
 "status_bar_error_link_missed_title" = "えー！%@ に参加できませんでした";
-"status_bar_error_link_missed_message" = "リンクが登録されていないか、サポートされていないミーティングサービスです";
+"status_bar_error_link_missed_message" = "ミーティングリンクが登録されていないか、サポートされていないサービスです";
 "status_bar_error_teams_link_title" = "おっと！Microsoft Team アプリでリンクを開けませんでした";
-"status_bar_error_teams_link_message" = "Make sure you have Microsoft Teams app installed, or change the app in the preferences.";
-"status_bar_error_zoom_app_link_title" = "Oops! Unable to open the link in Zoom app";
-"status_bar_error_zoom_app_link_message" = "Make sure you have Zoom app installed, or change the app in the preferences.";
-"status_bar_error_zoom_native_link_title" = "Oops! Unable to open the native link in Zoom app";
-"status_bar_error_zoom_native_link_message" = "Make sure you have Zoom app installed, or change the app in the preferences.";
+"status_bar_error_teams_link_message" = "Microsoft Team アプリをインストールするか、設定でアプリを変更してください。";
+"status_bar_error_zoom_app_link_title" = "おーっと！ Zoom アプリでリンクを開けません。";
+"status_bar_error_zoom_app_link_message" = "Zoom アプリをインストールするか、設定でアプリを変更してください。";
+"status_bar_error_zoom_native_link_title" = "ぎゃー！ Zoom アプリでネイティブリンクを開けません";
+"status_bar_error_zoom_native_link_message" = "Zoom アプリをインストールするか、設定でアプリを変更してください。";
 
 // MARK: - Welcome screen
 
@@ -250,8 +250,8 @@
 "access_screen_access_denied_title" = "おっと！カレンダーへのアクセスが拒否されているようです。";
 "access_screen_access_screen_access_denied_go_to_title" = "Go to";
 "access_screen_access_denied_system_preferences_button" = "システム設定";
-"access_screen_access_denied_checkbox_title" = "and select a checkbox near MeetingBar.";
-"access_screen_access_denied_relaunch_title" = "Then you need to launch the app manually to continue setting up.";
+"access_screen_access_denied_checkbox_title" = "MeetingBarの近くにあるチェックボックスを選択します。";
+"access_screen_access_denied_relaunch_title" = "その後、手動でアプリを起動して設定を続ける必要があります。";
 "access_screen_access_granted_title" = "カレンダーへのアクセス許可を求めています。";
 "access_screen_access_granted_click_ok_title" = "macOS のポップアップウィンドウで \"OK\" をクリックしてください。";
 
@@ -274,13 +274,13 @@
 "constants_create_meeting_service_gcalendar" = "Google Calendar";
 "constants_create_meeting_service_outlook_live" = "Outlook Live";
 "constants_create_meeting_service_outlook_office365" = "Outlook Office365";
-"constants_create_meeting_service_url" = "Custom url";
+"constants_create_meeting_service_url" = "カスタムURL";
 
-"constants_meeting_service_phone" = "Phone";
+"constants_meeting_service_phone" = "電話";
 "constants_meeting_service_meet" = "Google Meet";
 "constants_meeting_service_hangouts" = "Google Hangouts";
 "constants_meeting_service_zoom" = "Zoom";
-"constants_meeting_service_zoom_native" = "Zoom native";
+"constants_meeting_service_zoom_native" = "Zoom ネイティブ";
 "constants_meeting_service_teams" = "Microsoft Teams";
 "constants_meeting_service_webex" = "Cisco Webex";
 "constants_meeting_service_jitsi" = "Jitsi";
@@ -317,7 +317,7 @@
 "constants_meeting_service_blackboard_collab" = "Blackboard Collaborate";
 "constants_meeting_service_coscreen" = "CoScreen";
 "constants_meeting_service_vowel" = "Vowel";
-"constants_meeting_service_other" = "Other";
+"constants_meeting_service_other" = "その他";
 "constants_meeting_service_url" = "URL";
 
 "constants_browser_brave" = "Brave";
@@ -332,7 +332,7 @@
 
 // MARK: - Store
 
-"store_patronage_title" = "MeetingBar Patronage";
+"store_patronage_title" = "MeetingBar のパトロンになる";
 "store_patronage_restore_success_message" = "復元に成功しました";
 "store_patronage_restore_nothing_message" = "復元する内容がありません";
 "store_patronage_purchase_success_message" = "購入に成功しました。サポートありがとうございます！";
@@ -351,5 +351,5 @@
 
 // MARK: - Link open
 
-"link_url_cant_open_title" = "おっと！ %@ リンクを開くことが出来ませんでした";
-"link_url_cant_open_message" = "Make sure you have %@ installed, or change the browser in preferences.";
+"link_url_cant_open_title" = "ひえー！ %@ リンクを開くことが出来ませんでした";
+"link_url_cant_open_message" = "%@ をインストールするか、設定でブラウザーを変更してください。";

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -54,9 +54,9 @@
 "preferences_general_patron_three_months" = "3ヶ月 - 2.99 USD";
 "preferences_general_patron_six_months" = "6ヶ月 - 5.99 USD";
 "preferences_general_patron_twelve_months" = "12ヶ月 - 11.99 USD";
-"preferences_general_patron_description" = "These one-time purchases do not auto-renew.";
-"preferences_general_patron_thank_for_purchase" = "Thanks! You support MeetingBar for %d Month! 🎉";
-"preferences_general_patron_restore_purchases" = "Restore Purchases";
+"preferences_general_patron_description" = "これらは一回限りの購入で、自動更新されません。";
+"preferences_general_patron_thank_for_purchase" = "ありがとう！あなたは%dヶ月間 MeetingBar をサポートします！🎉";
+"preferences_general_patron_restore_purchases" = "購入の復元";
 "preferences_general_feedback_title" = "質問やフィードバックがあれば、\nお気軽にお問い合わせください:";
 "preferences_general_feedback_email" = "メール";
 "preferences_general_feedback_twitter" = "twitter";
@@ -141,7 +141,7 @@
 "preferences_configure_browsers_modal_alert_title" = "ブラウザー設定を追加できませんでした";
 "preferences_configure_browsers_choose_broser_panel_title" = "正しいブラウザーアプリを指定してください";
 "preferences_configure_browsers_choose_broser_panel_prompt" = "ブラウザーの選択";
-"preferences_configure_browsers_choose_broser_panel_message" = "Select a browser from any path!";
+"preferences_configure_browsers_choose_broser_panel_message" = "任意のパスからブラウザを選択してください！";
 
 // MARK: - Preferences Bookmarks
 
@@ -153,15 +153,15 @@
 "preferences_bookmarks_new_bookmark_name" = "名前";
 "preferences_bookmarks_new_bookmark_link_phone" = "リンク / 電話番号";
 "preferences_bookmarks_new_bookmark_service" = "サービス";
-"preferences_bookmarks_new_bookmark_already_exist" = "A bookmark with this link/phone already exists with the name %@:\n%@";
-"preferences_bookmarks_new_bookmark_error_title" = "Can't add bookmark";
+"preferences_bookmarks_new_bookmark_already_exist" = "このリンク / 電話番号のブックマークは既に %@ として登録されています:\n%@";
+"preferences_bookmarks_new_bookmark_error_title" = "ブックマークを追加できません";
 
 // MARK: - Preferences Calendars
 
 "preferences_calendars_select_calendars_title" = "表示するカレンダーの選択";
 "preferences_calendars_add_account_description" = "必要なカレンダーが見当たりませんか？";
 "preferences_calendars_add_account_button" = "アカウントを追加";
-"preferences_calendars_add_account_modal" = "To add external Calendars follow these steps:\n1. Open the default Calendar App\n2. Click 'Add Account' in the menu\n3. Choose and connect your account";
+"preferences_calendars_add_account_modal" = "外部カレンダーを追加するには、次の手順を実行してください。\n1. デフォルトのカレンダーアプリを開きます。\n2. メニューの「アカウントを追加」をクリックします。\n3. アカウントを選択して接続します。";
 
 // MARK: - Preferences Advanced
 
@@ -170,7 +170,7 @@
 "preferences_advanced_apple_script_placeholder" = "# ここにスクリプトを書いてください\ntell application \"Music\" to pause";
 "preferences_advanced_save_script_button" = "保存";
 "preferences_advanced_wrong_location_title" = "場所が誤っています";
-"preferences_advanced_wrong_location_message" = "Please select the User > Library > Application Scripts > leits.MeetingBar folder";
+"preferences_advanced_wrong_location_message" = "User > Library > Application Scripts > leits.MeetingBar フォルダを選択してください";
 "preferences_advanced_wrong_location_button" = "了解！";
 "preferences_advanced_regex_title" = "ミーティングリンク用のカスタム正規表現";
 "preferences_advanced_regex_add_button" = "正規表現を追加";
@@ -337,13 +337,13 @@
 "store_patronage_restore_nothing_message" = "復元する内容がありません";
 "store_patronage_purchase_success_message" = "購入に成功しました。サポートありがとうございます！";
 "store_patronage_purchase_unknown_message" = "不明なエラーが発生しました。サポートにお問い合わせください";
-"store_patronage_purchase_client_invalid_message" = "Not allowed to make the payment";
-"store_patronage_purchase_payment_invalid_message" = "The purchase identifier was invalid";
-"store_patronage_purchase_payment_not_allowed_message" = "The device is not allowed to make the payment";
-"store_patronage_purchase_store_product_not_available_message" = "The product is not available in the current storefront";
-"store_patronage_purchase_cloud_service_permission_denied_message" = "Access to cloud service information is not allowed";
-"store_patronage_purchase_cloud_service_network_connection_failed" = "Could not connect to the network";
-"store_patronage_purchase_cloud_service_revoked_message" = "User has revoked permission to use this cloud service";
+"store_patronage_purchase_client_invalid_message" = "決済ができません";
+"store_patronage_purchase_payment_invalid_message" = "購入者の識別子が無効です";
+"store_patronage_purchase_payment_not_allowed_message" = "このデバイスでは支払いを行うことが出来ません";
+"store_patronage_purchase_store_product_not_available_message" = "製品は現在ストアフロントでご利用できません";
+"store_patronage_purchase_cloud_service_permission_denied_message" = "クラウドサービスの情報へのアクセスが拒否されました";
+"store_patronage_purchase_cloud_service_network_connection_failed" = "ネットワークに接続できません";
+"store_patronage_purchase_cloud_service_revoked_message" = "ユーザーはこのクラウドサービスの利用許可を取り消されました";
 
 // MARK: - Notifications
 

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -13,7 +13,6 @@
 "general_delete" = "削除";
 "general_save" = "保存";
 "general_meeting" = "ミーティング";
-
 "create_meeting_error_title" = "新しいミーティングが作成できませんでした";
 "create_meeting_error_message" = "カスタムURL %@ がないか、異常です。設定で正しい値を入力してください。";
 "next_meeting_empty_title" = "今日はもうミーティングがありません";
@@ -21,11 +20,13 @@
 
 // MARK: - Window titles
 
+
 "window_title_preferences" = "MeetingBar の設定";
 "window_title_onboarding" = "MeetingBar へようこそ！";
 "windows_title_changelog" = "MeetingBar の新機能";
 
 // MARK: - Preferences tabs
+
 
 "preferences_tab_general" = "一般";
 "preferences_tab_appearance" = "外観";
@@ -35,6 +36,7 @@
 "preferences_tab_advanced" = "高度な設定";
 
 // MARK: - Preferences General
+
 
 "preferences_general_option_login_launch" = "ログイン時に起動";
 "preferences_general_option_preferred_language_title" = "言語:";
@@ -46,7 +48,7 @@
 "preferences_general_shortcut_join_next" = "次のミーティングに参加:";
 "preferences_general_shortcut_join_from_clipboard" = "クリップボードからミーティングに参加:";
 "preferences_general_shortcut_toggle_meeting_name_visibility" = "ステータスバーのタイトル表示をトグルする:";
-"preferences_general_meeting_bar_description" = "MeetingBar は Andrii Leitsius によって開発されたオープンソースアプリケーションです。オンラインミーティングをスムーズで簡単にすることを目的としています。";
+"preferences_general_meeting_bar_description" = "MeetingBar は Andrii Leitsius によって開発されたオープンソースアプリケーションです。\nオンラインミーティングをスムーズで簡単にすることを目的としています。";
 "preferences_general_external_patronage" = "パトロンになる";
 "preferences_general_external_gitHub" = "GitHub";
 "preferences_general_external_contact" = "お問い合わせ";
@@ -64,13 +66,14 @@
 
 // MARK: - Preferences Appearance
 
+
 "preferences_appearance_events_title" = "イベント";
 "preferences_appearance_events_show_events_for_title" = "表示するイベント";
 "preferences_appearance_events_show_events_for_today_value" = "今日";
 "preferences_appearance_events_show_events_for_today_tomorrow_value" = "今日と明日";
 "preferences_appearance_events_non_all_day_title" = "その他のイベント:";
-"preferences_appearance_events_value_inactive_without_meeting_link" = "ミーティングリンクのないイベントを非アクティブで表示";
-"preferences_appearance_events_value_hide_without_meeting_link" = "ミーティングリンクのないイベントを非表示";
+"preferences_appearance_events_value_inactive_without_meeting_link" = "リンクのないイベントを非アクティブで表示";
+"preferences_appearance_events_value_hide_without_meeting_link" = "リンクのないイベントを非表示";
 "preferences_appearance_events_all_day_title" = "終日のイベント:";
 "preferences_appearance_events_without_guest_title" = "ゲストのないイベント:";
 "preferences_appearance_events_past_title" = "過去のイベント:";
@@ -81,13 +84,13 @@
 "preferences_appearance_events_value_as_inactive" = "非アクティブとして表示";
 "preferences_appearance_events_value_as_underlined" = "下線を表示";
 "preferences_appearance_events_value_with_strikethrough" = "取り消し線で表示";
-"preferences_appearance_events_value_only_with_link" = "ミーティングリンクのあるイベントのみ表示";
+"preferences_appearance_events_value_only_with_link" = "リンクのあるイベントのみ表示";
 "preferences_appearance_status_bar_title" = "ステータスバー";
 "preferences_appearance_status_bar_icon_title" = "アイコン";
-"preferences_appearance_status_bar_icon_app_icon_value" = "\U00A0アプリアイコン";
-"preferences_appearance_status_bar_icon_calendar_icon_value" = "\U00A0カレンダーアイコン";
-"preferences_appearance_status_bar_icon_specific_icon_value" = "\U00A0ミーティング固有のアイコン (MS Teamsなど)";
-"preferences_appearance_status_bar_icon_no_icon_value" = "\U00A0アイコンなし";
+"preferences_appearance_status_bar_icon_app_icon_value" = " アプリアイコン";
+"preferences_appearance_status_bar_icon_calendar_icon_value" = " カレンダーアイコン";
+"preferences_appearance_status_bar_icon_specific_icon_value" = " ミーティング固有のアイコン (MS Teamsなど)";
+"preferences_appearance_status_bar_icon_no_icon_value" = " アイコンなし";
 "preferences_appearance_status_bar_title_title" = "タイトル";
 "preferences_appearance_status_bar_title_event_title_value" = "イベント名";
 "preferences_appearance_status_bar_title_dot_value" = "ドット (•)";
@@ -97,10 +100,10 @@
 "preferences_appearance_status_bar_time_show_value" = "表示";
 "preferences_appearance_status_bar_time_show_under_title_value" = "タイトルの下に表示";
 "preferences_appearance_status_bar_time_hide_value" = "非表示";
-"preferences_appearance_status_bar_next_event" = "%d 分以内に開始されるミーティングのみ表示";
+"preferences_appearance_status_bar_next_event" = "%d分以内に開始されるミーティングのみ表示";
 "preferences_appearance_menu_title" = "メニュー";
 "preferences_appearance_menu_shorten_event_title_toggle" = "ミーティング名を短縮する";
-"preferences_appearance_menu_shorten_event_title_stepper" = "%d 文字";
+"preferences_appearance_menu_shorten_event_title_stepper" = "%d文字";
 "preferences_appearance_menu_time_format_title" = "時刻形式:";
 "preferences_appearance_menu_time_format_12_hour_value" = "12時間 (AM/PM)";
 "preferences_appearance_menu_time_format_24_hour_value" = "24時間";
@@ -110,6 +113,7 @@
 "preferences_appearance_menu_show_event_details_value" = "サブメニューに詳細表示";
 
 // MARK: - Preferences Services
+
 
 "preferences_services_link_meeting_title" = "すべてのミーティングリンクを開くアプリ";
 "preferences_services_link_meet_title" = "Meet を開くアプリ";
@@ -128,6 +132,7 @@
 
 // MARK: - Preferences Services Browsers Configuration
 
+
 "preferences_configure_browsers_button" = "ブラウザー設定";
 "preferences_configure_browsers_delete_alert_title" = "ブラウザー設定を削除しますか？";
 "preferences_configure_browsers_delete_alert_message" = "%@ のブラウザー設定を削除してもよろしいですか？";
@@ -141,9 +146,10 @@
 "preferences_configure_browsers_modal_alert_title" = "ブラウザー設定を追加できませんでした";
 "preferences_configure_browsers_choose_broser_panel_title" = "正しいブラウザーアプリを指定してください";
 "preferences_configure_browsers_choose_broser_panel_prompt" = "ブラウザーの選択";
-"preferences_configure_browsers_choose_broser_panel_message" = "任意のパスからブラウザを選択してください！";
+"preferences_configure_browsers_choose_broser_panel_message" = "任意のパスからブラウザーを選択してください！";
 
 // MARK: - Preferences Bookmarks
+
 
 "preferences_bookmarks_no_bookmarks_placeholder" = "ブックマークはまだありません";
 "preferences_bookmarks_delete_bookmark_title" = "ブックマークの削除";
@@ -158,16 +164,18 @@
 
 // MARK: - Preferences Calendars
 
+
 "preferences_calendars_select_calendars_title" = "表示するカレンダーの選択";
 "preferences_calendars_add_account_description" = "必要なカレンダーが見当たりませんか？";
 "preferences_calendars_add_account_button" = "アカウントを追加";
-"preferences_calendars_add_account_modal" = "外部カレンダーを追加するには、次の手順を実行してください。\n1. デフォルトのカレンダーアプリを開きます。\n2. メニューの「アカウントを追加」をクリックします。\n3. アカウントを選択して接続します。";
+"preferences_calendars_add_account_modal" = "外部カレンダーを追加するには、次の手順を実行してください:\n1. デフォルトのカレンダーアプリを開きます。\n2. メニューの「アカウントを追加」をクリックします。\n3. アカウントを選択して接続します。";
 
 // MARK: - Preferences Advanced
 
-"preferences_advanced_setting_warning" = "⚠️ これらの設定は、その内容を理解した上で使用してください。";
+
+"preferences_advanced_setting_warning" = "⚠️ これらの設定は、その内容を理解した上で使用してください";
 "preferences_advanced_apple_script_checkmark" = "ミーティング参加時に AppleScript を実行する";
-"preferences_advanced_apple_script_placeholder" = "# ここにスクリプトを書いてください\ntell application \"Music\" to pause";
+"preferences_advanced_apple_script_placeholder" = "# ここにスクリプトを書いてください\ntell application \\"Music\\" to pause";
 "preferences_advanced_save_script_button" = "保存";
 "preferences_advanced_wrong_location_title" = "場所が誤っています";
 "preferences_advanced_wrong_location_message" = "User > Library > Application Scripts > leits.MeetingBar フォルダを選択してください";
@@ -181,9 +189,10 @@
 
 // MARK: - Status bar
 
+
 "status_bar_section_today" = "今日";
 "status_bar_section_tomorrow" = "明日";
-"status_bar_empty_calendar_message" = "環境設定でカレンダーを選択すると、\nミーティングが表示されます。";
+"status_bar_empty_calendar_message" = "環境設定でカレンダーを選択すると、\nミーティングが表示されます";
 "status_bar_section_join_next_meeting" = "次のミーティングに参加";
 "status_bar_section_join_from_clipboard" = "クリップボードからミーティングを開く";
 "status_bar_section_join_create_meeting" = "ミーティングを作成";
@@ -225,12 +234,13 @@
 "status_bar_error_link_missed_message" = "ミーティングリンクが登録されていないか、サポートされていないサービスです";
 "status_bar_error_teams_link_title" = "おっと！Microsoft Team アプリでリンクを開けませんでした";
 "status_bar_error_teams_link_message" = "Microsoft Team アプリをインストールするか、設定でアプリを変更してください。";
-"status_bar_error_zoom_app_link_title" = "おーっと！ Zoom アプリでリンクを開けません。";
+"status_bar_error_zoom_app_link_title" = "おーっと！ Zoom アプリでリンクを開けません";
 "status_bar_error_zoom_app_link_message" = "Zoom アプリをインストールするか、設定でアプリを変更してください。";
 "status_bar_error_zoom_native_link_title" = "ぎゃー！ Zoom アプリでネイティブリンクを開けません";
 "status_bar_error_zoom_native_link_message" = "Zoom アプリをインストールするか、設定でアプリを変更してください。";
 
 // MARK: - Welcome screen
+
 
 "welcome_screen_greeting_main_title" = "こんにちは！ MeetingBar は必要な機能が揃ったシンプルなアプリです。";
 "welcome_screen_greeting_additional_title" = "100% 使いこなしましょう！";
@@ -242,10 +252,12 @@
 
 // MARK: - Calendars screen
 
+
 "calendars_screen_select_calendar_title" = "カレンダーが選択されていません";
 "calendars_screen_start_button" = "アプリを開始する";
 
 // MARK: - Access screen
+
 
 "access_screen_access_denied_title" = "おっと！カレンダーへのアクセスが拒否されているようです。";
 "access_screen_access_screen_access_denied_go_to_title" = "Go to";
@@ -257,6 +269,7 @@
 
 // MARK: - Shared
 
+
 "shared_send_notification_toggle" = "イベント開始前に通知する";
 "shared_send_notification_directly_value" = "イベントが始まったとき";
 "shared_send_notification_one_minute_value" = "1分前";
@@ -266,6 +279,7 @@
 "shared_send_notification_disabled_tip" = "⚠️ MeetingBar の macOS の通知設定が現在オフになっています。ミーティングを見逃さないために、 macOS のシステム設定で通知を有効にしてください。";
 
 // MARK: - Constants
+
 "constants_create_meeting_service_meet" = "Google Meet";
 "constants_create_meeting_service_jam" = "Jam";
 "constants_create_meeting_service_coscreen" = "CoScreen";
@@ -275,12 +289,11 @@
 "constants_create_meeting_service_outlook_live" = "Outlook Live";
 "constants_create_meeting_service_outlook_office365" = "Outlook Office365";
 "constants_create_meeting_service_url" = "カスタムURL";
-
 "constants_meeting_service_phone" = "電話";
 "constants_meeting_service_meet" = "Google Meet";
 "constants_meeting_service_hangouts" = "Google Hangouts";
 "constants_meeting_service_zoom" = "Zoom";
-"constants_meeting_service_zoom_native" = "Zoom ネイティブ";
+"constants_meeting_service_zoom_native" = "Zoomネイティブ";
 "constants_meeting_service_teams" = "Microsoft Teams";
 "constants_meeting_service_webex" = "Cisco Webex";
 "constants_meeting_service_jitsi" = "Jitsi";
@@ -319,7 +332,6 @@
 "constants_meeting_service_vowel" = "Vowel";
 "constants_meeting_service_other" = "その他";
 "constants_meeting_service_url" = "URL";
-
 "constants_browser_brave" = "Brave";
 "constants_browser_chrome" = "Google Chrome";
 "constants_browser_chromium" = "Chromium";
@@ -331,6 +343,7 @@
 "constants_browser_defaultBrowser" = "標準のブラウザー";
 
 // MARK: - Store
+
 
 "store_patronage_title" = "MeetingBar のパトロンになる";
 "store_patronage_restore_success_message" = "復元に成功しました";
@@ -347,9 +360,11 @@
 
 // MARK: - Notifications
 
+
 "notifications_event_start_soon_body" = "もうすぐイベントが開始されます";
 
 // MARK: - Link open
 
-"link_url_cant_open_title" = "ひえー！ %@ リンクを開くことが出来ませんでした";
+
+"link_url_cant_open_title" = "ひえー！ %@ のリンクを開くことが出来ませんでした";
 "link_url_cant_open_message" = "%@ をインストールするか、設定でブラウザーを変更してください。";

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -87,10 +87,10 @@
 "preferences_appearance_events_value_only_with_link" = "リンクのあるイベントのみ表示";
 "preferences_appearance_status_bar_title" = "ステータスバー";
 "preferences_appearance_status_bar_icon_title" = "アイコン";
-"preferences_appearance_status_bar_icon_app_icon_value" = " アプリアイコン";
-"preferences_appearance_status_bar_icon_calendar_icon_value" = " カレンダーアイコン";
-"preferences_appearance_status_bar_icon_specific_icon_value" = " ミーティング固有のアイコン (MS Teamsなど)";
-"preferences_appearance_status_bar_icon_no_icon_value" = " アイコンなし";
+"preferences_appearance_status_bar_icon_app_icon_value" = "\U00A0アプリアイコン";
+"preferences_appearance_status_bar_icon_calendar_icon_value" = "\U00A0カレンダーアイコン";
+"preferences_appearance_status_bar_icon_specific_icon_value" = "\U00A0ミーティング固有のアイコン (MS Teamsなど)";
+"preferences_appearance_status_bar_icon_no_icon_value" = "\U00A0アイコンなし";
 "preferences_appearance_status_bar_title_title" = "タイトル";
 "preferences_appearance_status_bar_title_event_title_value" = "イベント名";
 "preferences_appearance_status_bar_title_dot_value" = "ドット (•)";
@@ -175,7 +175,7 @@
 
 "preferences_advanced_setting_warning" = "⚠️ これらの設定は、その内容を理解した上で使用してください";
 "preferences_advanced_apple_script_checkmark" = "ミーティング参加時に AppleScript を実行する";
-"preferences_advanced_apple_script_placeholder" = "# ここにスクリプトを書いてください\ntell application \\"Music\\" to pause";
+"preferences_advanced_apple_script_placeholder" = "# ここにスクリプトを書いてください\ntell application \"Music\" to pause";
 "preferences_advanced_save_script_button" = "保存";
 "preferences_advanced_wrong_location_title" = "場所が誤っています";
 "preferences_advanced_wrong_location_message" = "User > Library > Application Scripts > leits.MeetingBar フォルダを選択してください";

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -1,0 +1,355 @@
+/* 
+  Localizable.strings
+  MeetingBar
+
+  Created by Sergey Ryazanov on 19.03.2021.
+  Copyright © 2021 Andrii Leitsius. All rights reserved.
+*/
+
+"general_ok" = "OK";
+"general_cancel" = "キャンセル";
+"general_close" = "閉じる";
+"general_add" = "追加";
+"general_delete" = "削除";
+"general_save" = "保存";
+"general_meeting" = "ミーティング";
+
+"create_meeting_error_title" = "新しいミーティングが作成できませんでした";
+"create_meeting_error_message" = "Custom url \"%@\" is missing or invalid. Please enter a value in the app preferences.";
+"next_meeting_empty_title" = "今日はもうミーティングがありません";
+"next_meeting_empty_message" = "ウオー！ココアを作る時間です";
+
+// MARK: - Window titles
+
+"window_title_preferences" = "MeetingBar の設定";
+"window_title_onboarding" = "MeetingBar へようこそ！";
+"windows_title_changelog" = "MeetingBar の新機能";
+
+// MARK: - Preferences tabs
+
+"preferences_tab_general" = "一般";
+"preferences_tab_appearance" = "外観";
+"preferences_tab_services" = "サービス";
+"preferences_tab_bookmarks" = "ブックマーク";
+"preferences_tab_calendars" = "カレンダー";
+"preferences_tab_advanced" = "高度な設定";
+
+// MARK: - Preferences General
+
+"preferences_general_option_login_launch" = "ログイン時に起動";
+"preferences_general_option_preferred_language_title" = "言語:";
+"preferences_general_option_preferred_language_system_value" = "システム設定に従う";
+"preferences_general_option_shortcuts" = "ショートカット";
+"preferences_general_all_shortcut" = "すべてのショートカット";
+"preferences_general_shortcut_open_menu" = "メニューを開く:";
+"preferences_general_shortcut_create_meeting" = "ミーティングを作成:";
+"preferences_general_shortcut_join_next" = "次のミーティングに参加:";
+"preferences_general_shortcut_join_from_clipboard" = "クリップボードからミーティングに参加:";
+"preferences_general_shortcut_toggle_meeting_name_visibility" = "ステータスバーのタイトル表示をトグルする:";
+"preferences_general_meeting_bar_description" = "MeetingBar は Andrii Leitsius によって開発されたオープンソースアプリケーションです\nオンラインミーティングをスムーズで簡単なものにすることを目的としています";
+"preferences_general_external_patronage" = "パトロンになる";
+"preferences_general_external_gitHub" = "GitHub";
+"preferences_general_external_contact" = "お問い合わせ";
+"preferences_general_patron_title" = "パトロンになる";
+"preferences_general_patron_three_months" = "3ヶ月 - 2.99 USD";
+"preferences_general_patron_six_months" = "6ヶ月 - 5.99 USD";
+"preferences_general_patron_twelve_months" = "12ヶ月 - 11.99 USD";
+"preferences_general_patron_description" = "These one-time purchases do not auto-renew.";
+"preferences_general_patron_thank_for_purchase" = "Thanks! You support MeetingBar for %d Month! 🎉";
+"preferences_general_patron_restore_purchases" = "Restore Purchases";
+"preferences_general_feedback_title" = "質問やフィードバックがあれば、\nお気軽にお問い合わせください:";
+"preferences_general_feedback_email" = "email";
+"preferences_general_feedback_twitter" = "twitter";
+"preferences_general_feedback_telegram" = "telegram";
+
+// MARK: - Preferences Appearance
+
+"preferences_appearance_events_title" = "イベント";
+"preferences_appearance_events_show_events_for_title" = "表示するイベント";
+"preferences_appearance_events_show_events_for_today_value" = "今日";
+"preferences_appearance_events_show_events_for_today_tomorrow_value" = "今日と明日";
+"preferences_appearance_events_non_all_day_title" = "その他のイベント:";
+"preferences_appearance_events_value_inactive_without_meeting_link" = "ミーティングリンクのないイベントを非アクティブで表示";
+"preferences_appearance_events_value_hide_without_meeting_link" = "ミーティングリンクのないイベントを非表示";
+"preferences_appearance_events_all_day_title" = "終日のイベント:";
+"preferences_appearance_events_without_guest_title" = "ゲストのないイベント:";
+"preferences_appearance_events_past_title" = "過去のイベント:";
+"preferences_appearance_events_pending_title" = "保留中のイベント";
+"preferences_appearance_events_declined_title" = "不参加にしたイベント:";
+"preferences_appearance_events_value_show" = "表示する";
+"preferences_appearance_events_value_hide" = "非表示";
+"preferences_appearance_events_value_as_inactive" = "非アクティブとして表示";
+"preferences_appearance_events_value_as_underlined" = "下線を表示";
+"preferences_appearance_events_value_with_strikethrough" = "取り消し線で表示";
+"preferences_appearance_events_value_only_with_link" = "ミーティングリンクのあるイベントのみ表示";
+"preferences_appearance_status_bar_title" = "ステータスバー";
+"preferences_appearance_status_bar_icon_title" = "アイコン";
+"preferences_appearance_status_bar_icon_app_icon_value" = "\U00A0アプリアイコン";
+"preferences_appearance_status_bar_icon_calendar_icon_value" = "\U00A0カレンダーアイコン";
+"preferences_appearance_status_bar_icon_specific_icon_value" = "\U00A0ミーティング固有のアイコン (MS Teamsなど)";
+"preferences_appearance_status_bar_icon_no_icon_value" = "\U00A0アイコンなし";
+"preferences_appearance_status_bar_title_title" = "タイトル";
+"preferences_appearance_status_bar_title_event_title_value" = "イベント名";
+"preferences_appearance_status_bar_title_dot_value" = "ドット (•)";
+"preferences_appearance_status_bar_title_hide_value" = "非表示";
+"preferences_appearance_status_bar_title_shorten_stepper" = "%d 文字に切り詰める";
+"preferences_appearance_status_bar_time_title" = "時刻";
+"preferences_appearance_status_bar_time_show_value" = "表示";
+"preferences_appearance_status_bar_time_show_under_title_value" = "タイトルの下に表示";
+"preferences_appearance_status_bar_time_hide_value" = "非表示";
+"preferences_appearance_status_bar_next_event" = "%d 分以内に開始されるミーティングのみ表示";
+"preferences_appearance_menu_title" = "メニュー";
+"preferences_appearance_menu_shorten_event_title_toggle" = "ミーティング名を短縮する";
+"preferences_appearance_menu_shorten_event_title_stepper" = "%d 文字";
+"preferences_appearance_menu_time_format_title" = "時刻形式:";
+"preferences_appearance_menu_time_format_12_hour_value" = "12時間 (AM/PM)";
+"preferences_appearance_menu_time_format_24_hour_value" = "24時間";
+"preferences_appearance_menu_show_event_title" = "イベント表示:";
+"preferences_appearance_menu_show_event_end_time_value" = "終了時刻";
+"preferences_appearance_menu_show_event_icon_value" = "アイコン";
+"preferences_appearance_menu_show_event_details_value" = "サブメニューに詳細表示";
+
+// MARK: - Preferences Services
+
+"preferences_services_link_meeting_title" = "すべてのミーティングリンクを開くアプリ";
+"preferences_services_link_meet_title" = "Meet を開くアプリ";
+"preferences_services_link_zoom_title" = "Zoom を開くアプリ";
+"preferences_services_link_team_title" = "Teams を開くアプリ";
+"preferences_services_link_default_browser_value" = "標準のブラウザー";
+"preferences_services_link_zoom_value" = "Zoom アプリ";
+"preferences_services_link_teams_value" = "Teams アプリ";
+"preferences_services_supported_links_list" = "サポートしているサービス一覧:\n%@";
+"preferences_services_supported_links_mailback" = "もしあなたが使っているサービスが無ければご連絡ください";
+"preferences_services_create_meeting_title" = "ミーティングを作成するサービス";
+"preferences_services_create_meeting_custom_url_value" = "カスタム URL";
+"preferences_services_create_meeting_custom_url_placeholder" = "正しい URL を入力してください (https:// などのスキーマも必要です)";
+"preferences_services_google_meet_tip" = "Tip: Meet はパラメタを利用してアカウントを選択できます。例: https://meet.google.com/new?authuser=1";
+"preferences_services_create_meeting_browser_title" = "使用するブラウザ";
+
+// MARK: - Preferences Services Browsers Configuration
+
+"preferences_configure_browsers_button" = "ブラウザー設定";
+"preferences_configure_browsers_delete_alert_title" = "ブラウザー設定を削除しますか？";
+"preferences_configure_browsers_delete_alert_message" = "%@ のブラウザー設定を削除してもよろしいですか？";
+"preferences_configure_browsers_add_button_browser_title" = "ブラウザー";
+"preferences_configure_browsers_add_button_all_system_title" = "すべてのシステムブラウザー";
+"preferences_configure_browsers_modal_add_browser_title" = "ブラウザーを追加する";
+"preferences_configure_browsers_modal_edit_browser_title" = "ブラウザーの編集";
+"preferences_configure_browsers_modal_add_browser_name" = "名前";
+"preferences_configure_browsers_modal_add_browser_path" = "パス";
+"preferences_configure_browsers_modal_add_browser_choose_browser_button_title" = "ブラウザーの選択";
+"preferences_configure_browsers_modal_alert_title" = "ブラウザー設定を追加できませんでした";
+"preferences_configure_browsers_choose_broser_panel_title" = "正しいブラウザーアプリを指定してください";
+"preferences_configure_browsers_choose_broser_panel_prompt" = "ブラウザーの選択";
+"preferences_configure_browsers_choose_broser_panel_message" = "Select a browser from any path!";
+
+// MARK: - Preferences Bookmarks
+
+"preferences_bookmarks_no_bookmarks_placeholder" = "ブックマークはまだありません";
+"preferences_bookmarks_delete_bookmark_title" = "Delete bookmark?";
+"preferences_bookmarks_delete_bookmark_message" = "Do you want to delete bookmark %@?";
+"preferences_bookmarks_add_bookmark_button" = "ブックマークを追加する";
+"preferences_bookmarks_new_bookmark_title" = "New bookmark";
+"preferences_bookmarks_new_bookmark_name" = "Name";
+"preferences_bookmarks_new_bookmark_link_phone" = "Link/Phone";
+"preferences_bookmarks_new_bookmark_service" = "Service";
+"preferences_bookmarks_new_bookmark_already_exist" = "A bookmark with this link/phone already exists with the name %@:\n%@";
+"preferences_bookmarks_new_bookmark_error_title" = "Can't add bookmark";
+
+// MARK: - Preferences Calendars
+
+"preferences_calendars_select_calendars_title" = "ステータスバーに表示したいカレンダーの選択";
+"preferences_calendars_add_account_description" = "必要なカレンダーが見当たりませんか？";
+"preferences_calendars_add_account_button" = "アカウントの追加";
+"preferences_calendars_add_account_modal" = "To add external Calendars follow these steps:\n1. Open the default Calendar App\n2. Click 'Add Account' in the menu\n3. Choose and connect your account";
+
+// MARK: - Preferences Advanced
+
+"preferences_advanced_setting_warning" = "⚠️ これらの設定は、その内容を理解した上で使用してください。";
+"preferences_advanced_apple_script_checkmark" = "ミーティング参加時に AppleScript を実行する";
+"preferences_advanced_apple_script_placeholder" = "# ここにスクリプトを書いてください\ntell application \"Music\" to pause";
+"preferences_advanced_save_script_button" = "保存";
+"preferences_advanced_wrong_location_title" = "場所が誤っています";
+"preferences_advanced_wrong_location_message" = "Please select the User > Library > Application Scripts > leits.MeetingBar folder";
+"preferences_advanced_wrong_location_button" = "了解！";
+"preferences_advanced_regex_title" = "ミーティングリンク用のカスタム正規表現";
+"preferences_advanced_regex_add_button" = "正規表現を追加";
+"preferences_advanced_regex_edit_button" = "編集";
+"preferences_advanced_regex_delete_button" = "x";
+"preferences_advanced_regex_new_title" = "正規表現を入力する";
+"preferences_advanced_regex_new_cant_save_title" = "正規表現を保存できませんでした";
+
+// MARK: - Status bar
+
+"status_bar_section_today" = "今日";
+"status_bar_section_tomorrow" = "明日";
+"status_bar_empty_calendar_message" = "Select calendars in preferences\nto see your meetings";
+"status_bar_section_join_next_meeting" = "次のミーティングに参加";
+"status_bar_section_join_from_clipboard" = "クリップボードからミーティングを開く";
+"status_bar_section_join_create_meeting" = "ミーティングを作成";
+"status_bar_section_bookmarks_title" = "ブックマーク";
+"status_bar_section_bookmarks_menu" = "ブックマークメニュー";
+"status_bar_section_date_nothing" = "%@はミーティングがありません";
+"status_bar_event_start_time_all_day" = "終日";
+"status_bar_submenu_calendar_title" = "カレンダー: %@";
+"status_bar_submenu_duration_all_day" = "%@ - %@ (%@分)";
+"status_bar_submenu_status_title" = "状態: %@";
+"status_bar_submenu_status_accepted" = " 👍 Accepted";
+"status_bar_submenu_status_canceled" = " 👎 Canceled";
+"status_bar_submenu_status_tentative" = " ☝️ Tentative";
+"status_bar_submenu_status_pending" = " ⏳ Pending";
+"status_bar_submenu_status_unknown" = " ❔ Unknown";
+"status_bar_submenu_status_default_extended" = " ❔ (%@)";
+"status_bar_submenu_status_default_simple" = " ❔ (Unknown)";
+"status_bar_submenu_location_title" = "場所:";
+"status_bar_submenu_organizer_title" = "主催者:";
+"status_bar_submenu_notes_title" = "ノート:";
+"status_bar_submenu_attendees_title" = "参加者 (%d)";
+"status_bar_submenu_attendees_no_name" = "No name attendee";
+"status_bar_submenu_attendees_you" = "%@ (you)";
+"status_bar_submenu_attendees_status_tentative" = " [tentative]";
+"status_bar_submenu_attendees_status_unknown" = " [?]";
+"status_bar_submenu_open_in_calendar" = "カレンダーアプリで開く";
+"status_bar_submenu_open_in_fantastical" = "Fantastical で開く";
+"status_bar_quick_actions" = "クイックアクション";
+"status_bar_show_meeting_names" = "ミーティング名を表示する";
+"status_bar_hide_meeting_names" = "ミーティング名を隠す";
+"status_bar_whats_new" = "What's new?";
+"status_bar_preferences" = "設定";
+"status_bar_quit" = "MeetingBar を終了";
+"status_bar_no_title" = "タイトルなし";
+"status_bar_event_status_now" = "now (%@ left)";
+"status_bar_event_status_in" = "あと%@";
+"status_bar_error_apple_script_title" = "AppleScript return error";
+"status_bar_error_link_missed_title" = "えー！%@ に参加できませんでした";
+"status_bar_error_link_missed_message" = "リンクが登録されていないか、サポートされていないミーティングサービスです";
+"status_bar_error_teams_link_title" = "おっと！Microsoft Team アプリでリンクを開けませんでした";
+"status_bar_error_teams_link_message" = "Make sure you have Microsoft Teams app installed, or change the app in the preferences.";
+"status_bar_error_zoom_app_link_title" = "Oops! Unable to open the link in Zoom app";
+"status_bar_error_zoom_app_link_message" = "Make sure you have Zoom app installed, or change the app in the preferences.";
+"status_bar_error_zoom_native_link_title" = "Oops! Unable to open the native link in Zoom app";
+"status_bar_error_zoom_native_link_message" = "Make sure you have Zoom app installed, or change the app in the preferences.";
+
+// MARK: - Welcome screen
+
+"welcome_screen_greeting_main_title" = "こんにちは！ MeetingBar は必要な機能が揃ったシンプルなアプリです。";
+"welcome_screen_greeting_additional_title" = "100% 使いこなしましょう！";
+"welcome_screen_login_launch_toggle_title" = "ログイン時に MeetingBar を起動する";
+"welcome_screen_shortcut_next_meeting_title" = "次のミーティングに参加するためのショートカット:";
+"welcome_screen_ad_hoc_meeting_title" = "次のアプリでミーティングを作成: ";
+"welcome_screen_shortcut_ad_hoc_meeting_title" = "ショートカット:";
+"welcome_screen_setup_calendar_title" = "カレンダーの設定";
+
+// MARK: - Calendars screen
+
+"calendars_screen_select_calendar_title" = "カレンダーが選択されていません";
+"calendars_screen_start_button" = "アプリを開始する";
+
+// MARK: - Access screen
+
+"access_screen_access_denied_title" = "おっと！カレンダーへのアクセスが拒否されているようです。";
+"access_screen_access_screen_access_denied_go_to_title" = "Go to";
+"access_screen_access_denied_system_preferences_button" = "システム設定";
+"access_screen_access_denied_checkbox_title" = "and select a checkbox near MeetingBar.";
+"access_screen_access_denied_relaunch_title" = "Then you need to launch the app manually to continue setting up.";
+"access_screen_access_granted_title" = "カレンダーへのアクセス許可を求めています。";
+"access_screen_access_granted_click_ok_title" = "macOS のポップアップウィンドウで \"OK\" をクリックしてください。";
+
+// MARK: - Shared
+
+"shared_send_notification_toggle" = "イベント開始前に通知する";
+"shared_send_notification_directly_value" = "イベントが始まったとき";
+"shared_send_notification_one_minute_value" = "1分前";
+"shared_send_notification_three_minute_value" = "3分前";
+"shared_send_notification_five_minute_value" = "5分前";
+"shared_send_notification_no_alert_style_tip" = "⚠️ MeetingBar の macOS の通知設定は、現在アラートに設定されていません。持続的な通知をご希望の場合は、アラートを有効にしてください。";
+"shared_send_notification_disabled_tip" = "⚠️ MeetingBar の macOS の通知設定が現在オフになっています。ミーティングを見逃さないために、 macOS のシステム設定で通知を有効にしてください。";
+
+// MARK: - Constants
+"constants_create_meeting_service_meet" = "Google Meet";
+"constants_create_meeting_service_jam" = "Jam";
+"constants_create_meeting_service_coscreen" = "CoScreen";
+"constants_create_meeting_service_zoom" = "Zoom";
+"constants_create_meeting_service_teams" = "Microsoft Teams";
+"constants_create_meeting_service_gcalendar" = "Google Calendar";
+"constants_create_meeting_service_outlook_live" = "Outlook Live";
+"constants_create_meeting_service_outlook_office365" = "Outlook Office365";
+"constants_create_meeting_service_url" = "Custom url";
+
+"constants_meeting_service_phone" = "Phone";
+"constants_meeting_service_meet" = "Google Meet";
+"constants_meeting_service_hangouts" = "Google Hangouts";
+"constants_meeting_service_zoom" = "Zoom";
+"constants_meeting_service_zoom_native" = "Zoom native";
+"constants_meeting_service_teams" = "Microsoft Teams";
+"constants_meeting_service_webex" = "Cisco Webex";
+"constants_meeting_service_jitsi" = "Jitsi";
+"constants_meeting_service_chime" = "Amazon Chime";
+"constants_meeting_service_ringcentral" = "Ring Central";
+"constants_meeting_service_gotomeeting" = "GoToMeeting";
+"constants_meeting_service_gotowebinar" = "GoToWebinar";
+"constants_meeting_service_bluejeans" = "BlueJeans";
+"constants_meeting_service_eight_x_eight" = "8x8";
+"constants_meeting_service_demio" = "Demio";
+"constants_meeting_service_join_me" = "Join.me";
+"constants_meeting_service_zoomgov" = "ZoomGov";
+"constants_meeting_service_whereby" = "Whereby";
+"constants_meeting_service_uberconference" = "Uber Conference";
+"constants_meeting_service_blizz" = "Blizz";
+"constants_meeting_service_teamviewer_meeting" = "Teamviewer Meeting";
+"constants_meeting_service_vsee" = "VSee";
+"constants_meeting_service_starleaf" = "StarLeaf";
+"constants_meeting_service_duo" = "Google Duo";
+"constants_meeting_service_voov" = "Tencent VooV";
+"constants_meeting_service_facebook_workspace" = "Facebook Workspace";
+"constants_meeting_service_lifesize" = "Lifesize";
+"constants_meeting_service_skype" = "Skype";
+"constants_meeting_service_skype4biz" = "Skype For Business";
+"constants_meeting_service_skype4biz_selfhosted" = "Skype For Business (SH)";
+"constants_meeting_service_facetime" = "Facetime";
+"constants_meeting_service_facetimeaudio" = "Facetime Audio";
+"constants_meeting_service_youtube" = "YouTube";
+"constants_meeting_service_vonageMeetings" = "Vonage Meetings";
+"constants_meeting_service_meetStream" = "Google Meet Stream";
+"constants_meeting_service_around" = "Around";
+"constants_meeting_service_jam" = "Jam";
+"constants_meeting_service_discord" = "Discord";
+"constants_meeting_service_blackboard_collab" = "Blackboard Collaborate";
+"constants_meeting_service_coscreen" = "CoScreen";
+"constants_meeting_service_vowel" = "Vowel";
+"constants_meeting_service_other" = "Other";
+"constants_meeting_service_url" = "URL";
+
+"constants_browser_brave" = "Brave";
+"constants_browser_chrome" = "Google Chrome";
+"constants_browser_chromium" = "Chromium";
+"constants_browser_edge" = "Microsoft Edge";
+"constants_browser_firefox" = "Firefox";
+"constants_browser_opera" = "Opera";
+"constants_browser_vivaldi" = "Vivaldi";
+"constants_browser_safari" = "Safari";
+"constants_browser_defaultBrowser" = "標準のブラウザー";
+
+// MARK: - Store
+
+"store_patronage_title" = "MeetingBar Patronage";
+"store_patronage_restore_success_message" = "復元に成功しました";
+"store_patronage_restore_nothing_message" = "復元する内容がありません";
+"store_patronage_purchase_success_message" = "購入に成功しました。サポートありがとうございます！";
+"store_patronage_purchase_unknown_message" = "不明なエラーが発生しました。サポートにお問い合わせください";
+"store_patronage_purchase_client_invalid_message" = "Not allowed to make the payment";
+"store_patronage_purchase_payment_invalid_message" = "The purchase identifier was invalid";
+"store_patronage_purchase_payment_not_allowed_message" = "The device is not allowed to make the payment";
+"store_patronage_purchase_store_product_not_available_message" = "The product is not available in the current storefront";
+"store_patronage_purchase_cloud_service_permission_denied_message" = "Access to cloud service information is not allowed";
+"store_patronage_purchase_cloud_service_network_connection_failed" = "Could not connect to the network";
+"store_patronage_purchase_cloud_service_revoked_message" = "User has revoked permission to use this cloud service";
+
+// MARK: - Notifications
+
+"notifications_event_start_soon_body" = "もうすぐイベントが開始されます";
+
+// MARK: - Link open
+
+"link_url_cant_open_title" = "おっと！ %@ リンクを開くことが出来ませんでした";
+"link_url_cant_open_message" = "Make sure you have %@ installed, or change the browser in preferences.";

--- a/MeetingBar/Views/Changelog/Changelog.swift
+++ b/MeetingBar/Views/Changelog/Changelog.swift
@@ -62,6 +62,11 @@ struct ChangelogView: View {
                         Text("Fixed zoom link detection")
                     }
                 }
+                if lastRevisedVersionInChangelog < "3.7.0" {
+                    Section(header: Text("Version 3.7.0")) {
+                        Text("🌍 Added translations into Japanese")
+                    }
+                }
             }.listStyle(SidebarListStyle())
             Button("Close", action: close)
         }.padding()

--- a/MeetingBar/Views/Shared.swift
+++ b/MeetingBar/Views/Shared.swift
@@ -74,6 +74,7 @@ struct LaunchAtLoginANDPreferredLanguagePicker: View {
                 Text("Deutsche").tag(AppLanguage.german)
                 Text("Norks").tag(AppLanguage.norwegian)
                 Text("Čeština").tag(AppLanguage.czech)
+                Text("Japanese").tag(AppLanguage.japanese)
             }.frame(width: 250)
         }
     }


### PR DESCRIPTION
### Status
**READY**

### Description

MeetingBar supported multilingualization, so I added Japanese translation. This is a very important improvement for Japanese people.

## Checklist
- [x] Localized
- [x] Added to changelog:
  - [x] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
1. Build an App and Run it
2. Click MeetingBar on Status bar, and click preferences
3. Set preferred language to `Japanese`
4. Restart MeetingBar
5. You can see Japanese translation
