### PR TITLE
support pattern for new ovice url

### DIFF
--- a/MeetingBar/Services/MeetingServices.swift
+++ b/MeetingBar/Services/MeetingServices.swift
@@ -300,7 +300,7 @@ private let meetingLinkRegexes: [MeetingServices: NSRegularExpression] = [
     .lark: try! NSRegularExpression(pattern: #" https://vc\.larksuite\.com/j/[0-9]+"#),
     .feishu: try! NSRegularExpression(pattern: #"https://vc\.feishu\.cn/j/[0-9]+"#),
     .vimeo: try! NSRegularExpression(pattern: #"https://vimeo\.com/(showcase|event)/[0-9]+|https://venues\.vimeo\.com/[^\s]+"#),
-    .ovice: try! NSRegularExpression(pattern: #"https://([a-z0-9-.]+)?ovice\.in/[^\s]*"#),
+    .ovice: try! NSRegularExpression(pattern: #"https://([a-z0-9-.]+)?ovice\.(in|com)/[^\s]*"#),
     .facetime: try! NSRegularExpression(pattern: #"https://facetime\.apple\.com/join[^\s]*"#),
     .chorus: try! NSRegularExpression(pattern: #"https?://go\.chorus\.ai/[^\s]+"#),
     .pop: try! NSRegularExpression(pattern: #"https?://pop\.com/j/[0-9-]+"#),

--- a/MeetingBarTests/MeetingServicesTests.swift
+++ b/MeetingBarTests/MeetingServicesTests.swift
@@ -21,6 +21,7 @@ let meetings = [
     MeetingLink(service: .blackboard_collab, url: URL(string: "https://us.bbcollab.com/invite/EFC53F2790E6E50FFCC2AFBC16CC69EE")!),
     MeetingLink(service: .coscreen, url: URL(string: "https://join.coscreen.co/Eng-Leads/95RyHqtzn7EoQjQ19ju3")!),
     MeetingLink(service: .ovice, url: URL(string: "https://universeph-armynight.ovice.in/lobby/enter")!),
+    MeetingLink(service: .ovice, url: URL(string: "https://app.ovice.com/universeph-armynight/@102,105")!),
     MeetingLink(service: .facetime, url: URL(string: "https://facetime.apple.com/join#v=1&p=AeVKu1rGEeyppwJC8kftBg&k=FrCNneouFgL26VdnDit78WHNoGjzZyteymBi1U5I23E")!),
     MeetingLink(service: .pop, url: URL(string: "https://pop.com/j/810-218-630")!),
     MeetingLink(service: .gong, url: URL(string: "https://join.gong.io/mycompany/ryker.morgan")!),


### PR DESCRIPTION
### Status
**READY**

### Description

This pull request updates the regular expression to support the new ovice URL pattern.
The current pattern does not allow opening URLs in the new format, so this fix ensures proper handling of the updated URLs.


## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
	1.	Prepare a new ovice URL (e.g., `https://app.ovice.com/universeph-armynight/@102,105`)
	2.	Open the URL using MeetingBar
	3.	Verify that the URL is correctly processed and recognized as a valid meeting link




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting link detection to support oVice links from both ovice.in and ovice.com, ensuring oVice meetings are recognized and accessible regardless of domain.

* **Tests**
  * Added test coverage for oVice links using the ovice.com domain to validate detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->