### PR TITLE
Fix typo "recomended" in Localizable.strings (en)

### DIFF
--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -270,7 +270,7 @@
 "access_screen_access_granted_click_ok_title" = "Click \"OK\" in the macOS popup.";
 "access_screen_provider_picker_label" = "Select calendars provider";
 "access_screen_provider_macos_title" = "MacOS Calendar app";
-"access_screen_provider_macos_recomended" = "(recomended)";
+"access_screen_provider_macos_recomended" = "(recommended)";
 "access_screen_provider_macos_data_source" = "Get data from MacOS Calendar app";
 "access_screen_provider_macos_number_of_accounts" = "Any number of any connected accounts";
 "access_screen_provider_gcalendar_data_source" = "Get data directly from Google Calendar";


### PR DESCRIPTION
### Status
**READY**

### Description
Replace typo "recomended" with correct "recommended" in Localizable.strings (en)


## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
n/a
