### PR TITLE
Fix typo in `shared_automatic_event_join_toggle` string

### DIFF
--- a/MeetingBar/Resources /Localization /cs.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /cs.lproj/Localizable.strings
@@ -68,7 +68,7 @@
 "access_screen_access_denied_checkbox_title" = "a zaškrtněte políčko u položky MeetingBar.";
 "access_screen_access_screen_access_denied_go_to_title" = "Přejděte na";
 "access_screen_access_denied_system_preferences_button" = "Předvolby systému";
-"shared_automatic_event_join_toggle" = "Automatic join next event meeting";
+"shared_automatic_event_join_toggle" = "Automatically join next event meeting";
 "shared_automatic_event_join_tip" = "This setting will automatically open your next meeting in your configured app or browser";
 
 // MARK: - Access screen

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -296,7 +296,7 @@
 "shared_send_notification_toggle" = "Send notification to join next event meeting";
 "shared_send_notification_no_alert_style_tip" = "⚠️ Your macOS notification settings for MeetingBar are not set to alert. Do so if you want persistent notifications.";
 "shared_send_notification_disabled_tip" = "⚠️ Your macOS notification settings for MeetingBar are off. Turn on notifications in the macOS system settings to keep track of meetings.";
-"shared_automatic_event_join_toggle" = "Automatic join next event meeting";
+"shared_automatic_event_join_toggle" = "Automatically join next event meeting";
 "shared_automatic_event_join_tip" = "This setting will automatically open your next meeting in your configured app or browser";
 
 // MARK: - Constants

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -300,7 +300,7 @@
 "general_five_minute_before" = "5分前";
 "shared_send_notification_no_alert_style_tip" = "⚠️ MeetingBar の macOS の通知設定は、通知パネルに設定されていません。持続的な通知を利用する場合は、通知パネルに設定してください。";
 "shared_send_notification_disabled_tip" = "⚠️ MeetingBar の macOS の通知設定が現在オフになっています。ミーティングを見逃さないために、 macOS のシステム設定で通知を有効にしてください。";
-"shared_automatic_event_join_toggle" = "Automatic join next event meeting";
+"shared_automatic_event_join_toggle" = "Automatically join next event meeting";
 "shared_automatic_event_join_tip" = "This setting will automatically open your next meeting in your configured app or browser";
 
 // MARK: - Constants

--- a/MeetingBar/Resources /Localization /nb-NO.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /nb-NO.lproj/Localizable.strings
@@ -45,7 +45,7 @@
 "access_screen_access_granted_title" = "Forespør tilgang til kalendere.";
 "access_screen_access_denied_relaunch_title" = "Så må du kjøre programmet manuelt for å fortsette oppsettet.";
 "access_screen_access_denied_checkbox_title" = "og velg avkryssningsboksen ved siden av MeetingBar.";
-"shared_automatic_event_join_toggle" = "Automatic join next event meeting";
+"shared_automatic_event_join_toggle" = "Automatically join next event meeting";
 "shared_automatic_event_join_tip" = "This setting will automatically open your next meeting in your configured app or browser";
 
 // MARK: - Access screen

--- a/MeetingBar/Resources /Localization /pl.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /pl.lproj/Localizable.strings
@@ -283,7 +283,7 @@
 "general_five_minute_before" = "5 minut przed";
 "shared_send_notification_no_alert_style_tip" = "⚠️ Twoje ustawienia powiadomień macOS dla MeetingBar nie są ustawione na alert. Zrób to, jeśli chcesz mieć trwałe powiadomienia.";
 "shared_send_notification_disabled_tip" = "⚠️ Twoje ustawienia powiadomień macOS dla MeetingBar są wyłączone. Włącz powiadomienia w ustawieniach systemowych macOS, aby śledzić spotkania.";
-"shared_automatic_event_join_toggle" = "Automatic join next event meeting";
+"shared_automatic_event_join_toggle" = "Automatically join next event meeting";
 "shared_automatic_event_join_tip" = "This setting will automatically open your next meeting in your configured app or browser";
 
 // MARK: - Constants

--- a/MeetingBar/Resources /Localization /tr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /tr.lproj/Localizable.strings
@@ -328,7 +328,7 @@
 "constants_meeting_service_skype4biz_selfhosted" = "Skype For Business (SH)";
 "store_patronage_purchase_cloud_service_permission_denied_message" = "Bulut servis bilgilerine erişim izni verilmedi";
 "notifications_event_start_three_minutes_body" = "Toplantı üç dakika içinde başlıyor";
-"shared_automatic_event_join_toggle" = "Automatic join next event meeting";
+"shared_automatic_event_join_toggle" = "Automatically join next event meeting";
 "shared_automatic_event_join_tip" = "This setting will automatically open your next meeting in your configured app or browser";
 
 // MARK: - Link open


### PR DESCRIPTION
Fixes a typo in this string (should read “automatically”), in EN and all other languages (in two commits). https://github.com/leits/MeetingBar/blob/9c66f5faa1ee7d18760d93519a941dde7fdc7283/MeetingBar/Resources%20/Localization%20/en.lproj/Localizable.strings#L299