### PR TITLE
Fix: Improve Google Calendar OAuth reliability with retry and wake refresh

### DIFF
--- a/MeetingBar/App/AppDelegate.swift
+++ b/MeetingBar/App/AppDelegate.swift
@@ -26,6 +26,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotifi
     private var eventCancellable: AnyCancellable?
 
     func applicationDidFinishLaunching(_: Notification) {
+        // Skip UI setup when running under XCTest
+        if NSClassFromString("XCTestCase") != nil {
+            return
+        }
+
         // AppStore sync
         completeStoreTransactions()
         checkAppSource()
@@ -102,6 +107,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotifi
         dnc.addObserver(
             self, selector: #selector(AppDelegate.unlockListener),
             name: .init("com.apple.screenIsUnlocked"), object: nil
+        )
+
+        // Also listen for system wake (covers cases where screen lock/unlock
+        // notifications may not fire, e.g. Touch ID auto-unlock).
+        NSWorkspace.shared.notificationCenter.addObserver(
+            self, selector: #selector(AppDelegate.didWakeListener),
+            name: NSWorkspace.didWakeNotification, object: nil
         )
     }
 
@@ -320,6 +332,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotifi
     @objc
     func unlockListener(notification _: NSNotification) {
         screenIsLocked = false
+        // Trigger an immediate calendar refresh after screen unlock / wake
+        // so events are up-to-date when the user returns.
+        eventManager?.triggerRefresh()
+    }
+
+    @objc
+    func didWakeListener(notification _: NSNotification) {
+        // Trigger a refresh after system wake to cover cases where
+        // screen lock/unlock notifications may not fire.
+        eventManager?.triggerRefresh()
     }
 
     /*

--- a/MeetingBar/Core/Managers/EventManager.swift
+++ b/MeetingBar/Core/Managers/EventManager.swift
@@ -30,10 +30,24 @@ public class EventManager: ObservableObject {
 
     private var storeChangeCancellable: AnyCancellable?
 
+    /// Maximum number of retry attempts for failed refreshes
+    private static let maxRetryAttempts = 5
+
+    /// Base delay (in seconds) for exponential backoff.
+    /// Overridable in tests via the DEBUG initializer.
+    private let baseRetryDelay: TimeInterval
+
+    /// How long (in seconds) before event data is considered stale and worth re-fetching
+    private static let staleThreshold: TimeInterval = 900  // 15 minutes
+
+    /// Timestamp of the last successful event fetch
+    private var lastSuccessfulRefresh: Date = .distantPast
+
     // MARK: - Initialization
 
     public init(refreshInterval: TimeInterval = 180) async {
         self.refreshInterval = refreshInterval
+        self.baseRetryDelay = 2
         provider = await MainActor.run {
             switch Defaults[.eventStoreProvider] {
             case .macOSEventKit: return EKEventStore.shared
@@ -99,6 +113,17 @@ public class EventManager: ObservableObject {
         refreshSubject.send()
     }
 
+    /// Trigger an immediate refresh (e.g. after screen unlock / wake).
+    /// Skips the refresh if the last successful fetch was within the stale threshold,
+    /// to avoid unnecessary API calls on quick lock/unlock cycles.
+    public func triggerRefresh() {
+        guard Date().timeIntervalSince(lastSuccessfulRefresh) > Self.staleThreshold else {
+            NSLog("EventManager skipping refresh — last successful refresh was \(Int(Date().timeIntervalSince(lastSuccessfulRefresh)))s ago (threshold: \(Int(Self.staleThreshold))s)")
+            return
+        }
+        refreshSubject.send()
+    }
+
     /// Fetches events for the selected calendars within the specified date range
     private func fetchEvents(fromCalendars: [MBCalendar]) async throws -> [MBEvent] {
         let dateFrom = Calendar.current.startOfDay(for: Date())
@@ -135,6 +160,52 @@ public class EventManager: ObservableObject {
         return rawEvents.filtered().sorted { $0.startDate < $1.startDate }
     }
 
+    /// Attempts to fetch calendars & events, retrying with exponential backoff
+    /// on failure. Stops after `maxRetryAttempts` and returns empty results.
+    private func fetchWithRetry() async -> ([MBCalendar], [MBEvent]) {
+        var attempt = 0
+
+        while attempt < Self.maxRetryAttempts {
+            do {
+                // On retries, attempt to re-authenticate in case the token expired
+                if attempt > 0 {
+                    NSLog("EventManager retry attempt \(attempt)/\(Self.maxRetryAttempts) — re-authenticating…")
+                    try await provider.signIn(forcePrompt: false)
+                }
+
+                let cals = try await provider.fetchAllCalendars()
+                let evts = try await fetchEvents(fromCalendars: cals)
+
+                if attempt > 0 {
+                    NSLog("EventManager retry succeeded on attempt \(attempt + 1)")
+                }
+                lastSuccessfulRefresh = Date()
+                return (cals, evts)
+            } catch {
+                attempt += 1
+                NSLog("EventManager refresh failed (attempt \(attempt)/\(Self.maxRetryAttempts)): \(error)")
+
+                if attempt >= Self.maxRetryAttempts {
+                    NSLog("EventManager giving up after \(Self.maxRetryAttempts) attempts")
+                    if NSClassFromString("XCTestCase") == nil {
+                        sendNotification(
+                            "Calendar refresh failed",
+                            "MeetingBar could not load your events. Try switching calendars in Preferences."
+                        )
+                    }
+                    return ([], [])
+                }
+
+                // Exponential backoff: e.g. 2s, 4s, 8s, 16s, 32s
+                let delay = baseRetryDelay * pow(2.0, Double(attempt - 1))
+                NSLog("EventManager will retry in \(delay)s…")
+                try? await Task.sleep(nanoseconds: UInt64(delay * Double(NSEC_PER_SEC)))
+            }
+        }
+
+        return ([], [])
+    }
+
     private func setupPublishers() {
         // A) Defaults changes as an “empty” trigger
         let defaultsPub = Defaults.publisher(keys:
@@ -165,7 +236,7 @@ public class EventManager: ObservableObject {
         // D) Merge them all
         let trigger = Publishers.Merge3(defaultsPub, timerPub, manualPub)
 
-        // E) When any fires, fetch calendars & events
+        // E) When any fires, fetch calendars & events with exponential backoff retry
         trigger
             .flatMap { [weak self] _ -> AnyPublisher<([MBCalendar], [MBEvent]), Never> in
                 guard let self = self else {
@@ -174,27 +245,21 @@ public class EventManager: ObservableObject {
                 return Deferred {
                     Future<([MBCalendar], [MBEvent]), Error> { promise in
                         Task {
-                            do {
-                                let cals = try await self.provider.fetchAllCalendars()
-                                let evts = try await self.fetchEvents(fromCalendars: cals)
-                                promise(.success((cals, evts)))
-                            } catch {
-                                NSLog("EventManager refresh failed: \(error)")
-                                promise(.success(([], [])))
-                            }
+                            let result = await self.fetchWithRetry()
+                            promise(.success(result))
                         }
                     }
                 }
-                .catch { error -> Empty<([MBCalendar], [MBEvent]), Never> in
+                .catch { error -> Just<([MBCalendar], [MBEvent])> in
                     NSLog("EventManager refresh failed: \(error)")
-                    return Empty(completeImmediately: true)
+                    return Just(([], []))
                 }
                 .eraseToAnyPublisher()
             }
             // **important: hop back to the main run-loop before assigning**
             .receive(on: RunLoop.main)
             .sink { [weak self] cals, evts in
-                // now we’re safely on the main actor / main thread
+                // now we're safely on the main actor / main thread
                 self?.calendars = cals
                 self?.events = evts
             }
@@ -205,12 +270,20 @@ public class EventManager: ObservableObject {
         /// Test-only initializer: inject your own store and skip
         /// the async system-store configuration.
         public init(provider: EventStore,
-                    refreshInterval: TimeInterval = 0) {
+                    refreshInterval: TimeInterval = 0,
+                    baseRetryDelay: TimeInterval = 0.01) {
             self.refreshInterval = refreshInterval
+            self.baseRetryDelay = baseRetryDelay
             self.provider = provider
             // no storeChangeCancellable for real notifications
             setupPublishers()
             refreshSubject.send()
+        }
+
+        /// Allows tests to override the last successful refresh timestamp
+        /// to simulate stale/fresh state.
+        func setLastSuccessfulRefresh(_ date: Date) {
+            lastSuccessfulRefresh = date
         }
     #endif
 }

--- a/MeetingBarTests/Helpers/FakeEventStore.swift
+++ b/MeetingBarTests/Helpers/FakeEventStore.swift
@@ -13,6 +13,19 @@ final class FakeEventStore: EventStore {
     var stubbedCalendars: [MBCalendar]
     var stubbedEvents: [MBEvent]
 
+    /// When non-nil, `fetchAllCalendars()` throws this error.
+    var errorToThrow: Error?
+
+    /// Counts how many times `fetchAllCalendars()` has been called.
+    var fetchCalendarsCallCount = 0
+
+    /// Counts how many times `signIn(forcePrompt:)` has been called.
+    var signInCallCount = 0
+
+    /// When set, `errorToThrow` is cleared after this many failures,
+    /// allowing subsequent calls to succeed (simulates transient failures).
+    var succeedAfterFailures: Int?
+
     init(calendars: [MBCalendar] = [], events: [MBEvent] = []) {
         stubbedCalendars = calendars
         stubbedEvents = events
@@ -21,7 +34,16 @@ final class FakeEventStore: EventStore {
     // MARK: - EventStore
 
     func fetchAllCalendars() async throws -> [MBCalendar] {
-        stubbedCalendars
+        fetchCalendarsCallCount += 1
+        if let error = errorToThrow {
+            if let threshold = succeedAfterFailures,
+               fetchCalendarsCallCount > threshold {
+                // Stop throwing after enough failures
+            } else {
+                throw error
+            }
+        }
+        return stubbedCalendars
     }
 
     func fetchEventsForDateRange(
@@ -33,6 +55,8 @@ final class FakeEventStore: EventStore {
     }
 
     func refreshSources() async { /* no-op */ }
