### PR TITLE
fix(statusbar): make text visible for non focused screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 > unreleased
 
 - Added integration with Pop, Livestorm, Chorus & Gong
+- Fix readability of the statusbar text in multi-screen setups (#354)
 
 ## Version 3.10.0
 

--- a/MeetingBar/StatusBarItemController.swift
+++ b/MeetingBar/StatusBarItemController.swift
@@ -202,10 +202,9 @@ class StatusBarItemController: NSObject, NSMenuDelegate {
 
                     var styles = [NSAttributedString.Key: Any]()
                     styles[NSAttributedString.Key.font] = NSFont.systemFont(ofSize: 13)
+                    styles[NSAttributedString.Key.foregroundColor] = NSColor.white
 
-                    if eventStatus == .pending, Defaults[.showPendingEvents] == PendingEventsAppereance.show_inactive {
-                        styles[NSAttributedString.Key.foregroundColor] = NSColor.lightGray
-                    } else if eventStatus == .pending, Defaults[.showPendingEvents] == PendingEventsAppereance.show_underlined {
+                    if eventStatus == .pending, Defaults[.showPendingEvents] == PendingEventsAppereance.show_underlined {
                         styles[NSAttributedString.Key.underlineStyle] = NSUnderlineStyle.single.rawValue | NSUnderlineStyle.patternDot.rawValue | NSUnderlineStyle.byWord.rawValue
                     }
 

--- a/MeetingBar/Views/Changelog/Changelog.swift
+++ b/MeetingBar/Views/Changelog/Changelog.swift
@@ -96,6 +96,7 @@ struct ChangelogView: View {
                 if compareVersions("3.11.0", lastRevisedVersionInChangelog) {
                     Section(header: Text("Version 3.11.0")) {
                         Text("• Added integration with Pop, Livestorm, Chorus & Gong")
+                        Text("• Fix readability of the statusbar text in multi-screen setups (#354)")
                     }
                 }
 


### PR DESCRIPTION
### Status
**READY**

### Description

- previously the text of the statusbar item was only readable on focused screens
- by setting the text to white (instead of lightgray) the text is also visible on non focused screens now

![image](https://user-images.githubusercontent.com/3872101/161444088-6b527ec2-0a19-4ae9-9ab1-f305fd07ff00.png)


## Checklist
- [-] Localized
- [x] Added to changelog:
  - [x] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce

- Start meetingbar with two monitors
- look at the non focused status bar 
- the meetingbar text should be visible