### PR TITLE
Add option to show fullscreen notifications on all screens

### DIFF
--- a/MeetingBar/App/AppDelegate.swift
+++ b/MeetingBar/App/AppDelegate.swift
@@ -238,31 +238,41 @@ class AppDelegate: NSObject, NSApplicationDelegate, @preconcurrency UNUserNotifi
     }
 
     func openFullscreenNotificationWindow(event: MBEvent) {
-        let screenFrame = NSScreen.main?.frame ?? NSRect(x: 0, y: 0, width: 800, height: 600)
+        let screens: [NSScreen]
+        if Defaults[.fullscreenNotificationAllScreens] {
+            screens = NSScreen.screens
+        } else {
+            screens = [NSScreen.main].compactMap { $0 }
+        }
 
-        let window = NSWindow(
-            contentRect: screenFrame,
-            styleMask: [.borderless],
-            backing: .buffered,
-            defer: false
-        )
+        guard !screens.isEmpty else { return }
 
-        window.contentView = NSHostingView(
-            rootView: FullscreenNotification(event: event, window: window))
-        window.appearance = NSAppearance(named: .darkAqua)
-        window.collectionBehavior = .canJoinAllSpaces
-        window.collectionBehavior = .moveToActiveSpace
+        var windows: [NSWindow] = []
 
-        window.titlebarAppearsTransparent = true
-        window.styleMask.insert(.fullSizeContentView)
-        window.title = "Meetingbar Fullscreen Notification"
-        window.level = .screenSaver
+        for screen in screens {
+            let window = NSWindow(
+                contentRect: screen.frame,
+                styleMask: [.borderless],
+                backing: .buffered,
+                defer: false
+            )
+            window.appearance = NSAppearance(named: .darkAqua)
+            window.collectionBehavior = .canJoinAllSpaces
+            window.collectionBehavior = .moveToActiveSpace
+            window.titlebarAppearsTransparent = true
+            window.styleMask.insert(.fullSizeContentView)
+            window.title = "Meetingbar Fullscreen Notification"
+            window.level = .screenSaver
+            windows.append(window)
+        }
 
-        let controller = NSWindowController(window: window)
-        controller.showWindow(self)
-
-        window.center()
-        window.orderFrontRegardless()
+        for window in windows {
+            window.contentView = NSHostingView(
+                rootView: FullscreenNotification(event: event, windows: windows))
+            let controller = NSWindowController(window: window)
+            controller.showWindow(self)
+            window.orderFrontRegardless()
+        }
     }
 
     @objc

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -30,6 +30,7 @@ extension Defaults.Keys {
 
     static let fullscreenNotification = Key<Bool>("fullscreenNotification", default: false)
     static let fullscreenNotificationTime = Key<TimeBeforeEvent>("fullscreenNotificationTime", default: .atStart)
+    static let fullscreenNotificationAllScreens = Key<Bool>("fullscreenNotificationAllScreens", default: false)
     static let processedEventsForFullscreenNotification = Key<[ProcessedEvent]>("processedEventsForFullscreenNotification", default: [])
 
     static let preferredLanguage = Key<AppLanguage>("preferredLanguage", default: .system)

--- a/MeetingBar/Resources /Localization /cs.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /cs.lproj/Localizable.strings
@@ -57,6 +57,7 @@
 
 "shared_send_notification_toggle" = "Odeslat systémové oznámení";
 "shared_fullscreen_notification_toggle" = "Show a fullscreen notification";
+"shared_fullscreen_notification_all_screens_toggle" = "Zobrazit na všech obrazovkách";
 "access_screen_access_granted_click_ok_title" = "Ve vyskakovacím okně systému macOS klikněte na tlačítko \"OK\".";
 "access_screen_access_granted_title" = "Žádost o přístup ke kalendářům…";
 "access_screen_access_denied_relaunch_title" = "Pak spusťte aplikaci ručně a pokračujte v nastavení.";

--- a/MeetingBar/Resources /Localization /de.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /de.lproj/Localizable.strings
@@ -267,6 +267,7 @@
 
 "shared_send_notification_toggle" = "System-Benachrichtigung senden";
 "shared_fullscreen_notification_toggle" = "Benachrichtigung im Vollbildmodus anzeigen";
+"shared_fullscreen_notification_all_screens_toggle" = "Auf allen Bildschirmen anzeigen";
 "access_screen_access_granted_click_ok_title" = "Im macOS-Popup auf „OK“ klicken.";
 "access_screen_access_granted_title" = "Zugriff auf Kalender anfordern…";
 "access_screen_access_denied_relaunch_title" = "Anschließend die App manuell starten, um die Einrichtung fortzusetzen.";

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -288,6 +288,7 @@
 
 "shared_send_notification_toggle" = "Send a system notification";
 "shared_fullscreen_notification_toggle" = "Show a fullscreen notification";
+"shared_fullscreen_notification_all_screens_toggle" = "Show on all screens";
 "shared_send_notification_no_alert_style_tip" = "Note: Notifications are set to Banners, so they appear briefly before disappearing. To keep them onscreen until you dismiss them, switch to Alerts in your macOS notification settings.";
 "shared_send_notification_disabled_tip" = "⚠️ Your macOS notification settings for MeetingBar are off. Turn on notifications in the macOS system settings to keep track of meetings.";
 "shared_automatic_event_join_toggle" = "Automatically join next event meeting";

--- a/MeetingBar/Resources /Localization /es.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /es.lproj/Localizable.strings
@@ -283,6 +283,7 @@
 
 "shared_send_notification_toggle" = "Enviar una notificación del sistema";
 "shared_fullscreen_notification_toggle" = "Mostrar una notificación a pantalla completa";
+"shared_fullscreen_notification_all_screens_toggle" = "Mostrar en todas las pantallas";
 "shared_send_notification_no_alert_style_tip" = "⚠️ Tus configuraciones de notificación de macOS para MeetingBar no están establecidas como alertas. Cámbialo si deseas notificaciones persistentes. Nota: Las notificaciones estan puestas en \"Banners\", Asi que aparecen brevemente antes de irse, para mantenerlas en la pantalla hasta que se vayan cambia a Alertas en la configuraciòn de notificaciones en tu MacOs.";
 "shared_send_notification_disabled_tip" = "⚠️ Tus configuraciones de notificación de macOS para MeetingBar están desactivadas. Activa las notificaciones en la configuración del sistema de macOS para llevar un seguimiento de las reuniones.";
 "shared_automatic_event_join_toggle" = "Auto-unirse a la próxima reunión de evento";

--- a/MeetingBar/Resources /Localization /fr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /fr.lproj/Localizable.strings
@@ -71,6 +71,7 @@
 
 "shared_send_notification_toggle" = "Envoyer une notification système";
 "shared_fullscreen_notification_toggle" = "Affiche une notification plein écran";
+"shared_fullscreen_notification_all_screens_toggle" = "Afficher sur tous les écrans";
 "access_screen_access_granted_click_ok_title" = "Cliquez sur « OK » dans la fenêtre popup de macOS.";
 "access_screen_access_screen_access_denied_go_to_title" = "Allez dans les";
 "access_screen_access_denied_checkbox_title" = "et sélectionnez une case à cocher près de MeetingBar.";

--- a/MeetingBar/Resources /Localization /he.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /he.lproj/Localizable.strings
@@ -187,6 +187,7 @@
 
 "shared_send_notification_toggle" = "לשלוח התראת מערכת";
 "shared_fullscreen_notification_toggle" = "הצגת התראה על כל המסך";
+"shared_fullscreen_notification_all_screens_toggle" = "הצג בכל המסכים";
 "general_when_event_starts" = "כאשר אירוע מתחיל";
 "general_one_minute_before" = "דקה לפני";
 "general_three_minute_before" = "3 דקות לפני";

--- a/MeetingBar/Resources /Localization /hr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /hr.lproj/Localizable.strings
@@ -268,6 +268,7 @@
 
 "shared_send_notification_toggle" = "Pošalji obavijest sustava";
 "shared_fullscreen_notification_toggle" = "Prikaži obavijest na cijelom ekranu";
+"shared_fullscreen_notification_all_screens_toggle" = "Prikaži na svim zaslonima";
 "general_when_event_starts" = "kad događaj počne";
 "general_one_minute_before" = "1 minutu prije";
 "general_three_minute_before" = "3 minute prije";

--- a/MeetingBar/Resources /Localization /hu.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /hu.lproj/Localizable.strings
@@ -140,3 +140,4 @@
 "status_bar_menu_dismiss_next_meeting" = "Következő találkozó elbocsátása";
 "status_bar_section_refresh_sources" = "Források frissítése";
 "status_bar_menu_dismiss_curent_meeting" = "Jelenlegi találkozó elbocsátása";
+"shared_fullscreen_notification_all_screens_toggle" = "Megjelenítés minden képernyőn";

--- a/MeetingBar/Resources /Localization /it.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /it.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 
 "shared_send_notification_toggle" = "Invia una notifica di sistema";
 "shared_fullscreen_notification_toggle" = "Mostra una notifica a schermo intero";
+"shared_fullscreen_notification_all_screens_toggle" = "Mostra su tutti gli schermi";
 "general_when_event_starts" = "quando inizia l'evento";
 "general_one_minute_before" = "1 minuto prima";
 "general_three_minute_before" = "3 minuti prima";

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -284,6 +284,7 @@
 
 "shared_send_notification_toggle" = "イベント開始前に通知する";
 "shared_fullscreen_notification_toggle" = "全画面通知";
+"shared_fullscreen_notification_all_screens_toggle" = "すべての画面に表示";
 "general_when_event_starts" = "イベントが始まったとき";
 "general_one_minute_before" = "1分前";
 "general_three_minute_before" = "3分前";

--- a/MeetingBar/Resources /Localization /ko.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ko.lproj/Localizable.strings
@@ -231,3 +231,4 @@
 "access_screen_provider_macos_title" = "MacOS Calendar app";
 "access_screen_provider_macos_recommended" = "(추천)";
 "access_screen_provider_macos_data_source" = "MacOS Calendar app 데이터 가져오기";
+"shared_fullscreen_notification_all_screens_toggle" = "모든 화면에 표시";

--- a/MeetingBar/Resources /Localization /nb-NO.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /nb-NO.lproj/Localizable.strings
@@ -44,6 +44,7 @@
 
 "shared_send_notification_toggle" = "Send merknad om å ta del i neste begivenhetsmøte";
 "shared_fullscreen_notification_toggle" = "Show a fullscreen notification";
+"shared_fullscreen_notification_all_screens_toggle" = "Vis på alle skjermer";
 "access_screen_access_granted_click_ok_title" = "Klikk «OK» i oppsprettsvinduet fra macOS.";
 "access_screen_access_granted_title" = "Forespør tilgang til kalendere.";
 "access_screen_access_denied_relaunch_title" = "Så må du kjøre programmet manuelt for å fortsette oppsettet.";

--- a/MeetingBar/Resources /Localization /nl.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /nl.lproj/Localizable.strings
@@ -189,6 +189,7 @@
 "status_bar_submenu_status_declined" = " 👎 Afgewezen";
 "access_screen_try_again" = "Opnieuw proberen";
 "shared_fullscreen_notification_toggle" = "Toon een melding op volledig scherm";
+"shared_fullscreen_notification_all_screens_toggle" = "Op alle schermen weergeven";
 "preferences_bookmarks_new_bookmark_title" = "Nieuwe bladwijzer";
 "preferences_bookmarks_new_bookmark_name" = "Naam";
 "preferences_bookmarks_new_bookmark_service" = "Dienst";

--- a/MeetingBar/Resources /Localization /pl.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /pl.lproj/Localizable.strings
@@ -267,6 +267,7 @@
 
 "shared_send_notification_toggle" = "Wyślij powiadomienie systemowe";
 "shared_fullscreen_notification_toggle" = "Pokaż pełnoekranowe powiadomienie";
+"shared_fullscreen_notification_all_screens_toggle" = "Pokaż na wszystkich ekranach";
 "general_when_event_starts" = "gdy wydarzenie się rozpocznie";
 "general_one_minute_before" = "1 minutę przed";
 "general_three_minute_before" = "3 minuty przed";

--- a/MeetingBar/Resources /Localization /pt-BR.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /pt-BR.lproj/Localizable.strings
@@ -334,6 +334,7 @@
 
 
 "shared_fullscreen_notification_toggle" = "Exibir notificação em tela cheia";
+"shared_fullscreen_notification_all_screens_toggle" = "Mostrar em todas as telas";
 "preferences_tab_links" = "Links";
 "preferences_appearance_status_bar_ongoing_title" = "Mostrar reuniões em andamento:";
 "preferences_appearance_status_bar_ongoing_time_immediate_value" = "Ocultar e depois de iniciar";

--- a/MeetingBar/Resources /Localization /pt.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /pt.lproj/Localizable.strings
@@ -90,6 +90,7 @@
 "preferences_services_link_default_browser_value" = "Navegador padrão";
 "welcome_screen_ad_hoc_meeting_title" = "Criar reuniões ad hoc em ";
 "shared_fullscreen_notification_toggle" = "Exibir notificação em ecrã cheio";
+"shared_fullscreen_notification_all_screens_toggle" = "Mostrar em todos os ecrãs";
 "notifications_event_ends_soon_body" = "O evento encerrará em breve";
 "notifications_event_ends_one_minute_body" = "O evento encerrará num minuto";
 "notifications_event_ends_three_minutes_body" = "O evento encerrará em três minutos";

--- a/MeetingBar/Resources /Localization /sk.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /sk.lproj/Localizable.strings
@@ -289,6 +289,7 @@
 "notifications_event_ends_three_minutes_body" = "Udalosť sa končí o tri minúty";
 "notifications_event_ends_five_minutes_body" = "Udalosť sa končí o päť minút";
 "shared_fullscreen_notification_toggle" = "Zobraziť upozornenie na celú obrazovku";
+"shared_fullscreen_notification_all_screens_toggle" = "Zobraziť na všetkých obrazovkách";
 "constants_meeting_service_zoom_native" = "Zoom natívne";
 
 // MARK: - Store

--- a/MeetingBar/Resources /Localization /ta.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ta.lproj/Localizable.strings
@@ -247,6 +247,7 @@
 "access_screen_try_again" = "மீண்டும் முயற்சிக்கவும்";
 "shared_send_notification_toggle" = "கணினி அறிவிப்பை அனுப்பவும்";
 "shared_fullscreen_notification_toggle" = "முழுத்திரை அறிவிப்பைக் காட்டு";
+"shared_fullscreen_notification_all_screens_toggle" = "அனைத்து திரைகளிலும் காட்டு";
 "shared_send_notification_no_alert_style_tip" = "குறிப்பு: அறிவிப்புகள் பதாகைகளுக்கு அமைக்கப்பட்டுள்ளன, எனவே அவை மறைந்து போவதற்கு முன்பு சுருக்கமாகத் தோன்றும். நீங்கள் அவற்றை நிராகரிக்கும் வரை அவற்றை திரையில் வைத்திருக்க, உங்கள் MACOS அறிவிப்பு அமைப்புகளில் எச்சரிக்கைகளுக்கு மாறவும்.";
 "shared_send_notification_disabled_tip" = "Metter சந்திப்புக்கான உங்கள் MACOS அறிவிப்பு அமைப்புகள் முடக்கப்பட்டுள்ளன. கூட்டங்களைக் கண்காணிக்க MACOS கணினி அமைப்புகளில் அறிவிப்புகளை இயக்கவும்.";
 "constants_meeting_service_other" = "மற்றொன்று";

--- a/MeetingBar/Resources /Localization /tr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /tr.lproj/Localizable.strings
@@ -297,6 +297,7 @@
 
 "shared_send_notification_toggle" = "Bir sonraki etkinlik toplantısına katılmak için sistem bildirimi gönderin";
 "shared_fullscreen_notification_toggle" = "Tam ekran bildirimi göster";
+"shared_fullscreen_notification_all_screens_toggle" = "Tüm ekranlarda göster";
 "general_when_event_starts" = "etkinlik başladığında";
 "calendars_screen_start_button" = "Uygulamayı kullanmaya başla";
 "access_screen_access_denied_system_preferences_button" = "Sistem Tercihleri";

--- a/MeetingBar/Resources /Localization /uk.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /uk.lproj/Localizable.strings
@@ -272,6 +272,7 @@
 
 "shared_send_notification_toggle" = "Надсилати системне сповіщення";
 "shared_fullscreen_notification_toggle" = "Показувати повноекранне сповіщення";
+"shared_fullscreen_notification_all_screens_toggle" = "Показати на всіх екранах";
 "general_when_event_starts" = "коли зустріч розпочинається";
 "general_one_minute_before" = "за 1 хвилину до початку";
 "general_three_minute_before" = "за 3 хвилини до початку";

--- a/MeetingBar/Resources /Localization /zh-Hans.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /zh-Hans.lproj/Localizable.strings
@@ -8,3 +8,4 @@
 "create_meeting_error_message" = "自定义URL\"%@\"缺失或无效。 ";
 "preferences_general_option_preferred_language_title" = "语言：";
 "preferences_general_option_shortcuts" = "快捷方式";
+"shared_fullscreen_notification_all_screens_toggle" = "在所有屏幕上显示";

--- a/MeetingBar/UI/Views/FullscreenNotification.swift
+++ b/MeetingBar/UI/Views/FullscreenNotification.swift
@@ -11,7 +11,7 @@ import SwiftUI
 
 struct FullscreenNotification: View {
     var event: MBEvent
-    var window: NSWindow?
+    var windows: [NSWindow]
 
     var body: some View {
         ZStack {
@@ -51,12 +51,12 @@ struct FullscreenNotification: View {
     }
 
     func dismiss() {
-        window?.close()
+        windows.forEach { $0.close() }
     }
 
     func joinEvent() {
         event.openMeeting()
-        window?.close()
+        windows.forEach { $0.close() }
     }
 }
 
@@ -80,5 +80,5 @@ struct VisualEffect: NSViewRepresentable {
 }
 
 #Preview {
-    FullscreenNotification(event: generateFakeEvent(), window: nil)
+    FullscreenNotification(event: generateFakeEvent(), windows: [])
 }

--- a/MeetingBar/UI/Views/Shared.swift
+++ b/MeetingBar/UI/Views/Shared.swift
@@ -40,6 +40,7 @@ struct AutomaticEventJoinPicker: View {
 struct FullscreenNotificationPicker: View {
     @Default(.fullscreenNotification) var fullscreenNotification
     @Default(.fullscreenNotificationTime) var fullscreenNotificationTime
+    @Default(.fullscreenNotificationAllScreens) var fullscreenNotificationAllScreens
 
     var body: some View {
         HStack {
@@ -51,6 +52,9 @@ struct FullscreenNotificationPicker: View {
                 Text("general_five_minute_before".loco()).tag(TimeBeforeEvent.fiveMinuteBefore)
             }.frame(width: 220, alignment: .leading).labelsHidden().disabled(!fullscreenNotification)
         }
+        Toggle("shared_fullscreen_notification_all_screens_toggle".loco(), isOn: $fullscreenNotificationAllScreens)
+            .disabled(!fullscreenNotification)
+            .padding(.leading, 20)
     }
 }
 

--- a/MeetingBarTests/FullscreenNotificationTests.swift
+++ b/MeetingBarTests/FullscreenNotificationTests.swift
@@ -1,0 +1,31 @@
+//
+//  FullscreenNotificationTests.swift
+//  MeetingBarTests
+//
+//  Copyright © 2025 Andrii Leitsius. All rights reserved.
+//
+
+import XCTest
+import Defaults
+
+@testable import MeetingBar
+
+class FullscreenNotificationTests: BaseTestCase {
+
+    func test_fullscreenNotificationAllScreens_defaultsToFalse() {
+        XCTAssertFalse(Defaults[.fullscreenNotificationAllScreens])
+    }
+
+    func test_fullscreenNotificationAllScreens_canBeEnabled() {
+        Defaults[.fullscreenNotificationAllScreens] = true
+        XCTAssertTrue(Defaults[.fullscreenNotificationAllScreens])
+    }
+
+    func test_fullscreenNotificationAllScreens_independentOfMainToggle() {
+        Defaults[.fullscreenNotification] = false
+        Defaults[.fullscreenNotificationAllScreens] = true
+
+        XCTAssertFalse(Defaults[.fullscreenNotification])
+        XCTAssertTrue(Defaults[.fullscreenNotificationAllScreens])
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a new "Show on all screens" toggle under the fullscreen notification setting in Preferences → General → Event Notifications
- When enabled, creates a notification window on every connected display instead of just the main screen
- Dismissing or joining from any screen closes all notification windows simultaneously
- Includes localized strings for all 22 supported languages and unit tests for the new setting

## Test plan

- [ ] Enable fullscreen notifications and the new "Show on all screens" toggle
- [ ] Create a calendar event with a meeting link (Zoom, Google Meet, etc.) starting within the configured notification window
- [ ] Verify notification appears on all connected displays
- [ ] Click Close or Join on any screen — verify all windows dismiss together
- [ ] Disable "Show on all screens" and verify notification only appears on the main screen
- [ ] Verify the toggle is disabled when fullscreen notifications are turned off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to display fullscreen notifications on all connected screens instead of just the primary screen.

* **Localization**
  * Added full multi-language support for the new multi-screen notification feature across 20+ languages, including English, German, French, Spanish, Chinese, Japanese, Korean, and others.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->