### PR TITLE
Fix update menu if event changes

### DIFF
--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -19,7 +19,7 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
     var statusItem: NSStatusItem!
     var statusItemMenu: NSMenu!
     var menuIsOpen = false
-    var currentStatusBarEvent: EKEvent? = nil
+    var currentStatusBarEvent: EKEvent?
 
     var eventStore: EKEventStore!
     var calendars: [EKCalendar] = []

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -167,7 +167,7 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
             }
 
             if currentStatusBarEvent?.eventIdentifier != nextEvent?.eventIdentifier {
-                if nextEvent == nil || (nextEvent!).startDate   .timeIntervalSinceNow <= 0 {
+                if nextEvent == nil || (nextEvent!).startDate.timeIntervalSinceNow <= 0 {
                     currentStatusBarEvent = nextEvent
                     updateMenu()
                 }

--- a/MeetingBar/StatusBarItemControler.swift
+++ b/MeetingBar/StatusBarItemControler.swift
@@ -19,6 +19,7 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
     var statusItem: NSStatusItem!
     var statusItemMenu: NSMenu!
     var menuIsOpen = false
+    var currentStatusBarEvent: EKEvent? = nil
 
     var eventStore: EKEventStore!
     var calendars: [EKCalendar] = []
@@ -162,6 +163,13 @@ class StatusBarItemControler: NSObject, NSMenuDelegate {
                     button.image = NSImage(named: Defaults[.eventTitleIconFormat].rawValue)!
                 default:
                     button.image = NSImage(named: "iconCalendar")
+                }
+            }
+
+            if currentStatusBarEvent?.eventIdentifier != nextEvent?.eventIdentifier {
+                if nextEvent == nil || (nextEvent!).startDate   .timeIntervalSinceNow <= 0 {
+                    currentStatusBarEvent = nextEvent
+                    updateMenu()
                 }
             }
 


### PR DESCRIPTION
### Status
**READY**

### Description
Added a check to auto refresh the menu in case the toolbar event changes over and becomes active (to remove the sometimes weird long delay). This should fix #351 


## Checklist
- [X] Localized
- [X] Added to changelog:
  - [X] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [X] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

No changelog required as this should be the expected behaviour anyways I assume?

### Steps to Test or Reproduce
Wait for an event to become active and check the menu that the active indicator changes right away as well.
