### PR TITLE
Fix typo in German translation

### DIFF
--- a/MeetingBar/Resources /Localization /de.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /de.lproj/Localizable.strings
@@ -273,7 +273,7 @@
 "access_screen_access_denied_checkbox_title" = "und aktiviere ein Kontrollkästchen bei MeetingBar.";
 "access_screen_access_denied_system_preferences_button" = "Systemeinstellungen";
 "access_screen_access_screen_access_denied_go_to_title" = "Gehe zu";
-"shared_automatic_event_join_toggle" = "Automatisch zum nächsten Meeting beitretten";
+"shared_automatic_event_join_toggle" = "Automatisch zum nächsten Meeting beitreten";
 "shared_automatic_event_join_tip" = "Diese Einstellung wird automatisch das nächste Meeting in ihrer voreingestellten App oder dem Browser öffnen";
 
 // MARK: - Access screen


### PR DESCRIPTION
### Status
**READY**

### Description
Fix typo in German translation: `beitretten` -> `beitreten`
Translation key that was changed: `shared_automatic_event_join_toggle`

## Checklist
- [x] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
How it looked before:
<img width="693" alt="" src="https://github.com/user-attachments/assets/ab36acdf-0d64-4f0f-bb49-02940495392d" />

