### PR TITLE
Fix fullscreen notifications on multi-monitor setups

### DIFF
--- a/MeetingBar/App/AppDelegate.swift
+++ b/MeetingBar/App/AppDelegate.swift
@@ -238,7 +238,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotifi
     }
 
     func openFullscreenNotificationWindow(event: MBEvent) {
-        let screenFrame = NSScreen.main?.frame ?? NSRect(x: 0, y: 0, width: 800, height: 600)
+        let primaryScreen = NSScreen.screens.first
+        let screenFrame = primaryScreen?.frame ?? NSRect(x: 0, y: 0, width: 800, height: 600)
 
         let window = NSWindow(
             contentRect: screenFrame,
@@ -250,8 +251,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotifi
         window.contentView = NSHostingView(
             rootView: FullscreenNotification(event: event, window: window))
         window.appearance = NSAppearance(named: .darkAqua)
-        window.collectionBehavior = .canJoinAllSpaces
-        window.collectionBehavior = .moveToActiveSpace
+        window.collectionBehavior = [.moveToActiveSpace]
 
         window.titlebarAppearsTransparent = true
         window.styleMask.insert(.fullSizeContentView)
@@ -261,6 +261,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotifi
         let controller = NSWindowController(window: window)
         controller.showWindow(self)
 
+        window.setFrame(screenFrame, display: true)
         window.center()
         window.orderFrontRegardless()
     }


### PR DESCRIPTION
On devices with multiple screens, there are issues with fullscreen notifications. This updates the behavior to show the fullscreen notification on the active space of the primary screen, rather than the active screen as determined by mouse focus.

Fixes https://github.com/leits/MeetingBar/issues/859
Related https://github.com/leits/MeetingBar/issues/856
Maybe related to https://github.com/leits/MeetingBar/issues/882, https://github.com/leits/MeetingBar/issues/865

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fullscreen notification window positioning to correctly display on the primary screen with proper dimensions and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->