### PR TITLE
fix: text key

### DIFF
--- a/MeetingBar/UI/Views/Preferences/CalendarsTab.swift
+++ b/MeetingBar/UI/Views/Preferences/CalendarsTab.swift
@@ -90,7 +90,7 @@ struct ProviderPicker: View {
 struct AccessDeniedBanner: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 4) {
-            Text("access_screen_access_denied_go_to_title".loco())
+            Text("access_screen_access_screen_access_denied_go_to_title".loco())
             Button("access_screen_access_denied_system_preferences_button".loco()) {
                 NSWorkspace.shared.open(Links.calendarPreferences)
             }


### PR DESCRIPTION
### Status
**READY/IN DEVELOPMENT/HOLD**

### Description

The commit 796f1c0 lost a part of the key and this shows up in the current beta

<img width="690" alt="image" src="https://github.com/user-attachments/assets/86fdde52-0452-4c1e-b633-54f272360210" />


This PR uses [the existing key](https://github.com/leits/MeetingBar/blob/0fdea2f8d22adedff125b41622ba46ecf3845888/MeetingBar/Resources%20/Localization%20/en.lproj/Localizable.strings#L269).

## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce

Install Beta on MacOS and switch to Calendars tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the localization key for the access denied banner text in the calendar preferences tab. No visible change in functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->