### PR TITLE
Keep last events on refresh errors

### DIFF
--- a/MeetingBar/Core/Managers/EventManager.swift
+++ b/MeetingBar/Core/Managers/EventManager.swift
@@ -174,20 +174,17 @@ public class EventManager: ObservableObject {
                 return Deferred {
                     Future<([MBCalendar], [MBEvent]), Error> { promise in
                         Task {
+                            let current = await MainActor.run { (self.calendars, self.events) }
                             do {
                                 let cals = try await self.provider.fetchAllCalendars()
                                 let evts = try await self.fetchEvents(fromCalendars: cals)
                                 promise(.success((cals, evts)))
                             } catch {
                                 NSLog("EventManager refresh failed: \(error)")
-                                promise(.success(([], [])))
+                                promise(.success(current))
                             }
                         }
                     }
-                }
-                .catch { error -> Empty<([MBCalendar], [MBEvent]), Never> in
-                    NSLog("EventManager refresh failed: \(error)")
-                    return Empty(completeImmediately: true)
                 }
                 .eraseToAnyPublisher()
             }


### PR DESCRIPTION
### Motivation
- Prevent losing the last known calendars and events when a refresh fetch fails by avoiding overwriting them with empty arrays.

### Description
- In `MeetingBar/Core/Managers/EventManager.swift` capture the current `self.calendars` and `self.events` on the `MainActor` before creating the `Future`, and return that `current` tuple from the `catch` block instead of `([], [])`, and remove the downstream `.catch` that converted errors into an empty publisher.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b26704820833191c17c32053686aa)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for calendar data retrieval. When fetching calendar information fails, the app now gracefully displays your previously cached calendars and events instead of an empty state, maintaining visibility to your data.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->