### PR TITLE
Fix calendar email for meeting link

### DIFF
--- a/MeetingBar/EventStores/EKEventStore.swift
+++ b/MeetingBar/EventStores/EKEventStore.swift
@@ -45,14 +45,14 @@ extension EKEventStore: EventStore {
     func fetchAllCalendars() -> Promise<[MBCalendar]> {
         Promise { seal in
             var allCalendars: [MBCalendar] = []
-            
+
             for ekcalendar in EKEventStore.shared.calendars(for: .event) {
                 let dateFrom = Calendar.current.startOfDay(for: Date())
                 let dateTo = Calendar.current.date(byAdding: .day, value: 1, to: dateFrom)!
-                
+
                 let predicate = predicateForEvents(withStart: dateFrom, end: dateTo, calendars: [ekcalendar])
                 let email = EKEventStore.shared.events(matching: predicate).first?.attendees?.first { $0.isCurrentUser }?.safeNSURL?.resourceSpecifier
-                
+
                 let calendar = MBCalendar(
                     title: ekcalendar.title,
                     ID: ekcalendar.calendarIdentifier,


### PR DESCRIPTION
### Status
**READY**

### Description
After updating Macbook Pro M1 to macOS 13.0 (22A380), tapping on calendar event was opening the meeting url in the browser but email account was not associated with the link, thus Google Meet was not opening on right email. I have tried uninstalling/reinstalling from appstore, brew and building from source, but link was not proper. After debugging code, I noticed that the function `getGmailAccount` was returning nil, (there was already a note there that this is bit hacky).

After looking further in the code, I saw that `email` was empty in `MBCalendar` but email was present in `attendee`, so I have modified `fetchAllCalendars` function a little bit to get email of the current user from the list of attendees. I have tested this changed and it seems to be working perfectly, i.e. email is being properly appending to the url and. Google Meet link is being opened with the right email of which the event is associated to.


## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
- Tested on macOS Ventura 13.0 (22A380)
- Sync local calendar with Google Meet link
- Tapping on event should open Google Meet link with the correct email associated for redirection to that logged in account
