### PR TITLE
Fix crash on startup due to events with nil email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Fix readability of the statusbar text in multi-screen setups (#354)
 - Detect hidden menubar icon (#429)
 - Added feature to snooze the notification
+- Fix crash due to meeting attendees without an email address (#460)
 
 ## Version 3.10.0
 

--- a/MeetingBar/EventStores/EKEventStore.swift
+++ b/MeetingBar/EventStores/EKEventStore.swift
@@ -107,6 +107,7 @@ extension EKEventStore: EventStore {
                     default:
                         attendeeStatus = .unknown
                     }
+
                     let optional = rawAttendee.participantRole == .optional
                     let email = rawAttendee.safeURL?.absoluteString
                     let attendee = MBEventAttendee(email: email, name: rawAttendee.name, status: attendeeStatus, optional: optional, isCurrentUser: rawAttendee.isCurrentUser)

--- a/MeetingBar/EventStores/EKEventStore.swift
+++ b/MeetingBar/EventStores/EKEventStore.swift
@@ -8,6 +8,13 @@
 import EventKit
 import PromiseKit
 
+// Ref: https://stackoverflow.com/a/66074963
+extension EKParticipant {
+    public var safeURL: URL? {
+        perform(#selector(getter: EKParticipant.url))?.takeUnretainedValue() as? NSURL? as? URL
+    }
+}
+
 extension EKEventStore: EventStore {
     static let shared = initEKEventStore()
 
@@ -100,9 +107,8 @@ extension EKEventStore: EventStore {
                     default:
                         attendeeStatus = .unknown
                     }
-
                     let optional = rawAttendee.participantRole == .optional
-                    let email = (rawAttendee.url as NSURL).resourceSpecifier
+                    let email = rawAttendee.safeURL?.absoluteString
                     let attendee = MBEventAttendee(email: email, name: rawAttendee.name, status: attendeeStatus, optional: optional, isCurrentUser: rawAttendee.isCurrentUser)
 
                     attendees.append(attendee)

--- a/MeetingBar/EventStores/EKEventStore.swift
+++ b/MeetingBar/EventStores/EKEventStore.swift
@@ -10,7 +10,7 @@ import PromiseKit
 
 // Ref: https://stackoverflow.com/a/66074963
 extension EKParticipant {
-    public var safeURL: URL? {
+    var safeURL: URL? {
         perform(#selector(getter: EKParticipant.url))?.takeUnretainedValue() as? NSURL? as? URL
     }
 }

--- a/MeetingBar/Views/Changelog/Changelog.swift
+++ b/MeetingBar/Views/Changelog/Changelog.swift
@@ -102,6 +102,7 @@ struct ChangelogView: View {
                         Text("• Advanced feature to join events automatically")
                         Text("• Integration with Pop, Livestorm, Chorus & Gong")
                         Text("• Fixed readability of the statusbar text in multi-screen setups")
+                        Text("• Fixed crash due to null emails for event attendees")
                     }
                 }
 


### PR DESCRIPTION
### Status
**READY**

### Description
Small fix for #460:  Created `EKParticipant.safeURL` as `EKParticipant.url` is not an optional.
(Note: I'm brand new to Swift, so am quite open to a better way to solve this!)


## Checklist
- [x] _(N/A)_ Localized
- [x] Added to changelog:
  - [x] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
- Create a meeting request (via Outlook/O365) with an attendee that has an X500 email address.
- Review the meeting in Calendar; note yellow exclamation mark next to the attendee with an invalid address 
- Launch MeetingBar