-    func signIn(forcePrompt: Bool = false) async throws { /* no-op */ }
+    func signIn(forcePrompt: Bool = false) async throws {
+        signInCallCount += 1
+    }
     func signOut() async { /* no-op */ }
 }

--- a/MeetingBarTests/RetryAndStalenessTests.swift
+++ b/MeetingBarTests/RetryAndStalenessTests.swift
@@ -1,0 +1,224 @@
+//
+//  RetryAndStalenessTests.swift
+//  MeetingBar
+//
+//  Tests for exponential backoff retry logic and staleness-based refresh gating.
+//
+
+import Combine
+import Defaults
+@testable import MeetingBar
+import XCTest
+
+// MARK: - Retry Logic Tests
+
+@MainActor
+final class RetryLogicTests: BaseTestCase {
+
+    private var cancellables = Set<AnyCancellable>()
+
+    /// When the store always throws, EventManager should retry up to 5 times
+    /// per refresh cycle and ultimately publish empty calendars/events.
+    func test_retryExhaustsAfterFiveAttempts() {
+        let store = FakeEventStore()
+        store.errorToThrow = NSError(domain: "TestError", code: 1)
+
+        let manager = EventManager(provider: store, refreshInterval: 0, baseRetryDelay: 0.01)
+
+        let exp = expectation(description: "retries exhausted")
+
+        // The init triggers at least one refresh cycle (5 attempts).
+        // Defaults observers may trigger additional cycles.
+        // We verify that fetchCalendarsCallCount is a multiple of 5
+        // (each cycle = 5 attempts) and signIn is called 4 times per cycle.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+            let cycles = store.fetchCalendarsCallCount / 5
+            XCTAssertGreaterThanOrEqual(cycles, 1,
+                           "Expected at least one full retry cycle (5 attempts)")
+            XCTAssertEqual(store.fetchCalendarsCallCount, cycles * 5,
+                           "Expected exactly 5 fetch attempts per cycle")
+            XCTAssertEqual(store.signInCallCount, cycles * 4,
+                           "Expected 4 signIn calls per cycle (retries 2-5)")
+            exp.fulfill()
+        }
+
+        wait(for: [exp], timeout: 5.0)
+    }
+
+    /// When the store fails transiently and then recovers, EventManager should
+    /// publish the successful result after retrying.
+    func test_retrySucceedsAfterTransientFailures() {
+        let fakeCal = MBCalendar(title: "Work", id: "work_cal", source: nil, email: nil, color: .blue)
+        let fakeEvt = makeFakeEvent(
+            id: "retry_event",
+            start: Date().addingTimeInterval(60),
+            end: Date().addingTimeInterval(3600)
+        )
+
+        let store = FakeEventStore(calendars: [fakeCal], events: [fakeEvt])
+        store.errorToThrow = NSError(domain: "TestError", code: 1)
+        store.succeedAfterFailures = 3  // fail 3 times, then succeed on attempt 4
+
+        Defaults[.selectedCalendarIDs] = ["work_cal"]
+
+        let manager = EventManager(provider: store, refreshInterval: 0, baseRetryDelay: 0.01)
+
+        let calExp = expectation(description: "calendars published after retry")
+        manager.$calendars
+            .drop(while: \.isEmpty)
+            .first()
+            .sink { cals in
+                XCTAssertEqual(cals.count, 1)
+                XCTAssertEqual(cals.first?.id, "work_cal")
+                calExp.fulfill()
+            }
+            .store(in: &cancellables)
+
+        let evtExp = expectation(description: "events published after retry")
+        manager.$events
+            .drop(while: \.isEmpty)
+            .first()
+            .sink { evts in
+                XCTAssertEqual(evts.count, 1)
+                XCTAssertEqual(evts.first?.id, "retry_event")
+                evtExp.fulfill()
+            }
+            .store(in: &cancellables)
+
+        wait(for: [calExp, evtExp], timeout: 5.0)
+
+        // At least one cycle succeeded: 3 failures + 1 success = 4 calls minimum
+        XCTAssertGreaterThanOrEqual(store.fetchCalendarsCallCount, 4,
+                       "Expected at least 4 fetch attempts (3 failures + 1 success)")
+        // signIn called on retries only (at least attempts 2, 3) = at least 2 per cycle
+        XCTAssertGreaterThanOrEqual(store.signInCallCount, 2,
+                       "Expected signIn to be called on retry attempts")
+    }
+
+    /// When the store succeeds on first try, no retries or signIn calls happen.
+    func test_noRetryOnSuccess() {
+        let fakeCal = MBCalendar(title: "Cal", id: "cal1", source: nil, email: nil, color: .red)
+        let fakeEvt = makeFakeEvent(
+            id: "ok_event",
+            start: Date().addingTimeInterval(60),
+            end: Date().addingTimeInterval(3600)
+        )
+
+        let store = FakeEventStore(calendars: [fakeCal], events: [fakeEvt])
+        Defaults[.selectedCalendarIDs] = ["cal1"]
+
+        let manager = EventManager(provider: store, refreshInterval: 0, baseRetryDelay: 0.01)
+
+        let exp = expectation(description: "events published without retry")
+        manager.$events
+            .drop(while: \.isEmpty)
+            .first()
+            .sink { evts in
+                XCTAssertEqual(evts.count, 1)
+                exp.fulfill()
+            }
+            .store(in: &cancellables)
+
+        wait(for: [exp], timeout: 2.0)
+
+        // Only 1 call, no retries
+        XCTAssertEqual(store.fetchCalendarsCallCount, 1)
+        // signIn is never called when the first attempt succeeds
+        XCTAssertEqual(store.signInCallCount, 0)
+    }
+}
+
+// MARK: - Staleness Tests
+
+@MainActor
+final class StalenessTests: BaseTestCase {
+
+    private var cancellables = Set<AnyCancellable>()
+
+    /// triggerRefresh should skip if the last refresh was recent (within 15 min).
+    func test_triggerRefreshSkipsWhenFresh() {
+        let store = FakeEventStore(
+            calendars: [MBCalendar(title: "C", id: "c1", source: nil, email: nil, color: .black)],
+            events: [makeFakeEvent(id: "S1", start: Date().addingTimeInterval(60), end: Date().addingTimeInterval(3600))]
+        )
+        Defaults[.selectedCalendarIDs] = ["c1"]
+
+        let manager = EventManager(provider: store, refreshInterval: 0, baseRetryDelay: 0.01)
+
+        // Wait for initial load to complete
+        let initialExp = expectation(description: "initial load")
+        manager.$events
+            .drop(while: \.isEmpty)
+            .first()
+            .sink { _ in initialExp.fulfill() }
+            .store(in: &cancellables)
+        wait(for: [initialExp], timeout: 2.0)
+
+        let countAfterInitial = store.fetchCalendarsCallCount
+
+        // Simulate a recent refresh by setting lastSuccessfulRefresh to now
+        manager.setLastSuccessfulRefresh(Date())
+
+        // Now swap events so we can detect if a refresh actually happens
+        store.stubbedEvents = [makeFakeEvent(id: "S2", start: Date().addingTimeInterval(120), end: Date().addingTimeInterval(7200))]
+
+        // triggerRefresh should be a no-op since we just refreshed
+        manager.triggerRefresh()
+
+        // Give some time for a potential (unwanted) refresh
+        let skipExp = expectation(description: "no refresh happened")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            // fetchCalendarsCallCount should not have increased
+            XCTAssertEqual(store.fetchCalendarsCallCount, countAfterInitial,
+                           "Expected no additional fetch when data is fresh")
+            // Events should still be S1, not S2
+            XCTAssertEqual(manager.events.first?.id, "S1",
+                           "Events should not have changed when refresh was skipped")
+            skipExp.fulfill()
+        }
+        wait(for: [skipExp], timeout: 2.0)
+    }
+
+    /// triggerRefresh should proceed when data is stale (last refresh > 15 min ago).
+    func test_triggerRefreshProceedsWhenStale() {
+        let store = FakeEventStore(
+            calendars: [MBCalendar(title: "C", id: "c1", source: nil, email: nil, color: .black)],
+            events: [makeFakeEvent(id: "Old", start: Date().addingTimeInterval(60), end: Date().addingTimeInterval(3600))]
+        )
+        Defaults[.selectedCalendarIDs] = ["c1"]
+
+        let manager = EventManager(provider: store, refreshInterval: 0, baseRetryDelay: 0.01)
+
+        // Wait for initial load
+        let initialExp = expectation(description: "initial load")
+        manager.$events
+            .drop(while: \.isEmpty)
+            .first()
+            .sink { _ in initialExp.fulfill() }
+            .store(in: &cancellables)
+        wait(for: [initialExp], timeout: 2.0)
+
+        // Simulate stale data: last refresh was 20 minutes ago
+        manager.setLastSuccessfulRefresh(Date().addingTimeInterval(-1200))
+
+        // Swap to new events
+        let newEvt = makeFakeEvent(id: "New", start: Date().addingTimeInterval(120), end: Date().addingTimeInterval(7200))
+        store.stubbedEvents = [newEvt]
+
+        // triggerRefresh should actually fire since data is stale
+        let refreshExp = expectation(description: "stale refresh happened")
+        manager.$events
+            .dropFirst()
+            .first()
+            .sink { evts in
+                XCTAssertEqual(evts.first?.id, "New",
+                               "Expected new events after stale triggerRefresh")
+                refreshExp.fulfill()
+            }
+            .store(in: &cancellables)
+
+        manager.triggerRefresh()
+
+        wait(for: [refreshExp], timeout: 2.0)
+    }
+}


