### PR TITLE
Added regex event filter system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog for Meetingbar
 ## Version 3.9.0 (WIP)
 > unreleased
+* Added support to filter out events by regex
 
 ## Version 3.8.0 (WIP)
 > (released 15th Sep 2021)

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -103,5 +103,5 @@ extension Defaults.Keys {
     static let runJoinEventScript = Key<Bool>("runAppleScriptWhenJoiningEvent", default: false)
     static let joinEventScript = Key<String>("joinEventScript", default: "preferences_advanced_apple_script_placeholder".loco())
     static let customRegexes = Key<[String]>("customRegexes", default: [])
-    static let customEventRegexes = Key<[String]>("customEventRegexes", default: [])
+    static let filterEventRegexes = Key<[String]>("filterEventRegexes", default: [])
 }

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -103,4 +103,5 @@ extension Defaults.Keys {
     static let runJoinEventScript = Key<Bool>("runAppleScriptWhenJoiningEvent", default: false)
     static let joinEventScript = Key<String>("joinEventScript", default: "preferences_advanced_apple_script_placeholder".loco())
     static let customRegexes = Key<[String]>("customRegexes", default: [])
+    static let customEventRegexes = Key<[String]>("customEventRegexes", default: [])
 }

--- a/MeetingBar/Extensions/EventStore.swift
+++ b/MeetingBar/Extensions/EventStore.swift
@@ -41,7 +41,7 @@ extension EKEventStore {
             if !shouldIncludeMeeting(calendarEvent) {
                 continue
             }
-            
+
             var addEvent = false
             if calendarEvent.isAllDay {
                 if Defaults[.allDayEvents] == AlldayEventsAppereance.show {

--- a/MeetingBar/Extensions/EventStore.swift
+++ b/MeetingBar/Extensions/EventStore.swift
@@ -38,8 +38,11 @@ extension EKEventStore {
         var filteredCalendarEvents = [EKEvent]()
 
         for calendarEvent in calendarEvents {
+            if !shouldIncludeMeeting(calendarEvent) {
+                continue
+            }
+            
             var addEvent = false
-
             if calendarEvent.isAllDay {
                 if Defaults[.allDayEvents] == AlldayEventsAppereance.show {
                     addEvent = true
@@ -109,7 +112,7 @@ extension EKEventStore {
         // but the next event is closer than 13 minutes later
         // then show the next event
         for event in nextEvents {
-            if event.isAllDay {
+            if event.isAllDay || !shouldIncludeMeeting(event) {
                 continue
             } else {
                 if Defaults[.nonAllDayEvents] == NonAlldayEventsAppereance.show_inactive_without_meeting_link {

--- a/MeetingBar/Extensions/String.swift
+++ b/MeetingBar/Extensions/String.swift
@@ -47,7 +47,7 @@ extension String {
     ///   - replacement: The replacement string.
     /// - Returns: The string with the replacement, if any.
     func replacingFirstOccurrence(of target: String, with replacement: String) -> String {
-        if let range = self.range(of: target) {
+        if let range = range(of: target) {
             return replacingCharacters(in: range, with: replacement)
         }
         return self
@@ -63,7 +63,7 @@ extension String {
     /// - Returns: The string without HTML tags.
     func htmlTagsStripped() -> String {
         if containsHTML,
-           let data = self.data(using: .utf16),
+           let data = data(using: .utf16),
            let attributedSelf = NSAttributedString(
                html: data,
                options: [.documentType: NSAttributedString.DocumentType.html],

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -128,7 +128,7 @@ func detectLink(_ field: inout String) -> MeetingLink? {
 }
 
 func shouldIncludeMeeting(_ event: EKEvent) -> Bool {
-    for pattern in Defaults[.customEventRegexes] {
+    for pattern in Defaults[.filterEventRegexes] {
         if let regex = try? NSRegularExpression(pattern: pattern) {
             if hasMatch(text: event.title, regex: regex) {
                 return false

--- a/MeetingBar/Helpers.swift
+++ b/MeetingBar/Helpers.swift
@@ -64,6 +64,10 @@ func getMatch(text: String, regex: NSRegularExpression) -> String? {
     return nil
 }
 
+func hasMatch(text: String, regex: NSRegularExpression) -> Bool {
+    return regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)) != nil
+}
+
 func cleanUpNotes(_ notes: String) -> String {
     let zoomSeparator = "\n──────────"
     let meetSeparator = "-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-"
@@ -121,6 +125,17 @@ func detectLink(_ field: inout String) -> MeetingLink? {
         }
     }
     return nil
+}
+
+func shouldIncludeMeeting(_ event: EKEvent) -> Bool {
+    for pattern in Defaults[.customEventRegexes] {
+        if let regex = try? NSRegularExpression(pattern: pattern) {
+            if hasMatch(text: event.title, regex: regex) {
+                return false
+            }
+        }
+    }
+    return true
 }
 
 /**

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -175,6 +175,7 @@
 "preferences_advanced_wrong_location_title" = "Wrong location";
 "preferences_advanced_wrong_location_message" = "Please select the User → Library → Application Scripts → leits.MeetingBar folder";
 "preferences_advanced_wrong_location_button" = "Got it!";
+"preferences_advanced_event_regex_title" = "Custom regexes to filter out meetings";
 "preferences_advanced_regex_title" = "Custom regexes for meeting link";
 "preferences_advanced_regex_add_button" = "Add regex";
 "preferences_advanced_regex_edit_button" = "edit";

--- a/MeetingBar/Views/Changelog/Changelog.swift
+++ b/MeetingBar/Views/Changelog/Changelog.swift
@@ -78,6 +78,11 @@ struct ChangelogView: View {
                         Text("• Open the link from the event link field if the meeting service is not recognized")
                     }
                 }
+                if lastRevisedVersionInChangelog < "3.9.0" {
+                    Section(header: Text("Version 3.9.0")) {
+                        Text("• Support to filter out events by regex")
+                    }
+                }
             }.listStyle(SidebarListStyle())
             Button("Close", action: close)
         }.padding()

--- a/MeetingBar/Views/Preferences/AdvancedTab.swift
+++ b/MeetingBar/Views/Preferences/AdvancedTab.swift
@@ -15,7 +15,7 @@ struct AdvancedTab: View {
         VStack(alignment: .leading) {
             ScriptSection()
             Divider()
-            EventRegexesSection()
+            FilterEventRegexesSection()
             Divider()
             MeetingRegexesSection()
             Divider()
@@ -137,8 +137,8 @@ struct NSScrollableTextViewWrapper: NSViewRepresentable {
     }
 }
 
-struct EventRegexesSection: View {
-    @Default(.customEventRegexes) var customEventRegexes
+struct FilterEventRegexesSection: View {
+    @Default(.filterEventRegexes) var filterEventRegexes
 
     @State private var showingEditRegexModal = false
     @State private var selectedRegex = ""
@@ -151,7 +151,7 @@ struct EventRegexesSection: View {
                 Button("preferences_advanced_regex_add_button".loco()) { openEditRegexModal("") }
             }
             List {
-                ForEach(customEventRegexes, id: \.self) { regex in
+                ForEach(filterEventRegexes, id: \.self) { regex in
                     HStack {
                         Text(regex)
                         Spacer()
@@ -173,14 +173,14 @@ struct EventRegexesSection: View {
     }
 
     func addRegex(_ regex: String) {
-        if !customEventRegexes.contains(regex) {
-            customEventRegexes.append(regex)
+        if !filterEventRegexes.contains(regex) {
+            filterEventRegexes.append(regex)
         }
     }
 
     func removeRegex(_ regex: String) {
-        if let index = customEventRegexes.firstIndex(of: regex) {
-            customEventRegexes.remove(at: index)
+        if let index = filterEventRegexes.firstIndex(of: regex) {
+            filterEventRegexes.remove(at: index)
         }
     }
 }

--- a/MeetingBar/Views/Preferences/AdvancedTab.swift
+++ b/MeetingBar/Views/Preferences/AdvancedTab.swift
@@ -137,13 +137,12 @@ struct NSScrollableTextViewWrapper: NSViewRepresentable {
     }
 }
 
-
 struct EventRegexesSection: View {
     @Default(.customEventRegexes) var customEventRegexes
-    
+
     @State private var showingEditRegexModal = false
     @State private var selectedRegex = ""
-    
+
     var body: some View {
         Section {
             HStack {
@@ -166,7 +165,7 @@ struct EventRegexesSection: View {
             }
         }.padding(.leading, 19)
     }
-    
+
     func openEditRegexModal(_ regex: String) {
         selectedRegex = regex
         removeRegex(regex)

--- a/MeetingBar/Views/Preferences/AdvancedTab.swift
+++ b/MeetingBar/Views/Preferences/AdvancedTab.swift
@@ -15,7 +15,9 @@ struct AdvancedTab: View {
         VStack(alignment: .leading) {
             ScriptSection()
             Divider()
-            RegexesSection()
+            EventRegexesSection()
+            Divider()
+            MeetingRegexesSection()
             Divider()
             HStack {
                 Spacer()
@@ -135,7 +137,56 @@ struct NSScrollableTextViewWrapper: NSViewRepresentable {
     }
 }
 
-struct RegexesSection: View {
+
+struct EventRegexesSection: View {
+    @Default(.customEventRegexes) var customEventRegexes
+    
+    @State private var showingEditRegexModal = false
+    @State private var selectedRegex = ""
+    
+    var body: some View {
+        Section {
+            HStack {
+                Text("preferences_advanced_event_regex_title".loco())
+                Spacer()
+                Button("preferences_advanced_regex_add_button".loco()) { openEditRegexModal("") }
+            }
+            List {
+                ForEach(customEventRegexes, id: \.self) { regex in
+                    HStack {
+                        Text(regex)
+                        Spacer()
+                        Button("preferences_advanced_regex_edit_button".loco()) { openEditRegexModal(regex) }
+                        Button("preferences_advanced_regex_delete_button".loco()) { removeRegex(regex) }
+                    }
+                }
+            }
+            .sheet(isPresented: $showingEditRegexModal) {
+                EditRegexModal(regex: selectedRegex, function: addRegex)
+            }
+        }.padding(.leading, 19)
+    }
+    
+    func openEditRegexModal(_ regex: String) {
+        selectedRegex = regex
+        removeRegex(regex)
+//        showingEditRegexModal.toggle()
+    }
+
+    func addRegex(_ regex: String) {
+        if !customEventRegexes.contains(regex) {
+            customEventRegexes.append(regex)
+        }
+    }
+
+    func removeRegex(_ regex: String) {
+        if let index = customEventRegexes.firstIndex(of: regex) {
+            customEventRegexes.remove(at: index)
+        }
+    }
+}
+
+struct MeetingRegexesSection: View {
     @Default(.customRegexes) var customRegexes
 
     @State private var showingEditRegexModal = false

--- a/MeetingBar/Views/Preferences/AdvancedTab.swift
+++ b/MeetingBar/Views/Preferences/AdvancedTab.swift
@@ -170,7 +170,7 @@ struct EventRegexesSection: View {
     func openEditRegexModal(_ regex: String) {
         selectedRegex = regex
         removeRegex(regex)
-//        showingEditRegexModal.toggle()
+        showingEditRegexModal.toggle()
     }
 
     func addRegex(_ regex: String) {


### PR DESCRIPTION
### Status
**READY**

### Description
Closes ticket #355. It adds a new advanced preference to enter a list of regex conditions. Any event title that matches that regex will be filtered out


## Checklist
- [X] Localized
- [x] Added to changelog:
  - [x] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce

1. Open `Preferences`
2. Go to `Advanced` tab
3. Enter a regex condition in the first regex list
4. See how the event that matches the regex get filtered out
