### PR TITLE
✨ feat(jitsi): support for local jitsi-meet-app

### DIFF
--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -96,6 +96,7 @@ extension Defaults.Keys {
     static let useChromeForMeetLinks = Key<Bool?>("useChromeForMeetLinks") // Backward compatibility
     static let useAppForZoomLinks = Key<Bool>("useAppForZoomLinks", default: false)
     static let useAppForTeamsLinks = Key<Bool>("useAppForTeamsLinks", default: false)
+    static let useAppForJitsiLinks = Key<Bool>("useAppForJitsiLinks", default: false)
 
     // Advanced
     static let joinEventScriptLocation = Key<URL?>("joinEventScriptLocation", default: nil)

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -207,6 +207,18 @@ func getEventParticipantStatus(_ event: EKEvent) -> EKParticipantStatus? {
 
 func openMeetingURL(_ service: MeetingServices?, _ url: URL, _ browser: Browser?) {
     switch service {
+    case .jitsi:
+        if Defaults[.useAppForJitsiLinks] {
+            var jitsiAppUrl = URLComponents(url: url, resolvingAgainstBaseURL: false)!
+            jitsiAppUrl.scheme = "jitsi-meet"
+            let result = jitsiAppUrl.url!.openInDefaultBrowser()
+            if !result {
+                sendNotification("status_bar_error_jitsi_link_title".loco(), "status_bar_error_jitsi_link_message".loco())
+                url.openInDefaultBrowser()
+            }
+        } else {
+            url.openIn(browser: browser ?? systemDefaultBrowser)
+        }
     case .meet:
         url.openIn(browser: browser ?? Defaults[.meetBrowser])
 

--- a/MeetingBar/Resources /Localization /cs.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /cs.lproj/Localizable.strings
@@ -241,8 +241,10 @@
 "preferences_services_supported_links_list" = "Podporované odkazy na služby:\n%@";
 "preferences_services_link_teams_value" = "Aplikace Teams";
 "preferences_services_link_zoom_value" = "Aplikace Zoom";
+"preferences_services_link_jitsi_value" = "Aplikace Jitsi Meet";
 "preferences_services_link_default_browser_value" = "Výchozí prohlížeč";
 "preferences_services_link_team_title" = "Otvírat odkazy služby Teams v:";
+"preferences_services_link_jitsi_title" = "Otvírat odkazy služby Jitsi v:";
 "preferences_services_link_zoom_title" = "Otvírat odkazy služby Zoom v:";
 "preferences_services_link_meet_title" = "Otvírat odkazy služby Google Meet v:";
 

--- a/MeetingBar/Resources /Localization /de.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /de.lproj/Localizable.strings
@@ -216,9 +216,11 @@
 "preferences_services_create_meeting_custom_url_value" = "Benutzerdefinierte URL";
 "preferences_services_create_meeting_title" = "Konferenzen erstellen über";
 "preferences_services_supported_links_list" = "Unterstützte Links für Dienste:\n%@";
-"preferences_services_link_teams_value" = "Teams-Anwendung";
-"preferences_services_link_zoom_value" = "Zoom-Anwendung";
+"preferences_services_link_teams_value" = "Teams Anwendung";
+"preferences_services_link_zoom_value" = "Zoom Anwendung";
+"preferences_services_link_jitsi_value" = "Jitsi-Meet Anwendung";
 "preferences_services_link_team_title" = "Teams-Links öffnen in";
+"preferences_services_link_jitsi_title" = "Jitsi-Links öffnen in";
 "preferences_services_link_zoom_title" = "Zoom-Links öffnen in";
 "preferences_services_link_meet_title" = "Meet-links öffnen in";
 

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -120,9 +120,11 @@
 "preferences_services_link_meet_title" = "Open Google Meet links in";
 "preferences_services_link_zoom_title" = "Open Zoom links in";
 "preferences_services_link_team_title" = "Open Teams links in";
+"preferences_services_link_jitsi_title" = "Open Jitsi links in";
 "preferences_services_link_default_browser_value" = "Default web browser";
 "preferences_services_link_zoom_value" = "Zoom app";
 "preferences_services_link_teams_value" = "Teams app";
+"preferences_services_link_jitsi_value" = "Jitsi Meet app";
 "preferences_services_supported_links_list" = "Supported links for services:\n%@";
 "preferences_services_supported_links_mailback" = "If the service you use isn't supported, you can send an e-mail to the developers";
 "preferences_services_create_meeting_title" = "Create meetings via";

--- a/MeetingBar/Resources /Localization /fr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /fr.lproj/Localizable.strings
@@ -242,8 +242,11 @@
 "preferences_services_supported_links_list" = "Liens pris en charge pour les services :\n%@";
 "preferences_services_link_teams_value" = "Appli Teams";
 "preferences_services_link_zoom_value" = "Appli Zoom";
+"preferences_services_link_jitsi_value" = "Appli Jitsi";
+
 "preferences_services_link_default_browser_value" = "Navigateur par défaut";
 "preferences_services_link_team_title" = "Ouvrir les liens Team dans";
+"preferences_services_link_jitsi_title" = "Ouvrir les liens Jitsi dans";
 "preferences_services_link_zoom_title" = "Ouvrir les liens Zoom dans";
 "preferences_services_link_meet_title" = "Ouvrir les liens Meet dans";
 

--- a/MeetingBar/Resources /Localization /hr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /hr.lproj/Localizable.strings
@@ -114,9 +114,11 @@
 "preferences_services_link_meet_title" = "Otvori Meet poveznice u";
 "preferences_services_link_zoom_title" = "Otvori Zoom poveznice u";
 "preferences_services_link_team_title" = "Otvori Teams poveznice u";
+"preferences_services_link_jitsi_title" = "Open Jitsi links in";
 "preferences_services_link_default_browser_value" = "Standardni preglednik";
 "preferences_services_link_zoom_value" = "Zoom program";
 "preferences_services_link_teams_value" = "Teams program";
+"preferences_services_link_jitsi_value" = "Jitsi Meet program";
 "preferences_services_supported_links_list" = "Podržane poveznice za usluge:\n%@";
 "preferences_services_supported_links_mailback" = "Ako usluga nije podržana, javi mi putem e-maila";
 "preferences_services_create_meeting_title" = "Stvori sastanke putem";

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -119,9 +119,11 @@
 "preferences_services_link_meet_title" = "Meet を開くアプリ";
 "preferences_services_link_zoom_title" = "Zoom を開くアプリ";
 "preferences_services_link_team_title" = "Teams を開くアプリ";
+"preferences_services_link_jitsi_title" = "Jitsi を開くアプリ";
 "preferences_services_link_default_browser_value" = "標準のブラウザー";
 "preferences_services_link_zoom_value" = "Zoom アプリ";
 "preferences_services_link_teams_value" = "Teams アプリ";
+"preferences_services_link_jitsi_value" = "Jitsi Meet アプリ";
 "preferences_services_supported_links_list" = "サポートしているサービス一覧:\n%@";
 "preferences_services_supported_links_mailback" = "もしあなたが使っているサービスが無ければご連絡ください";
 "preferences_services_create_meeting_title" = "ミーティングを作成するサービス";

--- a/MeetingBar/Resources /Localization /nb-NO.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /nb-NO.lproj/Localizable.strings
@@ -263,8 +263,10 @@
 "preferences_services_supported_links_list" = "Støttede lenker for tjenester:\n%@";
 "preferences_services_link_teams_value" = "Teams-programmet";
 "preferences_services_link_zoom_value" = "Zoom-programmet";
+"preferences_services_link_jitsi_value" = "Jitsi Meet-programmet";
 "preferences_services_link_default_browser_value" = "Forvalgt nettleser";
 "preferences_services_link_team_title" = "Åpne Teams-lenker i";
+"preferences_services_link_jitsi_title" = "Åpne Jitsi-lenker i";
 "preferences_services_link_zoom_title" = "Åpne Zoom-lenker i";
 "preferences_services_link_meet_title" = "Åpne Google Meet-lenker i";
 

--- a/MeetingBar/Resources /Localization /ru.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ru.lproj/Localizable.strings
@@ -114,9 +114,11 @@
 "preferences_services_link_meet_title" = "Meet ссылки";
 "preferences_services_link_zoom_title" = "Zoom ссылки";
 "preferences_services_link_team_title" = "Teams ссылки";
+"preferences_services_link_jitsi_title" = "Open Jitsi links in";
 "preferences_services_link_default_browser_value" = "Браузер по умолчанию";
 "preferences_services_link_zoom_value" = "Приложении Zoom";
 "preferences_services_link_teams_value" = "Приложении Teams";
+"preferences_services_link_jitsi_value" = "Приложении Jitsi";
 "preferences_services_supported_links_list" = "Поддерживаются ссылки для сервисов:\n%@";
 "preferences_services_supported_links_mailback" = "Если приложения, которым вы пользуете, нет в списке, напишите мне";
 "preferences_services_create_meeting_title" = "Создавать события через";

--- a/MeetingBar/Resources /Localization /uk.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /uk.lproj/Localizable.strings
@@ -114,9 +114,12 @@
 "preferences_services_link_meet_title" = "Відкривати Meet посилання в";
 "preferences_services_link_zoom_title" = "Відкривати Zoom посилання в";
 "preferences_services_link_team_title" = "Відкривати Teams посилання в";
+"preferences_services_link_jitsi_title" = "Open Jitsi links in";
 "preferences_services_link_default_browser_value" = "основному браузері";
 "preferences_services_link_zoom_value" = "додатку Zoom";
 "preferences_services_link_teams_value" = "додатку Teams";
+"preferences_services_link_jitsi_value" = "додатку Jitsi";
+
 "preferences_services_supported_links_list" = "Розпізнаються посилання для сервісів:\n%@";
 "preferences_services_supported_links_mailback" = "Якщо сервіс, який Ви використовуєте для зустрічей, не підтримується, напишіть мені";
 "preferences_services_create_meeting_title" = "Створювати зустрічі в";

--- a/MeetingBar/Views/Preferences/ServicesTab.swift
+++ b/MeetingBar/Views/Preferences/ServicesTab.swift
@@ -18,6 +18,7 @@ struct ServicesTab: View {
     @Default(.defaultBrowser) var defaultBrowser
     @Default(.useAppForZoomLinks) var useAppForZoomLinks
     @Default(.useAppForTeamsLinks) var useAppForTeamsLinks
+    @Default(.useAppForJitsiLinks) var useAppForJitsiLinks
     @Default(.createMeetingServiceUrl) var createMeetingServiceUrl
     @Default(.createMeetingService) var createMeetingService
     @Default(.browsers) var allBrowser
@@ -48,6 +49,10 @@ struct ServicesTab: View {
                 Picker(selection: $useAppForTeamsLinks, label: Text("preferences_services_link_team_title".loco()).frame(width: 200, alignment: .leading)) {
                     Text("preferences_services_link_default_browser_value".loco()).tag(false)
                     Text("preferences_services_link_teams_value".loco()).tag(true)
+                }
+                Picker(selection: $useAppForJitsiLinks, label: Text("preferences_services_link_jitsi_title".loco()).frame(width: 200, alignment: .leading)) {
+                    Text("preferences_services_link_default_browser_value".loco()).tag(false)
+                    Text("preferences_services_link_jitsi_value".loco()).tag(true)
                 }
             }.padding(.horizontal, 10)
 


### PR DESCRIPTION
### Status
**READY**

### Description
- jitsi links can be now opened directly in the local app https://github.com/jitsi/jitsi-meet-electron instead of the standard browser
- the behaviour is opt-in and can be enabled in the services tab

![image](https://user-images.githubusercontent.com/3872101/130335620-bc809385-18f9-4a4d-aecd-aa0c7781cc37.png)


## Checklist
- [x] Localized

- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

The changelog could not be updated as the other pull request will otherwise have a conflict...

### Steps to Test or Reproduce

- create a test meeting, e.g. 
- install https://github.com/jitsi/jitsi-meet-electron via brew or manually
- configure to open jitsi links in the services tab
- click on the meeting entry in meetingbar 
- the jitsi-meet app should be opened now... 🎉

