### PR TITLE
add reclaim.ai links support

### DIFF
--- a/MeetingBar/MeetingServices.swift
+++ b/MeetingBar/MeetingServices.swift
@@ -70,6 +70,7 @@ enum MeetingServices: String, Codable, CaseIterable {
     case demodesk = "Demodesk"
     case zoho_cliq = "Zoho Cliq"
     case slack = "Slack"
+    case reclaim = "Reclaim.ai"
     case other = "Other"
 
     var localizedValue: String {
@@ -299,6 +300,7 @@ struct LinksRegex {
     let skype4biz_selfhosted = try! NSRegularExpression(pattern: #"https?:\/\/(meet|join)\.[^\s]*\/[a-z0-9.]+/meet\/[A-Za-z0-9./]+"#)
     let hangouts = try! NSRegularExpression(pattern: #"https?://hangouts.google.com/[^\s]*"#)
     let slack = try! NSRegularExpression(pattern: #"https?://app.slack.com/huddle/[A-Za-z0-9./]+"#)
+    let reclaim = try! NSRegularExpression(pattern: #"https?://reclaim.ai/z/[A-Za-z0-9./]+"#)
 }
 
 func getRegexForMeetingService(_ service: MeetingServices) -> NSRegularExpression? {
@@ -360,6 +362,13 @@ func getIconForMeetingService(_ meetingService: MeetingServices?) -> NSImage {
 
     // tested and verified
     case .some(.zoom), .some(.zoomgov), .some(.zoom_native):
+        image = NSImage(named: "zoom_icon")!
+        image.size = NSSize(width: 16, height: 16)
+
+
+    case .some(.reclaim):
+        // reclaim only uses its own links when zoom is involved, so they are always zoom links
+        // see https://devforum.zoom.us/t/major-zoom-gcal-sync-problems-recent-behavior-change/80912
         image = NSImage(named: "zoom_icon")!
         image.size = NSSize(width: 16, height: 16)
 

--- a/MeetingBar/MeetingServices.swift
+++ b/MeetingBar/MeetingServices.swift
@@ -365,7 +365,6 @@ func getIconForMeetingService(_ meetingService: MeetingServices?) -> NSImage {
         image = NSImage(named: "zoom_icon")!
         image.size = NSSize(width: 16, height: 16)
 
-
     case .some(.reclaim):
         // reclaim only uses its own links when zoom is involved, so they are always zoom links
         // see https://devforum.zoom.us/t/major-zoom-gcal-sync-problems-recent-behavior-change/80912

--- a/MeetingBarTests/MeetingServicesTests.swift
+++ b/MeetingBarTests/MeetingServicesTests.swift
@@ -32,6 +32,7 @@ let meetings = [
     MeetingLink(service: .demodesk, url: URL(string: "https://demodesk.com/NGYLHDWO")!),
     MeetingLink(service: .zoho_cliq, url: URL(string: "https://cliq.zoho.eu/meetings/alsfsma213")!),
     MeetingLink(service: .slack, url: URL(string: "https://app.slack.com/huddle/T01ABCDEFGH/C02ABCDEFGH")!)
+    MeetingLink(service: .reclaim, url: URL(string: "https://reclaim.ai/z/T01ABCDEFGH/C02ABCDEFGH")!)
 ]
 
 class MeetingServicesTests: XCTestCase {


### PR DESCRIPTION
### Status
**READY**

### Description
reclaim.ai started putting their own links for zoom meetings, because of a bug / change in zoom. This PR should add support for Zoom/Reclaim.

https://devforum.zoom.us/t/major-zoom-gcal-sync-problems-recent-behavior-change/80912


## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
