### PR TITLE
Change Localizable.strings "あと" to "まで".

### DIFF
--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -243,7 +243,7 @@
 "status_bar_quit" = "MeetingBar を終了";
 "status_bar_no_title" = "タイトルなし";
 "status_bar_event_status_now" = "現在 (残り %@)";
-"status_bar_event_status_in" = "あと%@";
+"status_bar_event_status_in" = "まで%@";
 "status_bar_error_apple_script_title" = "AppleScriptエラー";
 "status_bar_error_link_missed_title" = "ギャー！%@ に参加できませんでした";
 "status_bar_error_link_missed_message" = "ミーティングリンクが登録されていないか、サポートされていないサービスです";


### PR DESCRIPTION
Change to correct Japanese grammar.

### Status
**READY**

### Description

Thank you for the great software.
I am Japanese and I use it everyday.

I have one problem in using it.
The time until the meeting starts is expressed as "あと", but "あと" gives the nuance that the meeting is in progress.

Therefore, I was worried several times that the meeting had already started.

So I submit this PR.

Thank you very much for making the software.

## Checklist
- [x] Localized

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.
