### PR TITLE
changes regex for around links

### DIFF
--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -58,7 +58,7 @@ struct LinksRegex {
     let youtube = try! NSRegularExpression(pattern: #"https?://((www|m)\.)?(youtube\.com|youtu\.be)/[^\s]*"#)
     let vonageMeetings = try! NSRegularExpression(pattern: #"https?://meetings\.vonage\.com/[0-9]{9}"#)
     let meetStream = try! NSRegularExpression(pattern: #"https?://stream\.meet\.google\.com/stream/[a-z0-9-]+"#)
-    let around = try! NSRegularExpression(pattern: #"https?://meet\.around\.co/[^\s]*"#)
+    let around = try! NSRegularExpression(pattern: #"https?://(meet.)?around\.co/[^\s]*"#)
     let jam = try! NSRegularExpression(pattern: #"https?://jam\.systems/[^\s]*"#)
     let discord = try! NSRegularExpression(pattern: #"(http|https|discord)://(www\.)?(canary\.)?discord(app)?\.([a-zA-Z]{2,})(.+)?"#)
     let blackboard_collab = try! NSRegularExpression(pattern: #"https?://us\.bbcollab\.com/[^\s]*"#)

--- a/MeetingBarTests/HelpersTests.swift
+++ b/MeetingBarTests/HelpersTests.swift
@@ -15,6 +15,7 @@ let meetings = [
     MeetingLink(service: .zoom, url: URL(string: "https://zoom.us/j/5551112222")!),
     MeetingLink(service: .zoom_native, url: URL(string: "zoommtg://zoom.us/join?confno=123456789&pwd=xxxx&zc=0&browser=chrome&uname=Betty")!),
     MeetingLink(service: .around, url: URL(string: "https://meet.around.co/r/kyafvk1b")!),
+    MeetingLink(service: .around, url: URL(string: "https://around.co/r/kyafvk1b")!),
     MeetingLink(service: .blackboard_collab, url: URL(string: "https://us.bbcollab.com/guest/C2419D0F68382D351B97376D6B47ABA2")!),
     MeetingLink(service: .blackboard_collab, url: URL(string: "https://us.bbcollab.com/invite/EFC53F2790E6E50FFCC2AFBC16CC69EE")!),
     MeetingLink(service: .coscreen, url: URL(string: "https://join.coscreen.co/Eng-Leads/95RyHqtzn7EoQjQ19ju3")!),


### PR DESCRIPTION
### Status
Ready

### Description
Around can have meeting links with https://meet.around.co/... and https://around.co/... 
i've changed the regex and added test for the short url

## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
