### PR TITLE
Add "Run Apple Script on keyboard shortcut" feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 For next releases info look here: <https://github.com/leits/MeetingBar/releases>
 
 ## Version 4.3.0
-* Added Advanced feature to run AppleScript on keyboard shortcut
+*   Added Advanced feature to run AppleScript on keyboard shortcut
 
 ## Version 4.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 For next releases info look here: <https://github.com/leits/MeetingBar/releases>
 
+## Version 4.3.0
+* Added Advanced feature to run AppleScript on keyboard shortcut
+
 ## Version 4.0.0
 
 > (released)

--- a/MeetingBar/ActionsOnEventStart.swift
+++ b/MeetingBar/ActionsOnEventStart.swift
@@ -99,7 +99,7 @@ class ActionsOnEventStart: NSObject {
                 // so that we can run the script again ->
                 // this is an edge case when the event was already notified for, but scheduled for a later time.
                 if matchedEvent == nil || matchedEvent?.lastModifiedDate != nextEvent.lastModifiedDate {
-                    runMeetingStartsScript(event: nextEvent, type: ScriptType.meetingStart)
+                    runAppleScript(event: nextEvent, type: ScriptType.meetingStart)
 
                     // update the executed events
                     if matchedEvent != nil {

--- a/MeetingBar/AppDelegate.swift
+++ b/MeetingBar/AppDelegate.swift
@@ -110,6 +110,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             Defaults[.hideMeetingTitle].toggle()
         }
 
+        KeyboardShortcuts.onKeyUp(for: .runAppleScriptShortcut) {
+            runAppleScriptForKeyboardShortcut(events: self.statusBarItem.events)
+        }
+
         // Settings change observers
         appearanceSettingsObserver = Defaults.observe(
             keys: .statusbarEventTitleLength, .eventTimeFormat,

--- a/MeetingBar/Constants.swift
+++ b/MeetingBar/Constants.swift
@@ -204,3 +204,26 @@ on meetingStart(eventId, title, allday, startDate, endDate, eventLocation, repea
    end tell
 end meetingStart
 """
+
+let keyboardShortcutScriptPlaceholder = """
+# the method to be called with the following parameters for the next meeting.
+#
+# 1. parameter - eventId (string) - unique identifier from apples eventkit implementation
+# 2. parameter - title (string) - the title of the event (event title can be null, although it makes no sense!)
+# 3. parameter - allday (bool) - true for allday events, false for non allday events
+# 4. parameter - startDate (date) - needs casting in apple script to output (e.g. startDate as text)
+# 5 .parameter - endDate (date) - needs casting in apple script to output (e.g. startDate as text)
+# 6. parameter - eventLocation (string) - if no location is set, the value will be "EMPTY"
+# 7. parameter - repeatingEvent (bool) - true if it is part of an repeating event, false for single event
+# 8. parameter - attendeeCount (int32) - number of attendees- 0 for events without attendees
+# 9. parameter - meetingUrl (string) - the url to the meeting found in notes, url or location - only one meeting url is supported - if no meeting url is set, the value will be "EMPTY"
+# 10. parameter - meetingService (string), e.g MS Teams or Zoom- if no meeting service is found, the meeting service value is "EMPTY"
+# 11. parameter - meetingNotes (string)- the complete notes of a meeting -  if no notes are set, value "EMPTY" will be used
+
+on keyboardShortcut(eventId, title, allday, startDate, endDate, eventLocation, repeatingEvent, attendeeCount, meetingUrl, meetingService, meetingNotes)
+   tell application "Finder"
+       activate
+       display dialog title buttons {"OK"} default button "OK"
+   end tell
+end meetingStart
+"""

--- a/MeetingBar/EventStores/Event.swift
+++ b/MeetingBar/EventStores/Event.swift
@@ -142,7 +142,7 @@ class MBEvent {
     func openMeeting() {
         if let meetingLink = meetingLink {
             if Defaults[.runJoinEventScript], Defaults[.joinEventScriptLocation] != nil {
-                if let url = Defaults[.joinEventScriptLocation]?.appendingPathComponent("joinEventScript.scpt") {
+                if let url = Defaults[.joinEventScriptLocation]?.appendingPathComponent(ScriptType.joinEventScript.filename) {
                     let task = try! NSUserAppleScriptTask(url: url)
                     task.execute { error in
                         if let error = error {

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -112,7 +112,6 @@ extension Defaults.Keys {
     static let runKeyboardShortcutScript = Key<Bool>("runKeyboardShortcutScript", default: false)
     static let keyboardShortcutScriptContent = Key<String>("keyboardShortcutScriptContent", default: keyboardShortcutScriptPlaceholder)
 
-
     static let customRegexes = Key<[String]>("customRegexes", default: [])
     static let filterEventRegexes = Key<[String]>("filterEventRegexes", default: [])
 }

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -108,6 +108,11 @@ extension Defaults.Keys {
     static let eventStartScript = Key<String>("eventStartScript", default: eventStartScriptPlaceholder)
     static let processedEventsForRunScriptOnEventStart = Key<[ProcessedEvent]>("processedEventsForRunScriptOnEventStart", default: [])
 
+    static let keyboardShortcutScriptLocation = Key<URL?>("keyboardShortcutScriptLocation", default: nil)
+    static let runKeyboardShortcutScript = Key<Bool>("runKeyboardShortcutScript", default: false)
+    static let keyboardShortcutScriptContent = Key<String>("keyboardShortcutScriptContent", default: "preferences_advanced_apple_script_placeholder".loco())
+
+
     static let customRegexes = Key<[String]>("customRegexes", default: [])
     static let filterEventRegexes = Key<[String]>("filterEventRegexes", default: [])
 }

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -110,7 +110,7 @@ extension Defaults.Keys {
 
     static let keyboardShortcutScriptLocation = Key<URL?>("keyboardShortcutScriptLocation", default: nil)
     static let runKeyboardShortcutScript = Key<Bool>("runKeyboardShortcutScript", default: false)
-    static let keyboardShortcutScriptContent = Key<String>("keyboardShortcutScriptContent", default: "preferences_advanced_apple_script_placeholder".loco())
+    static let keyboardShortcutScriptContent = Key<String>("keyboardShortcutScriptContent", default: keyboardShortcutScriptPlaceholder)
 
 
     static let customRegexes = Key<[String]>("customRegexes", default: [])

--- a/MeetingBar/Extensions/KeyboardShortcutsNames.swift
+++ b/MeetingBar/Extensions/KeyboardShortcutsNames.swift
@@ -14,4 +14,5 @@ extension KeyboardShortcuts.Name {
     static let joinEventShortcut = Self("joinEventShortcut")
     static let openClipboardShortcut = Self("openClipboardShortcut")
     static let toggleMeetingTitleVisibilityShortcut = Self("toggleMeetingTitleVisibilityShortcut")
+    static let runAppleScriptShortcut = Self("runAppleScriptShortcut")
 }

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -179,6 +179,8 @@
 "preferences_advanced_apple_script_checkmark" = "Run AppleScript when joining a meeting";
 "preferences_advanced_apple_script_placeholder" = "# write your script here\ntell application \"Music\" to pause";
 "preferences_advanced_run_script_on_event_start" = "Run AppleScript automatically";
+"preferences_advanced_run_script_on_keyboard_shortcut" = "Run AppleScript on keyboard shortcut";
+
 "preferences_advanced_test_script_on_next_event" = "Test on next event";
 "preferences_advanced_edit_script" = "Edit script";
 "preferences_advanced_save_script_button" = "Save script";

--- a/MeetingBar/Scripts.swift
+++ b/MeetingBar/Scripts.swift
@@ -84,7 +84,6 @@ func runAppleScript(event: MBEvent, type: ScriptType) {
 
     let scriptPath = try! FileManager.default.url(for: .applicationScriptsDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
 
-
     let url = scriptPath.appendingPathComponent(type.filename)
 
     if FileManager.default.fileExists(atPath: url.path) {

--- a/MeetingBar/Scripts.swift
+++ b/MeetingBar/Scripts.swift
@@ -13,6 +13,17 @@ enum ScriptType: String, Codable, CaseIterable {
     case meetingStart
     /// not supported yet to execute apple scripts for meeting end
     case meetingEnd
+    case joinEventScript
+    case keyboardShortcut
+
+    var filename: String {
+        switch self {
+        case .meetingStart: return "eventStartScript.scpt"
+        case .meetingEnd: return "eventEndScript.scpt"
+        case .joinEventScript: return "joinEventScript.scpt"
+        case .keyboardShortcut: return "keyboardShortcutScript.scpt"
+        }
+    }
 }
 
 /**
@@ -55,7 +66,7 @@ func createAppleScriptParametersForEvent(event: MBEvent) -> NSAppleEventDescript
 }
 
 // runs the predefined script with parameters.
-func runMeetingStartsScript(event: MBEvent, type: ScriptType) {
+func runAppleScript(event: MBEvent, type: ScriptType) {
     NSLog("Run apple script for event \(String(describing: event.ID))")
 
     let parameters = createAppleScriptParametersForEvent(event: event)
@@ -73,7 +84,8 @@ func runMeetingStartsScript(event: MBEvent, type: ScriptType) {
 
     let scriptPath = try! FileManager.default.url(for: .applicationScriptsDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
 
-    let url = scriptPath.appendingPathComponent("eventStartScript.scpt")
+
+    let url = scriptPath.appendingPathComponent(type.filename)
 
     if FileManager.default.fileExists(atPath: url.path) {
         let appleScript = try! NSUserAppleScriptTask(url: url)
@@ -95,7 +107,15 @@ func runMeetingStartsScript(event: MBEvent, type: ScriptType) {
  */
 func runAppleScriptForNextEvent(events: [MBEvent]) {
     if let nextEvent = getNextEvent(events: events) {
-        runMeetingStartsScript(event: nextEvent, type: .meetingStart)
+        runAppleScript(event: nextEvent, type: .meetingStart)
+    } else {
+        sendNotification("next_meeting_empty_title".loco(), "next_meeting_empty_message".loco())
+    }
+}
+
+func runAppleScriptForKeyboardShortcut(events: [MBEvent]) {
+    if let nextEvent = getNextEvent(events: events) {
+        runAppleScript(event: nextEvent, type: .keyboardShortcut)
     } else {
         sendNotification("next_meeting_empty_title".loco(), "next_meeting_empty_message".loco())
     }

--- a/MeetingBar/Views/Changelog/Changelog.swift
+++ b/MeetingBar/Views/Changelog/Changelog.swift
@@ -127,6 +127,11 @@ struct ChangelogView: View {
                             Text("• Fixed delegated calendar for macOS Calendar data source")
                         }
                     }
+                    if compareVersions("4.3.0", lastRevisedVersionInChangelog) {
+                        Section(header: Text("Version 4.3")) {
+                            Text("• Advanced feature to run AppleScript on keyboard shortcut")
+                        }
+                    }
                 }
             }.listStyle(SidebarListStyle())
             Button("general_close".loco(), action: close)

--- a/MeetingBar/Views/Preferences/AdvancedTab.swift
+++ b/MeetingBar/Views/Preferences/AdvancedTab.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 
 import Defaults
+import KeyboardShortcuts
 
 struct AdvancedTab: View {
     var body: some View {
@@ -44,6 +45,12 @@ struct ScriptSection: View {
 
     @State private var showingJoinEventScriptModal = false
 
+    @Default(.runKeyboardShortcutScript) var runKeyboardShortcutScript
+    @Default(.keyboardShortcutScriptLocation) var keyboardShortcutScriptLocation
+    @Default(.keyboardShortcutScriptContent) var keyboardShortcutScriptContent
+
+    @State private var showingKeyboardScriptModal = false
+
     var body: some View {
         VStack(alignment: .leading) {
             HStack {
@@ -62,7 +69,7 @@ struct ScriptSection: View {
                     Button("preferences_advanced_edit_script".loco()) { showingRunEventStartScriptModal = true }
                 }
             }.sheet(isPresented: $showingRunEventStartScriptModal) {
-                EditScriptModal(script: $eventStartScript, scriptLocation: $eventStartScriptLocation, scriptName: "eventStartScript.scpt")
+                EditScriptModal(script: $eventStartScript, scriptLocation: $eventStartScriptLocation, scriptName: ScriptType.meetingStart.filename)
             }
 
             HStack {
@@ -72,7 +79,18 @@ struct ScriptSection: View {
                     Button("preferences_advanced_edit_script".loco()) { showingJoinEventScriptModal = true }
                 }
             }.sheet(isPresented: $showingJoinEventScriptModal) {
-                EditScriptModal(script: $joinEventScript, scriptLocation: $joinEventScriptLocation, scriptName: "joinEventScript.scpt")
+                EditScriptModal(script: $joinEventScript, scriptLocation: $joinEventScriptLocation, scriptName: ScriptType.joinEventScript.filename)
+            }
+            
+            HStack {
+                Toggle("preferences_advanced_run_script_on_keyboard_shortcut".loco(), isOn: $runKeyboardShortcutScript)
+                Spacer()
+                if runKeyboardShortcutScript {
+                    KeyboardShortcuts.Recorder(for: .runAppleScriptShortcut)
+                    Button("preferences_advanced_edit_script".loco()) { showingKeyboardScriptModal = true }
+                }
+            }.sheet(isPresented: $showingKeyboardScriptModal) {
+                EditScriptModal(script: $keyboardShortcutScriptContent, scriptLocation: $keyboardShortcutScriptLocation, scriptName: ScriptType.keyboardShortcut.filename)
             }
         }
     }

--- a/MeetingBar/Views/Preferences/AdvancedTab.swift
+++ b/MeetingBar/Views/Preferences/AdvancedTab.swift
@@ -81,7 +81,7 @@ struct ScriptSection: View {
             }.sheet(isPresented: $showingJoinEventScriptModal) {
                 EditScriptModal(script: $joinEventScript, scriptLocation: $joinEventScriptLocation, scriptName: ScriptType.joinEventScript.filename)
             }
-            
+
             HStack {
                 Toggle("preferences_advanced_run_script_on_keyboard_shortcut".loco(), isOn: $runKeyboardShortcutScript)
                 Spacer()


### PR DESCRIPTION
### Status
**READY**

### Description
Closes #573.
Adds support to run an AppleScript when you press a keyboard shortcut.

<img width="812" alt="image" src="https://user-images.githubusercontent.com/1180883/212388913-e46f6c65-9cd6-44b9-92c1-4f4e00b3c972.png">

- Wasn't sure whether to add a "test" button in there too?.
- Also not sure how localization works.
- Missed the CHANGELOG entry, let me add that now


## Checklist
- [ ] Localized
- [x] Added to changelog:
  - [x] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
- Open Preferences > Advanced
- Check the "Run AppleScript on keyboard shortcut" checkbox
- Choose a keyboard shortcut
- Hit "Edit script" and put in a script
- ???
- Profit!
