### PR TITLE
fix(swiftformat): disable rules to avoid timeouts

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,12 @@ jobs:
       - name: Install SwiftFormat
         run: brew install swiftformat
       - name: Run SwiftFormat
-        run: swiftformat --lint .
+        run: swiftformat --lint --disable redundantClosure,trailingClosures,indent --verbose .
   Tests:
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v1
-    - name: Install xcbeautify
-      run: brew install xcbeautify
-    - name: Run unit tests
-      run: xcodebuild -scheme MeetingBar test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcbeautify
+      - uses: actions/checkout@v1
+      - name: Install xcbeautify
+        run: brew install xcbeautify
+      - name: Run unit tests
+        run: xcodebuild -scheme MeetingBar test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO | xcbeautify


### PR DESCRIPTION
### Status
**READY**

### Description
- swiftformat in version 0.49.6 currently fails to run the rules redudantClosure, trailingClosures and indent on the AppDelegate.swift file because of a timeout
- the modified command disables these rules and let swiftformat run without timeouts

see https://github.com/nicklockwood/SwiftFormat/issues/1153


## Checklist
- [-] Localized
- [-] Added to changelog:
  - [-] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [-] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce

Run the current pipelines- it fails for swiftformat