### PR TITLE
Fix notification warning from overlapping with notification settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 For next releases info look here: https://github.com/leits/MeetingBar/releases
 
+## Version 4.0.7
+- Fix notification warning from overlapping with notification settings
+
 ## Version 4.0.0
 > (released)
 

--- a/MeetingBar/Views/Changelog/Changelog.swift
+++ b/MeetingBar/Views/Changelog/Changelog.swift
@@ -105,7 +105,7 @@ struct ChangelogView: View {
                         Text("• Fixed crash due to null emails for event attendees")
                     }
                 }
-                
+
                 if compareVersions("4.0.7", lastRevisedVersionInChangelog) {
                     Section(header: Text("Version 4.0.7")) {
                         Text("Fix notification warning from overlapping with notification settings")

--- a/MeetingBar/Views/Changelog/Changelog.swift
+++ b/MeetingBar/Views/Changelog/Changelog.swift
@@ -105,7 +105,12 @@ struct ChangelogView: View {
                         Text("• Fixed crash due to null emails for event attendees")
                     }
                 }
-
+                
+                if compareVersions("4.0.7", lastRevisedVersionInChangelog) {
+                    Section(header: Text("Version 4.0.7")) {
+                        Text("Fix notification warning from overlapping with notification settings")
+                    }
+                }
             }.listStyle(SidebarListStyle())
             Button("general_close".loco(), action: close)
         }.padding()

--- a/MeetingBar/Views/Shared.swift
+++ b/MeetingBar/Views/Shared.swift
@@ -52,11 +52,11 @@ struct JoinEventNotificationPicker: View {
                         Text("general_five_minute_before".loco()).tag(JoinEventNotificationTime.fiveMinuteBefore)
                     }.frame(width: 220, alignment: .leading).labelsHidden().disabled(!joinEventNotification)
                 }
-                
+
                 if noAlertStyle, !disabled, joinEventNotification {
                     Text("shared_send_notification_no_alert_style_tip".loco()).foregroundColor(.gray).font(.system(size: 12))
                 }
-                
+
                 if disabled, joinEventNotification {
                     Text("shared_send_notification_disabled_tip".loco()).foregroundColor(.gray).font(.system(size: 12))
                 }

--- a/MeetingBar/Views/Shared.swift
+++ b/MeetingBar/Views/Shared.swift
@@ -42,22 +42,24 @@ struct JoinEventNotificationPicker: View {
 
     var body: some View {
         ZStack {
-            HStack {
-                Toggle("shared_send_notification_toggle".loco(), isOn: $joinEventNotification)
-                Picker("", selection: $joinEventNotificationTime) {
-                    Text("general_when_event_starts".loco()).tag(JoinEventNotificationTime.atStart)
-                    Text("general_one_minute_before".loco()).tag(JoinEventNotificationTime.minuteBefore)
-                    Text("general_three_minute_before".loco()).tag(JoinEventNotificationTime.threeMinuteBefore)
-                    Text("general_five_minute_before".loco()).tag(JoinEventNotificationTime.fiveMinuteBefore)
-                }.frame(width: 220, alignment: .leading).labelsHidden().disabled(!joinEventNotification)
-            }
-
-            if noAlertStyle, !disabled, joinEventNotification {
-                Text("shared_send_notification_no_alert_style_tip".loco()).foregroundColor(.gray).font(.system(size: 12))
-            }
-
-            if disabled, joinEventNotification {
-                Text("shared_send_notification_disabled_tip".loco()).foregroundColor(.gray).font(.system(size: 12))
+            VStack {
+                HStack {
+                    Toggle("shared_send_notification_toggle".loco(), isOn: $joinEventNotification)
+                    Picker("", selection: $joinEventNotificationTime) {
+                        Text("general_when_event_starts".loco()).tag(JoinEventNotificationTime.atStart)
+                        Text("general_one_minute_before".loco()).tag(JoinEventNotificationTime.minuteBefore)
+                        Text("general_three_minute_before".loco()).tag(JoinEventNotificationTime.threeMinuteBefore)
+                        Text("general_five_minute_before".loco()).tag(JoinEventNotificationTime.fiveMinuteBefore)
+                    }.frame(width: 220, alignment: .leading).labelsHidden().disabled(!joinEventNotification)
+                }
+                
+                if noAlertStyle, !disabled, joinEventNotification {
+                    Text("shared_send_notification_no_alert_style_tip".loco()).foregroundColor(.gray).font(.system(size: 12))
+                }
+                
+                if disabled, joinEventNotification {
+                    Text("shared_send_notification_disabled_tip".loco()).foregroundColor(.gray).font(.system(size: 12))
+                }
             }
         }
     }


### PR DESCRIPTION
close #505 
### Status
**READY**

### Description
The warning view was overlapping the actual settings. This was a simple fix by embedding the views inside a VStack.

# OLD
<img width="812" alt="CleanShot 2022-09-23 at 09 30 39@2x" src="https://user-images.githubusercontent.com/47460844/191910620-e7ba3db8-5029-4cb7-bf14-0f3e5471fa00.png">

# FIXED
<img width="812" alt="CleanShot 2022-09-23 at 10 13 19@2x" src="https://user-images.githubusercontent.com/47460844/191910629-0750f2e0-2789-445c-9e62-12dfd1b3dec0.png">


## Checklist
- [x] Localized
- [x] Added to changelog:
  - [x] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)