### PR TITLE
Add icon for Gather meeting service

### DIFF
--- a/MeetingBar/MeetingServices.swift
+++ b/MeetingBar/MeetingServices.swift
@@ -605,6 +605,10 @@ func getIconForMeetingService(_ meetingService: MeetingServices?) -> NSImage {
         image = NSImage(named: "vonage_icon")!
         image.size = NSSize(width: 16, height: 16)
 
+    case .some(.gather):
+        image = NSImage(named: "gather_icon")!
+        image.size = NSSize(width: 16, height: 16)
+
     case .some(.url):
         image = NSImage(named: NSImage.touchBarOpenInBrowserTemplateName)!
         image.size = NSSize(width: 16, height: 16)


### PR DESCRIPTION
### Status
**READY**

### Description
The Gather icon did not appear, although it is officially listed as "Gather compatible." We checked the code and found that there was an additional part that needed to be implemented.

Before
![スクリーンショット 2023-11-20 5 35 43](https://github.com/leits/MeetingBar/assets/5304663/1a7ea8b8-e9d3-4805-b3d2-f722bc75ac1b)

After
![スクリーンショット 2023-11-20 5 17 50](https://github.com/leits/MeetingBar/assets/5304663/bc1efc88-cf37-4f62-8332-698deeb92044)


## Checklist
- [x] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
If you paste the Gather URL into your schedule and check the MeetingBar, you will see the Gather icon appear.
