### PR TITLE
Add 'Join Current Meeting' keyboard shortcut

### DIFF
--- a/MeetingBar/Core/Models/MBEvent+Helpers.swift
+++ b/MeetingBar/Core/Models/MBEvent+Helpers.swift
@@ -174,7 +174,10 @@ public extension Array where Element == MBEvent {
     }
 
     /// Returns the event that is currently in progress.
+    ///
     /// Unlike `nextEvent()`, this does not depend on ongoing visibility settings.
+    /// - Parameter linkRequired: If `true`, only events with a meeting link are considered.
+    /// - Returns: The currently running event that passes filters, or `nil`.
     func currentEvent(linkRequired: Bool = false) -> MBEvent? {
         let now = Date()
 

--- a/MeetingBar/Core/Models/MBEvent+Helpers.swift
+++ b/MeetingBar/Core/Models/MBEvent+Helpers.swift
@@ -172,4 +172,43 @@ public extension Array where Element == MBEvent {
         }
         return nextEvent
     }
+
+    /// Returns the event that is currently in progress.
+    /// Unlike `nextEvent()`, this does not depend on ongoing visibility settings.
+    func currentEvent(linkRequired: Bool = false) -> MBEvent? {
+        let now = Date()
+
+        for event in self {
+            guard event.startDate <= now, event.endDate > now else {
+                continue
+            }
+            if Defaults[.dismissedEvents].contains(where: { $0.id == event.id }) {
+                continue
+            }
+            if event.isAllDay {
+                continue
+            }
+            if event.meetingLink == nil, linkRequired {
+                continue
+            }
+            if event.participationStatus == .declined {
+                continue
+            }
+            if event.participationStatus == .pending,
+               Defaults[.showPendingEvents] == .hide || Defaults[.showPendingEvents] == .show_inactive {
+                continue
+            }
+            if event.participationStatus == .tentative,
+               Defaults[.showTentativeEvents] == .hide || Defaults[.showTentativeEvents] == .show_inactive {
+                continue
+            }
+            if event.status == .canceled {
+                continue
+            }
+
+            return event
+        }
+
+        return nil
+    }
 }

--- a/MeetingBar/Extensions/KeyboardShortcutsNames.swift
+++ b/MeetingBar/Extensions/KeyboardShortcutsNames.swift
@@ -14,6 +14,7 @@ extension KeyboardShortcuts.Name {
     static let createMeetingShortcut = Self("createMeetingShortcut")
     static let openMenuShortcut = Self("openMenuShortcut")
     static let joinEventShortcut = Self("joinEventShortcut")
+    static let joinCurrentEventShortcut = Self("joinCurrentEventShortcut")
     static let openClipboardShortcut = Self("openClipboardShortcut")
     static let toggleMeetingTitleVisibilityShortcut = Self("toggleMeetingTitleVisibilityShortcut")
 }

--- a/MeetingBar/Extensions/KeyboardShortcutsNames.swift
+++ b/MeetingBar/Extensions/KeyboardShortcutsNames.swift
@@ -11,10 +11,16 @@ import KeyboardShortcuts
 extension KeyboardShortcuts.Name: @unchecked @retroactive Sendable {}
 
 extension KeyboardShortcuts.Name {
+    /// Global shortcut used to create an ad-hoc meeting.
     static let createMeetingShortcut = Self("createMeetingShortcut")
+    /// Global shortcut used to open the status bar menu.
     static let openMenuShortcut = Self("openMenuShortcut")
+    /// Global shortcut used to join the nearest meeting (current or next).
     static let joinEventShortcut = Self("joinEventShortcut")
+    /// Global shortcut used to join only the currently running meeting.
     static let joinCurrentEventShortcut = Self("joinCurrentEventShortcut")
+    /// Global shortcut used to open a meeting link from clipboard.
     static let openClipboardShortcut = Self("openClipboardShortcut")
+    /// Global shortcut used to toggle status bar meeting title visibility.
     static let toggleMeetingTitleVisibilityShortcut = Self("toggleMeetingTitleVisibilityShortcut")
 }

--- a/MeetingBar/UI/StatusBar/MenuBuilder.swift
+++ b/MeetingBar/UI/StatusBar/MenuBuilder.swift
@@ -77,10 +77,13 @@ struct MenuBuilder {
 
             let joinItem = NSMenuItem(
                 title: itemTitle,
-                action: #selector(StatusBarItemController.joinNextMeeting),
+                action: nextEvent.startDate < now
+                    ? #selector(StatusBarItemController.joinCurrentMeeting)
+                    : #selector(StatusBarItemController.joinNextMeeting),
                 keyEquivalent: ""
             )
             joinItem.target = target
+            joinItem.setShortcut(for: nextEvent.startDate < now ? .joinCurrentEventShortcut : .joinEventShortcut)
             items.append(joinItem)
         }
 

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -405,6 +405,9 @@ final class StatusBarItemController {
     }
 
     @objc
