### PR TITLE
quick fix for issue #194

### DIFF
--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -176,7 +176,6 @@ func detectLinks(text: String) -> [URL] {
 
 func openEvent(_ event: EKEvent) {
     let eventTitle = event.title ?? "status_bar_no_title".loco()
-    let eventUrl = event.url?.absoluteString ?? ""
     if let meeting = getMeetingLink(event) {
         if Defaults[.runJoinEventScript], Defaults[.joinEventScriptLocation] != nil {
             if let url = Defaults[.joinEventScriptLocation]?.appendingPathComponent("joinEventScript.scpt") {
@@ -190,9 +189,8 @@ func openEvent(_ event: EKEvent) {
             }
         }
         openMeetingURL(meeting.service, meeting.url, nil)
-    } else if eventUrl != "" {
-        // NSLog("opening \(eventUrl) in default browser")
-        event.url?.openInDefaultBrowser()
+    } else if let eventUrl = event.url {
+        eventUrl.openInDefaultBrowser()
     } else {
         sendNotification("status_bar_error_link_missed_title".loco(eventTitle), "status_bar_error_link_missed_message".loco())
     }

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -176,6 +176,7 @@ func detectLinks(text: String) -> [URL] {
 
 func openEvent(_ event: EKEvent) {
     let eventTitle = event.title ?? "status_bar_no_title".loco()
+    let eventUrl = event.url?.absoluteString ?? ""
     if let meeting = getMeetingLink(event) {
         if Defaults[.runJoinEventScript], Defaults[.joinEventScriptLocation] != nil {
             if let url = Defaults[.joinEventScriptLocation]?.appendingPathComponent("joinEventScript.scpt") {
@@ -189,8 +190,8 @@ func openEvent(_ event: EKEvent) {
             }
         }
         openMeetingURL(meeting.service, meeting.url, nil)
-    } else if event.url != nil {
-        NSLog("opening \(String(describing: event.url?.absoluteString)) in default browser")
+    } else if eventUrl != "" {
+        // NSLog("opening \(eventUrl) in default browser")
         event.url?.openInDefaultBrowser()
     } else {
         sendNotification("status_bar_error_link_missed_title".loco(eventTitle), "status_bar_error_link_missed_message".loco())

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -189,6 +189,9 @@ func openEvent(_ event: EKEvent) {
             }
         }
         openMeetingURL(meeting.service, meeting.url, nil)
+    } else if event.url != nil {
+        NSLog("opening \(String(describing: event.url?.absoluteString)) in default browser")
+        event.url?.openInDefaultBrowser()
     } else {
         sendNotification("status_bar_error_link_missed_title".loco(eventTitle), "status_bar_error_link_missed_message".loco())
     }


### PR DESCRIPTION
### Status
**READY**

### Description
Small change related to #194 that opens the `URL` of an event in the default browser if it's not handled by `getMeetingLink()`

I think this improves the end user experience without causing any harm or unexpected functionality.

### Steps to Test or Reproduce

1. Create an event that has just a simple URL e.g. `https://www.google.com/search?q=MeetingBar`
![image](https://user-images.githubusercontent.com/1992842/131261215-fb598818-31d5-45d3-868c-a7d5fd3692cf.png)
2. Click on this event from MeetingBar
