### PR TITLE
Fix Google auth reprompting

### DIFF
--- a/MeetingBar/Core/EventStores/GCEventStore.swift
+++ b/MeetingBar/Core/EventStores/GCEventStore.swift
@@ -112,8 +112,7 @@ final class GCEventStore: NSObject,
 
         // additional parameters to be sure we get refresh_token
         let extra = [
-            "access_type": "offline",
-            "prompt": "consent"
+            "access_type": "offline"
         ]
 
         let request = OIDAuthorizationRequest(
@@ -159,8 +158,6 @@ final class GCEventStore: NSObject,
             if let acc = access { grp.addTask { try? await self.revoke(token: acc) } }
             if let ref = refresh { grp.addTask { try? await self.revoke(token: ref) } }
         }
-
-        urlSession.invalidateAndCancel()
 
         clearAuthState()
     }
@@ -228,8 +225,8 @@ final class GCEventStore: NSObject,
             try await signIn()
         }
         signInTask = task
+        defer { signInTask = nil }
         try await task.value
-        signInTask = nil
     }
 
     private func validAccessToken() async throws -> String {


### PR DESCRIPTION
## Summary
- avoid using the consent prompt each time Google authentication runs
- keep the URLSession alive when signing out
- ensure sign-in tasks always clean up when they fail

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_684579bfcaa483319ecc7327a7735037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sign-in reliability and session handling for Google Calendar integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->