+    /// Joins the meeting link for the event currently in progress.
+    ///
+    /// If there is no active event, a user-facing notification is shown.
     func joinCurrentMeeting() {
         if let currentEvent = events.currentEvent() {
             currentEvent.openMeeting()

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -127,6 +127,10 @@ final class StatusBarItemController {
     private func setupKeyboardShortcuts() {
         KeyboardShortcuts.onKeyUp(for: .createMeetingShortcut, action: createMeeting)
 
+        KeyboardShortcuts.onKeyUp(for: .joinCurrentEventShortcut) {
+            Task { @MainActor in self.joinCurrentMeeting() }
+        }
+
         KeyboardShortcuts.onKeyUp(for: .joinEventShortcut) {
             Task { @MainActor in self.joinNextMeeting() }
         }
@@ -398,6 +402,15 @@ final class StatusBarItemController {
 
     @objc func createMeetingAction() {
         createMeeting()
+    }
+
+    @objc
+    func joinCurrentMeeting() {
+        if let currentEvent = events.currentEvent() {
+            currentEvent.openMeeting()
+        } else {
+            sendNotification("status_bar_section_join_current_meeting".loco(), "next_meeting_empty_message".loco())
+        }
     }
 
     @objc

--- a/MeetingBar/UI/Views/Preferences/GeneralTab.swift
+++ b/MeetingBar/UI/Views/Preferences/GeneralTab.swift
@@ -43,6 +43,9 @@ struct ShortcutsSection: View {
             Text("preferences_general_shortcut_create_meeting".loco())
             KeyboardShortcuts.Recorder(for: .createMeetingShortcut)
 
+            Text("status_bar_section_join_current_meeting".loco() + ":")
+            KeyboardShortcuts.Recorder(for: .joinCurrentEventShortcut)
+
             Text("preferences_general_shortcut_join_next".loco())
             KeyboardShortcuts.Recorder(for: .joinEventShortcut)
 
@@ -73,6 +76,11 @@ struct ShortcutsModal: View {
                     Text("preferences_general_shortcut_create_meeting".loco())
                     Spacer()
                     KeyboardShortcuts.Recorder(for: .createMeetingShortcut)
+                }
+                HStack {
+                    Text("status_bar_section_join_current_meeting".loco() + ":")
+                    Spacer()
+                    KeyboardShortcuts.Recorder(for: .joinCurrentEventShortcut)
                 }
                 HStack {
                     Text("preferences_general_shortcut_join_next".loco())

--- a/MeetingBarTests/NextEventTests.swift
+++ b/MeetingBarTests/NextEventTests.swift
@@ -131,4 +131,32 @@ class NextEventTests: BaseTestCase {
         let array = [future, running]
         XCTAssertEqual(array.nextEvent(), running)
     }
+
+    func test_currentEvent_returnsRunningEvent() {
+        let running = makeFakeEvent(
+            id: "RUN",
+            start: now.addingTimeInterval(-120),
+            end: now.addingTimeInterval(600),
+            withLink: true
+        )
+        let future = makeFakeEvent(
+            id: "FUT",
+            start: now.addingTimeInterval(120),
+            end: now.addingTimeInterval(600),
+            withLink: true
+        )
+
+        XCTAssertEqual([future, running].currentEvent(), running)
+    }
+
+    func test_currentEvent_respectsLinkRequirement() {
+        let runningWithoutLink = makeFakeEvent(
+            id: "NO-LINK",
+            start: now.addingTimeInterval(-120),
+            end: now.addingTimeInterval(600),
+            withLink: false
+        )
+
+        XCTAssertNil([runningWithoutLink].currentEvent(linkRequired: true))
+    }
 }

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -52,7 +52,21 @@ final class MenuBuilderTests: BaseTestCase {
 
         XCTAssertEqual(MenuBuilder.plainTitles(of: items)[0],
                        "status_bar_section_join_current_meeting".loco())
+        XCTAssertEqual(items[0].action, #selector(StatusBarItemController.joinCurrentMeeting))
         XCTAssertTrue(items.contains { $0.action == #selector(StatusBarItemController.createMeetingAction) })
+    }
+
+    func test_joinSectionFutureEventUsesJoinNextAction() {
+        let future = makeFakeEvent(
+            id: "F",
+            start: Date().addingTimeInterval(300),
+            end: Date().addingTimeInterval(1_200)
+        )
+        let items = MenuBuilder(target: Dummy())
+            .buildJoinSection(nextEvent: future)
+
+        XCTAssertEqual(items[0].title, "status_bar_section_join_next_meeting".loco())
+        XCTAssertEqual(items[0].action, #selector(StatusBarItemController.joinNextMeeting))
     }
 
     func test_joinSectionWithoutEvent() {


### PR DESCRIPTION
Add support for joining an in-progress meeting directly. Introduces Array.currentEvent(linkRequired:) to find the currently running event while respecting visibility/dismissal rules, a new KeyboardShortcuts.Name.joinCurrentEventShortcut, and UI/behavior changes: MenuBuilder now selects joinCurrent vs joinNext action/shortcut when the next event has already started; StatusBarItemController registers the new shortcut and implements joinCurrentMeeting() (opens current event or posts a notification if none); Preferences General tab gains recorder entries for the new shortcut.

### Status
**READY/IN DEVELOPMENT/HOLD**

### Description
A few sentences describing the overall goals of the pull request's commits.


## Checklist
- [ ] Localized
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Join now: the Join menu can target the ongoing meeting when applicable.
  * New keyboard shortcuts added (including a dedicated "join current meeting" shortcut) and corresponding menu behavior.
  * Preferences updated to show and configure the "Join Current Meeting" shortcut.

* **Bug Fixes / Improvements**
  * Improved detection of the current in-progress meeting, including optional link requirement.

* **Tests**
  * Added tests verifying current-meeting selection and shortcut/menu behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->