### PR TITLE
display meeting location on the full screen overlay

### DIFF
--- a/MeetingBar/Views/FullscreenNotification.swift
+++ b/MeetingBar/Views/FullscreenNotification.swift
@@ -25,6 +25,15 @@ struct FullscreenNotification: View {
                 VStack(spacing: 10) {
                     Text(getEventDateString(event))
                 }.padding(15)
+                
+                // display location of the event, very useful if you
+                // have a lot of meetings in a building with a lot of meeting rooms
+                if let location = event.location {
+                    VStack(spacing: 10) {
+                        Text(location)
+                    }.padding(15)
+                }
+             
                 HStack(spacing: 30) {
                     Button(action: dismiss) {
                         Text("general_close".loco()).padding(.vertical, 5).padding(.horizontal, 20)


### PR DESCRIPTION
### Status
**READY**

### Description
We have a lot of people that are very excited for this project. But the problem is we work in a big office with a lot of meeting rooms. so every time I get the meeting popup, I still have to look at my calendar to see where I am supposed to be going.

Looking at the Google Calendar API, you are already including the right field, you are just not using it yet. this PR fixes that!

## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
configure a room/location on your google calendar meeting. when the full screen popup appears, it will now also diplsay the location.