### PR TITLE
Added new preference for controlling bookmark collapse

### DIFF
--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -315,7 +315,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             preferencesWindow.close()
         }
         preferencesWindow = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 700, height: 610),
+            contentRect: NSRect(x: 0, y: 0, width: 700, height: 650),
             styleMask: [.closable, .titled, .resizable],
             backing: .buffered,
             defer: false

--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -113,7 +113,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         }
 
         // Settings change observers
-        appearanceSettingsObserver = Defaults.observe(keys: .statusbarEventTitleLength, .eventTimeFormat, .eventTitleIconFormat, .showEventMaxTimeUntilEventThreshold, .showEventMaxTimeUntilEventEnabled, .showEventDetails, .shortenEventTitle, .menuEventTitleLength, .showEventEndTime, .showMeetingServiceIcon, .timeFormat, .bookmarks, .eventTitleFormat, options: []) {
+        appearanceSettingsObserver = Defaults.observe(keys: .statusbarEventTitleLength, .eventTimeFormat, .eventTitleIconFormat, .showEventMaxTimeUntilEventThreshold, .showEventMaxTimeUntilEventEnabled, .showEventDetails, .shortenEventTitle, .menuEventTitleLength, .bookmarksCollapseAfter, .showEventEndTime, .showMeetingServiceIcon, .timeFormat, .bookmarks, .eventTitleFormat, options: []) {
             self.statusBarItem.updateTitle()
             self.statusBarItem.updateMenu()
         }

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -65,6 +65,7 @@ extension Defaults.Keys {
 
     // Bookmarks
     static let bookmarks = Key<[Bookmark]>("bookmarks", default: [])
+    static let bookmarksCollapseAfter = Key<Int>("bookmarksCollapseAfter", default: 3)
 
     // all browser configurations
     static let browsers = Key<[Browser]>("browsers", default: [])

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -108,7 +108,8 @@
 "preferences_appearance_menu_shorten_event_title_toggle" = "Shorten event title to";
 "preferences_appearance_menu_shorten_event_title_stepper" = "%d characters";
 "preferences_appearance_menu_collapse_bookmarks_after_title" = "Collapse bookmarks menu item after";
-"preferences_appearance_menu_collapse_bookmarks_after_stepper" = "%d entries";
+"preferences_appearance_menu_collapse_bookmarks_after_stepper_plural" = "%d entries";
+"preferences_appearance_menu_collapse_bookmarks_after_stepper_singular" = "%d entry";
 "preferences_appearance_menu_time_format_title" = "Time format:";
 "preferences_appearance_menu_time_format_12_hour_value" = "12-hour (AM/PM)";
 "preferences_appearance_menu_time_format_24_hour_value" = "24-hour";

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -107,6 +107,8 @@
 "preferences_appearance_menu_title" = "Menu";
 "preferences_appearance_menu_shorten_event_title_toggle" = "Shorten event title to";
 "preferences_appearance_menu_shorten_event_title_stepper" = "%d characters";
+"preferences_appearance_menu_collapse_bookmarks_after_title" = "Collapse bookmarks menu item after";
+"preferences_appearance_menu_collapse_bookmarks_after_stepper" = "%d entries";
 "preferences_appearance_menu_time_format_title" = "Time format:";
 "preferences_appearance_menu_time_format_12_hour_value" = "12-hour (AM/PM)";
 "preferences_appearance_menu_time_format_24_hour_value" = "24-hour";

--- a/MeetingBar/StatusBarItemController.swift
+++ b/MeetingBar/StatusBarItemController.swift
@@ -709,7 +709,7 @@ class StatusBarItemController: NSObject, NSMenuDelegate {
 
         var bookmarksMenu: NSMenu
 
-        if Defaults[.bookmarks].count > 3 {
+        if Defaults[.bookmarks].count > Defaults[.bookmarksCollapseAfter] {
             bookmarksMenu = NSMenu(title: "status_bar_section_bookmarks_menu".loco())
             bookmarksItem.submenu = bookmarksMenu
         } else {

--- a/MeetingBar/Views/Preferences/AppearanceTab.swift
+++ b/MeetingBar/Views/Preferences/AppearanceTab.swift
@@ -132,7 +132,9 @@ struct MenuSection: View {
             }
             HStack {
                 Text("preferences_appearance_menu_collapse_bookmarks_after_title".loco())
-                Stepper("preferences_appearance_menu_collapse_bookmarks_after_stepper".loco(bookmarksCollapseAfter), value: $bookmarksCollapseAfter, in: 0 ... 100, step: 1)
+                Stepper(
+                    "preferences_appearance_menu_collapse_bookmarks_after_stepper_\(bookmarksCollapseAfter != 1 ? "plural" : "singular")".loco(bookmarksCollapseAfter),
+                    value: $bookmarksCollapseAfter, in: 0 ... 100, step: 1)
             }
         }.padding(.horizontal, 10)
     }

--- a/MeetingBar/Views/Preferences/AppearanceTab.swift
+++ b/MeetingBar/Views/Preferences/AppearanceTab.swift
@@ -30,7 +30,7 @@ struct StatusBarSection: View {
     @Default(.statusbarEventTitleLength) var statusbarEventTitleLength
     @Default(.showEventMaxTimeUntilEventThreshold) var showEventMaxTimeUntilEventThreshold
     @Default(.showEventMaxTimeUntilEventEnabled) var showEventMaxTimeUntilEventEnabled
-
+    
     var body: some View {
         Text("preferences_appearance_status_bar_title".loco()).font(.headline).bold()
         Section {
@@ -107,7 +107,8 @@ struct MenuSection: View {
     @Default(.showEventEndTime) var showEventEndTime
     @Default(.showEventDetails) var showEventDetails
     @Default(.showMeetingServiceIcon) var showMeetingServiceIcon
-
+    @Default(.bookmarksCollapseAfter) var bookmarksCollapseAfter
+    
     var body: some View {
         Text("preferences_appearance_menu_title".loco()).font(.headline).bold()
         Section {
@@ -128,6 +129,10 @@ struct MenuSection: View {
                     Toggle("preferences_appearance_menu_show_event_icon_value".loco(), isOn: $showMeetingServiceIcon)
                     Toggle("preferences_appearance_menu_show_event_details_value".loco(), isOn: $showEventDetails)
                 }
+            }
+            HStack {
+                Text("preferences_appearance_menu_collapse_bookmarks_after_title".loco())
+                Stepper("preferences_appearance_menu_collapse_bookmarks_after_stepper".loco(bookmarksCollapseAfter), value: $bookmarksCollapseAfter, in: 0 ... 100, step: 1)
             }
         }.padding(.horizontal, 10)
     }

--- a/MeetingBar/Views/Preferences/AppearanceTab.swift
+++ b/MeetingBar/Views/Preferences/AppearanceTab.swift
@@ -132,9 +132,7 @@ struct MenuSection: View {
             }
             HStack {
                 Text("preferences_appearance_menu_collapse_bookmarks_after_title".loco())
-                Stepper(
-                    "preferences_appearance_menu_collapse_bookmarks_after_stepper_\(bookmarksCollapseAfter != 1 ? "plural" : "singular")".loco(bookmarksCollapseAfter),
-                    value: $bookmarksCollapseAfter, in: 0 ... 100, step: 1)
+                Stepper("preferences_appearance_menu_collapse_bookmarks_after_stepper_\(bookmarksCollapseAfter != 1 ? "plural" : "singular")".loco(bookmarksCollapseAfter), value: $bookmarksCollapseAfter, in: 0 ... 100, step: 1)
             }
         }.padding(.horizontal, 10)
     }


### PR DESCRIPTION
### Status
**IN DEVELOPMENT**

### Description
Added a single setting for controlling the threshold under which the Bookmarks menu collapses to a submenu. This was previously always 3 but can now be configured by the user (default remains 3). This has been a personal gripe of mine for a while as I would rather just have quick access to all of my bookmarks rather than needing a submenu. 


## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)
