### PR TITLE
Fix event start script bug

### DIFF
--- a/MeetingBar/ActionsOnEventStart.swift
+++ b/MeetingBar/ActionsOnEventStart.swift
@@ -35,7 +35,7 @@ class ActionsOnEventStart: NSObject {
 
         // Only run if the user has activated it.
         let autoJoinActionActive = Defaults[.automaticEventJoin]
-        let runEventStartScriptActionActive = Defaults[.runEventStartScript] && (Defaults[.joinEventScriptLocation] != nil)
+        let runEventStartScriptActionActive = Defaults[.runEventStartScript] && (Defaults[.eventStartScriptLocation] != nil)
 
         if !autoJoinActionActive, !runEventStartScriptActionActive {
             return


### PR DESCRIPTION
### Status
**READY**

### Description
Found a bug with the event start script setting.  It will only run if a join script is also setup, I think due to just a type in the accessing Defaults


## Checklist
- [x] Localized (none required)
- [ ] Added to changelog: (unclear to me if you want this given that I didn't want to make a whole version, happy to do what you want here)
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
The bug happens if you have the run event script set but no join event. So Advanced settings looks like this:
![image](https://github.com/leits/MeetingBar/assets/414995/e4f8aa46-857a-4bf7-8c2d-160fba63638f)

In order for that to work, you have to have the join event location also set, which means you have to have that turned on.  This fix changes to check the event start script location, which is what I believe was intended.