### PR DESCRIPTION
## Problem

When MeetingBar uses Google Calendar as the data source, the connection often "drops" overnight. After waking the Mac in the morning, no meetings are displayed. Users have to manually go to Preferences → Calendars, switch to macOS Calendar, switch back to Google Calendar, and re-select their calendars to restore functionality.

## Root Cause

Two issues were identified:

1. **No refresh on wake/unlock:** When the Mac sleeps overnight and the user unlocks it in the morning, nothing triggers an event refresh. The 180-second Combine timer gets suspended during sleep and may not fire reliably or immediately on wake.

2. **Silent failure on auth errors:** When a refresh fails (e.g., expired OAuth token after overnight sleep), the error is logged but the result is silently set to empty arrays — showing zero calendars and zero events with no user feedback.

## Solution

### Wake/Unlock Refresh
- `unlockListener` now triggers `eventManager.triggerRefresh()` on screen unlock
- Added `NSWorkspace.didWakeNotification` observer as a belt-and-suspenders for system wake (covers Touch ID auto-unlock and other edge cases)
- `triggerRefresh()` includes a **15-minute staleness check** to avoid redundant API calls on quick lock/unlock cycles

### Exponential Backoff Retry
- Replaced the "try once, silently return empty" logic with `fetchWithRetry()`
- Retries up to **5 times** with exponential backoff: 2s → 4s → 8s → 16s → 32s
- On each retry, calls `provider.signIn(forcePrompt: false)` to re-authenticate (triggering AppAuth's token refresh)
- After all retries are exhausted, sends a **macOS notification** alerting the user instead of silently showing no events

### Test Infrastructure
- Added `XCTest` guard in `applicationDidFinishLaunching` to prevent the app UI from launching during tests
- Suppressed macOS notifications during test runs
- Extended `FakeEventStore` with error injection and call counting for retry testing
- Added comprehensive tests: retry exhaustion, transient failure recovery, no-retry on success, staleness skip, and staleness proceed

## Files Changed

| File | Change |
|------|--------|
| `MeetingBar/App/AppDelegate.swift` | Wake/unlock refresh triggers, XCTest guard |
| `MeetingBar/Core/Managers/EventManager.swift` | Retry logic, staleness check, triggerRefresh() |
| `MeetingBarTests/Helpers/FakeEventStore.swift` | Error injection support for testing |
| `MeetingBarTests/RetryAndStalenessTests.swift` | 5 new tests |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calendar events now automatically refresh when your computer wakes up or is unlocked
  * Automatic retry mechanism for failed event fetches to improve reliability
  * Smart refresh optimization to avoid redundant updates within recent time windows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->