### PR TITLE
fixed typos for Polish translation and added missing Polish translation

### DIFF
--- a/MeetingBar/Resources /Localization /pl.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /pl.lproj/Localizable.strings
@@ -96,7 +96,7 @@
 "preferences_appearance_status_bar_time_show_value" = "pokaż";
 "preferences_appearance_status_bar_time_show_under_title_value" = "pokaż pod tytułem";
 "preferences_appearance_status_bar_time_hide_value" = "ukryj";
-"preferences_appearance_status_bar_next_event_toggle" = "Pokaż tylko wydarzenie rozpoczynające się w ciągu";
+"preferences_appearance_status_bar_next_event_toggle" = "Pokaż tylko wydarzenia rozpoczynające się w ciągu";
 "preferences_appearance_status_bar_next_event_stepper" = "%d minut";
 "preferences_appearance_menu_title" = "Menu";
 "preferences_appearance_menu_shorten_event_title_toggle" = "Skróć tytuł wydarzenia do";
@@ -194,6 +194,7 @@
 "status_bar_section_join_next_meeting" = "Dołącz do następnego spotkania";
 "status_bar_section_join_current_meeting" = "Dołącz do bieżącego spotkania";
 "status_bar_section_join_from_clipboard" = "Otwórz spotkanie ze schowka";
+"status_bar_section_refresh_sources" = "Odśwież źródła";
 "status_bar_section_join_create_meeting" = "Utwórz spotkanie";
 "status_bar_section_bookmarks_title" = "Zakładki";
 "status_bar_section_bookmarks_menu" = "Menu zakładek";

--- a/MeetingBar/Views/Shared.swift
+++ b/MeetingBar/Views/Shared.swift
@@ -99,7 +99,7 @@ struct LaunchAtLoginANDPreferredLanguagePicker: View {
                         Text("Norks").tag(AppLanguage.norwegian)
                         Text("Čeština").tag(AppLanguage.czech)
                         Text("日本語").tag(AppLanguage.japanese)
-                        Text("Polskie").tag(AppLanguage.polish)
+                        Text("Polski").tag(AppLanguage.polish)
                         Text("עברית‎").tag(AppLanguage.hebrew)
                     }
                     Group {


### PR DESCRIPTION
### Status
**READY**

### Description
fixed typos for Polish translation and added missing Polish translation


## Checklist
- [x] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
Open preferences, switch to Polish language. Browse through the tabs. Next, click on the bar menu, go to "quick options" (szybkie działania), see last item in the menu.
