### PR TITLE
Add preference to show events for tomorrow in the status bar

### DIFF
--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -22,6 +22,7 @@ extension Defaults.Keys {
     static let onboardingCompleted = Key<Bool>("onboardingCompleted", default: false)
 
     static let showEventsForPeriod = Key<ShowEventsForPeriod>("showEventsForPeriod", default: .today)
+    static let includeTomorrowInStatusBar = Key<Bool>("includeTomorrowInStatusBar", default: false)
     static let joinEventNotification = Key<Bool>("joinEventNotification", default: true)
     static let joinEventNotificationTime = Key<JoinEventNotificationTime>("joinEventNotificationTime", default: .atStart)
 

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -73,6 +73,7 @@
 "preferences_appearance_events_show_events_for_title" = "Show events for";
 "preferences_appearance_events_show_events_for_today_value" = "today";
 "preferences_appearance_events_show_events_for_today_tomorrow_value" = "today and tomorrow";
+"preferences_appearance_status_bar_tomorrow_title" = "Include tomorrow in status bar";
 "preferences_appearance_events_non_all_day_title" = "Other events:";
 "preferences_appearance_events_value_inactive_without_meeting_link" = "show those without meeting links as inactive";
 "preferences_appearance_events_value_hide_without_meeting_link" = "hide all without meeting links";

--- a/MeetingBar/StatusBarItemController.swift
+++ b/MeetingBar/StatusBarItemController.swift
@@ -129,7 +129,7 @@ class StatusBarItemController: NSObject, NSMenuDelegate {
                 guard let nextEvent = nextEvent else {
                     return .none
                 }
-                if Calendar.current.isDateInTomorrow(nextEvent.startDate) {
+                if Calendar.current.isDateInTomorrow(nextEvent.startDate) && !Defaults[.includeTomorrowInStatusBar] {
                     return .none
                 }
 

--- a/MeetingBar/StatusBarItemController.swift
+++ b/MeetingBar/StatusBarItemController.swift
@@ -129,7 +129,7 @@ class StatusBarItemController: NSObject, NSMenuDelegate {
                 guard let nextEvent = nextEvent else {
                     return .none
                 }
-                if Calendar.current.isDateInTomorrow(nextEvent.startDate) && !Defaults[.includeTomorrowInStatusBar] {
+                if Calendar.current.isDateInTomorrow(nextEvent.startDate), !Defaults[.includeTomorrowInStatusBar] {
                     return .none
                 }
 

--- a/MeetingBar/Views/Preferences/AppearanceTab.swift
+++ b/MeetingBar/Views/Preferences/AppearanceTab.swift
@@ -141,6 +141,7 @@ struct EventsSection: View {
     @Default(.nonAllDayEvents) var nonAllDayEvents
     @Default(.showPendingEvents) var showPendingEvents
     @Default(.showEventsForPeriod) var showEventsForPeriod
+    @Default(.includeTomorrowInStatusBar) var includeTomorrowInStatusBar
 
     var body: some View {
         Text("preferences_appearance_events_title".loco()).font(.headline).bold()
@@ -150,6 +151,9 @@ struct EventsSection: View {
                     Text("preferences_appearance_events_show_events_for_today_value".loco()).tag(ShowEventsForPeriod.today)
                     Text("preferences_appearance_events_show_events_for_today_tomorrow_value".loco()).tag(ShowEventsForPeriod.today_n_tomorrow)
                 }.frame(width: 300)
+                if Defaults[.showEventsForPeriod] == .today_n_tomorrow {
+                    Toggle("preferences_appearance_status_bar_tomorrow_title".loco(), isOn: $includeTomorrowInStatusBar)
+                }
             }
 
             HStack {


### PR DESCRIPTION
### Status
READY

### Description
I was facing a problem due to the fact that I work with an organization on the other side of the world and my meetings usually start at midnight. This makes those events part of "tomorrow" which will never show up in the status bar so MeetingBar isn't useful prior to my first meeting. I can show events for "today and tomorrow" and set a range but it will not display a meeting that happens in 30 minutes if that meetings occurs past midnight.

#### Solution
My solution is to add a new preference that conditionally appears when events are shown for tomorrow. In this demo you can see:

1. I cannot see my meeting within the next hour
2. I show events for "today and tomorrow" and the meeting appears within the menu but not in status bar
3. I activate the new preference and now I can see my meeting coming up in the status bar

https://user-images.githubusercontent.com/734006/188869273-d031b778-0a0e-45a1-bb95-3a2ccb033173.mov

I realize this feels a bit awkward being outside the "status bar" area of preferences but

1. the "events" section does filter which events show in the status bar
2. this preference is only valid when events are shown for both today and tomorrow
3. It should not affecting existing behavior

I am not a Swift/MacOS developer so I apologize in advance for any rookie mistakes. I'm happy to update this with a different solution if this one isn't acceptable.

## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
1. Create an event at midnight/00:00/12AM
2. Set system time to 30 minutes prior
3. Observe that the event is not visible in the status bar
