### PR TITLE
Fix regex for zoom webinars

### DIFF
--- a/MeetingBar/MeetingServices.swift
+++ b/MeetingBar/MeetingServices.swift
@@ -247,7 +247,7 @@ func openMeetingURL(_ service: MeetingServices?, _ url: URL, _ browser: Browser?
 
 struct LinksRegex {
     let meet = try! NSRegularExpression(pattern: #"https?://meet.google.com/(_meet/)?[a-z-]+"#)
-    let zoom = try! NSRegularExpression(pattern: #"https?:\/\/(?:[a-zA-Z0-9-.]+)?zoom.(?:us|com.cn)\/(?:my|[a-z])\/[-a-zA-Z0-9()@:%_\+.~#?&=\/]*"#)
+    let zoom = try! NSRegularExpression(pattern: #"https?:\/\/(?:[a-zA-Z0-9-.]+)?zoom.(?:us|com.cn)\/(?:my|[a-z]|webinar)\/[-a-zA-Z0-9()@:%_\+.~#?&=\/]*"#)
     let zoom_native = try! NSRegularExpression(pattern: #"zoommtg://([a-z0-9-.]+)?zoom\.(us|com\.cn)/join[-a-zA-Z0-9()@:%_\+.~#?&=\/]*"#)
     let teams = try! NSRegularExpression(pattern: #"https?://teams\.microsoft\.com/l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+"#)
     let webex = try! NSRegularExpression(pattern: #"https?://([a-z0-9-.]+)?webex\.com/[^\s]*"#)


### PR DESCRIPTION
### Status
READY

### Description
This change adds support for zoom webinars.  These links take the form of:
https://company.zoom.us/webinar/register/WN_weEDiYboFZmW20t1GvD3JA


## Checklist
- [ ] Localized – It didn't seem like this was needed for this change?
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

*Note* happy to add a version change if you want me too, but wasn't clear to me that was desired

### Steps to Test or Reproduce
1. Create a meeting with a dummy webinar link in the notes (this is where these types of meetings normally have them)
2. See that the zoom icon is associated in MeetingBar
3. Click on meeting, see the link open in webbrowser
