### PR TITLE
feat: add support for multiple Google Calendar accounts

### DIFF
--- a/MeetingBar/Core/EventStores/GCEventStore.swift
+++ b/MeetingBar/Core/EventStores/GCEventStore.swift
@@ -8,6 +8,7 @@
 
 import AppAuthCore
 import AppKit
+import Defaults
 import Foundation
 
 let googleClientNumber = Bundle.main.object(forInfoDictionaryKey: "GOOGLE_CLIENT_NUMBER") as! String
@@ -22,13 +23,11 @@ enum AuthError: Error {
 }
 
 extension OIDAuthState {
-    /// token is considered fresh if it expires later than 300 seconds from now
     var isTokenFresh: Bool {
         guard let exp = lastTokenResponse?.accessTokenExpirationDate else { return false }
         return exp > Date().addingTimeInterval(300)
     }
 
-    /// convenience email extraction from ID token
     var userEmail: String? {
         guard let idToken = lastTokenResponse?.idToken else { return nil }
         let parts = idToken.split(separator: ".")
@@ -53,23 +52,20 @@ final class GCEventStore: NSObject,
     private static let kClientID     = "\(googleClientNumber).apps.googleusercontent.com"
     private static let kClientSecret = googleClientSecret
     private static let kRedirectURI  = "com.googleusercontent.apps.\(googleClientNumber):/oauthredirect"
-    private static let kKeychainName = googleAuthKeychainName
 
     // MARK: Stored properties
     @MainActor var currentAuthorizationFlow: OIDExternalUserAgentSession?
-    private(set) var userEmail: String?
+    @MainActor var pendingAuthAccountId: String?
 
-    private var authState: OIDAuthState? {
-        didSet {
-            // ensure delegates always set
-            authState?.stateChangeDelegate = self
-            authState?.errorDelegate       = self
-            persistAuthState()
-        }
+    private var accounts: [GoogleAccount] {
+        get { Defaults[.googleAccounts] }
+        set { Defaults[.googleAccounts] = newValue }
     }
 
+    private var authStates: [String: OIDAuthState] = [:]
+
     private var signInTask: Task<Void, Error>?
-    private var refreshTask: Task<String, Error>?
+    private var refreshTask: [String: Task<String, Error>] = [:]
 
     // Shared URLSession to leverage connection reuse
     private static let session: URLSession = {
@@ -84,39 +80,29 @@ final class GCEventStore: NSObject,
     static let shared = GCEventStore()
     private override init() {
         super.init()
-        self.authState = restoreAuthState()
-        // delegates were set in didSet, but set them again just in case restore returned nil
-        self.authState?.stateChangeDelegate = self
-        self.authState?.errorDelegate       = self
+        restoreAllAuthStates()
     }
 
     // MARK: Public API
 
-    func signIn(forcePrompt: Bool = false) async throws {
-        // if already authorised, nothing to do
-        if authState?.isAuthorized == true { return }
+    func getAccounts() -> [GoogleAccount] {
+        return accounts
+    }
 
-        // discover configuration for Google issuer
+    func addAccount() async throws -> GoogleAccount {
+        let accountId = UUID().uuidString
+
         let config = try await withCheckedThrowingContinuation { cont in
             OIDAuthorizationService.discoverConfiguration(forIssuer: URL(string: Self.kIssuer)!) { cfg, err in
                 if let cfg { cont.resume(returning: cfg) } else { cont.resume(throwing: err ?? NSError(domain: "GoogleSignIn", code: -1)) }
             }
         }
 
-        // request scopes we need
         let scopes = [
             "email",
             "https://www.googleapis.com/auth/calendar.calendarlist.readonly",
             "https://www.googleapis.com/auth/calendar.events.readonly"
         ]
-
-        // additional parameters to be sure we get refresh_token
-        var extra = [
-            "access_type": "offline"
-        ]
-        if forcePrompt {
-            extra["prompt"] = "consent"
-        }
 
         let request = OIDAuthorizationRequest(
             configuration: config,
@@ -125,36 +111,38 @@ final class GCEventStore: NSObject,
             scopes: scopes,
             redirectURL: URL(string: Self.kRedirectURI)!,
             responseType: OIDResponseTypeCode,
-            additionalParameters: extra
+            additionalParameters: ["access_type": "offline"]
         )
 
-        try await withCheckedThrowingContinuation { cont in
-            self.currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request,
-                                                                   externalUserAgent: self) { [weak self] state, error in
+        let account = try await withCheckedThrowingContinuation { cont in
+            pendingAuthAccountId = accountId
+            currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request,
+                                                               externalUserAgent: self) { [weak self] state, error in
                 guard let self else { return }
-                if let state {
-                    self.authState = state    // didSet handles persistence & delegates
-                    self.userEmail = state.userEmail
-                    sendNotification("Google Account connected", "\(self.userEmail ?? "") is connected")
-                    cont.resume()
+                self.pendingAuthAccountId = nil
+                self.currentAuthorizationFlow = nil
+
+                if let state, let email = state.userEmail {
+                    let account = GoogleAccount(id: accountId, email: email)
+                    self.authStates[accountId] = state
+                    state.stateChangeDelegate = self
+                    state.errorDelegate = self
+                    self.persistAuthState(for: account)
+                    self.accounts.append(account)
+                    sendNotification("Google Account connected", "\(email) is connected")
+                    cont.resume(returning: account)
                 } else {
                     cont.resume(throwing: error ?? NSError(domain: "GoogleSignIn", code: 1))
                 }
             }
         }
+
+        return account
     }
 
-    func signOut() async {
-        guard let state = authState else { return }
+    func removeAccount(_ account: GoogleAccount) async {
+        guard let state = authStates[account.id] else { return }
 
-        if let flow = currentAuthorizationFlow {
-                currentAuthorizationFlow = nil
-                await MainActor.run { flow.cancel() }
-            } else {
-                currentAuthorizationFlow = nil
-            }
-
-        // Revoke tokens in parallel
         let access  = state.lastTokenResponse?.accessToken
         let refresh = state.lastTokenResponse?.refreshToken
         await withTaskGroup(of: Void.self) { grp in
@@ -162,38 +150,61 @@ final class GCEventStore: NSObject,
             if let ref = refresh { grp.addTask { try? await self.revoke(token: ref) } }
         }
 
-        clearAuthState()
+        authStates.removeValue(forKey: account.id)
+        accounts.removeAll { $0.id == account.id }
+        Keychain.delete(for: accountKeychainKey(accountId: account.id))
+    }
+
+    func signIn(forcePrompt: Bool = false) async throws {
+        if !accounts.isEmpty { return }
+        _ = try await addAccount()
+    }
+
+    func signOut() async {
+        for account in accounts {
+            await removeAccount(account)
+        }
     }
 
     func refreshSources() async {}
 
     func fetchAllCalendars() async throws -> [MBCalendar] {
-        try await ensureSignedIn()
+        var allCalendars: [MBCalendar] = []
 
-        let url = URL(string: "https://www.googleapis.com/calendar/v3/users/me/calendarList?maxResults=250&showHidden=true")!
-        let items = try await fetchJSON(url)
+        for account in accounts {
+            guard let state = authStates[account.id], state.isAuthorized else { continue }
 
-        return items.compactMap { item -> MBCalendar? in
-            guard let title = item["summary"] as? String,
-                  let calendarID = item["id"] as? String,
-                  let backgroundColor = item["backgroundColor"] as? String else { return nil }
+            let url = URL(string: "https://www.googleapis.com/calendar/v3/users/me/calendarList?maxResults=250&showHidden=true")!
+            let items = try await fetchJSON(url, forAccount: account.id)
 
-            return MBCalendar(title: title,
-                              id: calendarID,
-                              source: userEmail,
-                              email: userEmail,
-                              color: hexStringToUIColor(hex: backgroundColor))
+            let calendars = items.compactMap { item -> MBCalendar? in
+                guard let title = item["summary"] as? String,
+                      let calendarID = item["id"] as? String,
+                      let backgroundColor = item["backgroundColor"] as? String else { return nil }
+
+                let prefixedCalendarId = "\(account.id):\(calendarID)"
+                return MBCalendar(title: title,
+                                  id: prefixedCalendarId,
+                                  source: account.email,
+                                  email: account.email,
+                                  color: hexStringToUIColor(hex: backgroundColor))
+            }
+            allCalendars.append(contentsOf: calendars)
         }
+
+        return allCalendars
     }
 
     private func getCalendarEventsForDateRange(calendar: MBCalendar,
+                                               accountId: String,
                                                dateFrom: Date,
                                                dateTo: Date) async throws -> [MBEvent] {
         let iso = ISO8601DateFormatter()
         let timeMin = iso.string(from: dateFrom)
         let timeMax = iso.string(from: dateTo)
 
-        var comps = URLComponents(string: "https://www.googleapis.com/calendar/v3/calendars/\(calendar.id)/events")!
+        let originalCalendarId = String(calendar.id.dropFirst("\(accountId):".count))
+        var comps = URLComponents(string: "https://www.googleapis.com/calendar/v3/calendars/\(originalCalendarId)/events")!
         comps.queryItems = [
             .init(name: "singleEvents", value: "true"),
             .init(name: "orderBy", value: "startTime"),
@@ -202,43 +213,45 @@ final class GCEventStore: NSObject,
             .init(name: "timeMin", value: timeMin)
         ]
 
-        let items = try await fetchJSON(comps.url!)
+        let items = try await fetchJSON(comps.url!, forAccount: accountId)
         return items.compactMap { GCParser.event(from: $0, calendar: calendar) }
     }
 
     func fetchEventsForDateRange(for calendars: [MBCalendar],
                                  from: Date,
                                  to: Date) async throws -> [MBEvent] {
-        try await ensureSignedIn()
         var result: [MBEvent] = []
-        for cal in calendars {
-            let ev = try await getCalendarEventsForDateRange(calendar: cal, dateFrom: from, dateTo: to)
-            result.append(contentsOf: ev)
+
+        let calendarsByAccount = Dictionary(grouping: calendars) { calendar in
+            calendar.id.components(separatedBy: ":").first ?? ""
         }
+
+        for (accountId, accountCalendars) in calendarsByAccount {
+            guard let state = authStates[accountId], state.isAuthorized else { continue }
+
+            for cal in accountCalendars {
+                let ev = try await getCalendarEventsForDateRange(calendar: cal, accountId: accountId, dateFrom: from, dateTo: to)
+                result.append(contentsOf: ev)
+            }
+        }
+
         return result
     }
 
     // MARK: - Private helpers
-    private func ensureSignedIn() async throws {
-        if authState?.isAuthorized == true,
-           authState?.lastTokenResponse?.refreshToken != nil {
-            return
-        }
 
-        if let running = signInTask { return try await running.value }
-
-        let forceConsent = authState?.lastTokenResponse?.refreshToken == nil
-
-        let task = Task {
-            try await signIn(forcePrompt: forceConsent)
-        }
-        signInTask = task
-        defer { signInTask = nil }
-        try await task.value
+    private func accountKeychainKey(accountId: String) -> String {
+        return "\(googleAuthKeychainName)_\(accountId)"
     }
 
-    private func validAccessToken(forceRefresh: Bool = false) async throws -> String {
-        guard let state = authState else { throw AuthError.notSignedIn }
+    private func ensureAccountSignedIn(_ accountId: String) async throws {
+        guard let state = authStates[accountId] else { throw AuthError.notSignedIn }
+        if state.isAuthorized, state.lastTokenResponse?.refreshToken != nil { return }
+        throw AuthError.notSignedIn
+    }
+
+    private func validAccessToken(for accountId: String, forceRefresh: Bool = false) async throws -> String {
+        guard let state = authStates[accountId] else { throw AuthError.notSignedIn }
 
         if !forceRefresh,
            state.isTokenFresh,
@@ -246,21 +259,23 @@ final class GCEventStore: NSObject,
             return token
         }
 
-        if let running = refreshTask { return try await running.value }
+        if let running = refreshTask[accountId] { return try await running.value }
 
         let task = Task<String, Error> {
-            defer { refreshTask = nil }
+            defer { refreshTask[accountId] = nil }
             return try await withCheckedThrowingContinuation { cont in
                 if forceRefresh { state.setNeedsTokenRefresh() }
 
                 state.performAction { [weak self] accessToken, _, error in
                     guard let self else { return }
                     if let token = accessToken {
-                        cont.resume(returning: token) // stateChangeDelegate persists new tokens
+                        cont.resume(returning: token)
                     } else {
                         if let err = error as NSError?,
                            err.domain == OIDOAuthTokenErrorDomain {
-                            self.clearAuthState()
+                            if let account = self.accounts.first(where: { $0.id == accountId }) {
+                                Task { await self.removeAccount(account) }
+                            }
                         }
                         cont.resume(throwing: error ?? AuthError.refreshFailed)
                     }
@@ -268,46 +283,44 @@ final class GCEventStore: NSObject,
             }
         }
 
-        refreshTask = task
+        refreshTask[accountId] = task
         return try await task.value
     }
 
     // MARK: Keychain persistence
 
-    private func persistAuthState() {
-        guard let state = authState else {
-            Keychain.delete(for: Self.kKeychainName)
+    private func persistAuthState(for account: GoogleAccount) {
+        guard let state = authStates[account.id] else {
+            Keychain.delete(for: accountKeychainKey(accountId: account.id))
             return
         }
         do {
             let data = try NSKeyedArchiver.archivedData(withRootObject: state, requiringSecureCoding: true)
-            Keychain.save(data: data, for: Self.kKeychainName)
+            Keychain.save(data: data, for: accountKeychainKey(accountId: account.id))
         } catch {
             NSLog("Error archiving OIDAuthState: \(error)")
         }
     }
 
-    private func restoreAuthState() -> OIDAuthState? {
-        guard let data = Keychain.load(for: Self.kKeychainName) else { return nil }
-        do {
-            guard let state = try NSKeyedUnarchiver.unarchivedObject(ofClass: OIDAuthState.self, from: data) else { return nil }
-            userEmail = state.userEmail
-            return state
-        } catch {
-            NSLog("Error unarchiving OIDAuthState: \(error)")
-            return nil
+    private func restoreAllAuthStates() {
+        for account in accounts {
+            let key = accountKeychainKey(accountId: account.id)
+            guard let data = Keychain.load(for: key) else { continue }
+            do {
+                guard let state = try NSKeyedUnarchiver.unarchivedObject(ofClass: OIDAuthState.self, from: data) else { continue }
+                state.stateChangeDelegate = self
+                state.errorDelegate = self
+                authStates[account.id] = state
+            } catch {
+                NSLog("Error unarchiving OIDAuthState: \(error)")
+            }
         }
     }
 
-    private func clearAuthState() {
-        authState  = nil
-        userEmail  = nil
-        Keychain.delete(for: Self.kKeychainName)
-    }
-
     // MARK: Networking helper
-    private func fetchJSON(_ url: URL, retrying: Bool = false) async throws -> [[String: Any]] {
-        let token = try await validAccessToken()
+
+    private func fetchJSON(_ url: URL, forAccount accountId: String, retrying: Bool = false) async throws -> [[String: Any]] {
+        let token = try await validAccessToken(for: accountId)
 
         var req = URLRequest(url: url)
         req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
@@ -318,12 +331,12 @@ final class GCEventStore: NSObject,
             switch http.statusCode {
             case 401, 403:
                 if !retrying {
-                    // force-refresh and retry
-                    _ = try await validAccessToken(forceRefresh: true)
-                    return try await fetchJSON(url, retrying: true)
+                    _ = try await validAccessToken(for: accountId, forceRefresh: true)
+                    return try await fetchJSON(url, forAccount: accountId, retrying: true)
                 }
-                // refresh token revoked – force re‑login
-                clearAuthState()
+                if let account = accounts.first(where: { $0.id == accountId }) {
+                    Task { await self.removeAccount(account) }
+                }
                 throw AuthError.notSignedIn
             case 200...299:
                 break
@@ -349,20 +362,36 @@ final class GCEventStore: NSObject,
     }
 
     // MARK: - OIDAuthState Delegates
-    func didChange(_ state: OIDAuthState) {
-        // persist every change (e.g., refreshed token)
-        persistAuthState()
+
+    nonisolated func didChange(_ state: OIDAuthState) {
+        let accessToken = state.lastTokenResponse?.accessToken
+        Task { @MainActor in
+            if let account = self.accounts.first(where: { account in
+                guard let storedState = self.authStates[account.id] else { return false }
+                return storedState.lastTokenResponse?.accessToken == accessToken
+            }) {
+                self.persistAuthState(for: account)
+            }
+        }
     }
 
-    func authState(_ state: OIDAuthState, didEncounterAuthorizationError error: Error) {
+    nonisolated func authState(_ state: OIDAuthState, didEncounterAuthorizationError error: Error) {
         let nsErr = error as NSError
         if nsErr.domain == OIDOAuthTokenErrorDomain {
-            // refresh token invalid → clean state & notify
-            clearAuthState()
+            let accessToken = state.lastTokenResponse?.accessToken
+            Task { @MainActor in
+                if let account = self.accounts.first(where: { account in
+                    guard let storedState = self.authStates[account.id] else { return false }
+                    return storedState.lastTokenResponse?.accessToken == accessToken
+                }) {
+                    await self.removeAccount(account)
+                }
+            }
         }
     }
 
     // MARK: - OIDExternalUserAgent
+
     func present(_ request: OIDExternalUserAgentRequest, session _: OIDExternalUserAgentSession) -> Bool {
         if let url = request.externalUserAgentRequestURL(), NSWorkspace.shared.open(url) {
             return true

--- a/MeetingBar/Core/Managers/EventManager.swift
+++ b/MeetingBar/Core/Managers/EventManager.swift
@@ -23,6 +23,8 @@ public class EventManager: ObservableObject {
     @Published public private(set) var calendars: [MBCalendar] = []
     @Published public private(set) var events: [MBEvent] = []
 
+    static weak var shared: EventManager?
+
     var provider: EventStore
     private let refreshInterval: TimeInterval
     private var cancellables = Set<AnyCancellable>()
@@ -43,6 +45,7 @@ public class EventManager: ObservableObject {
         await configureProvider(Defaults[.eventStoreProvider])
         setupPublishers()
         refreshSubject.send() // initial load
+        EventManager.shared = self
     }
 
     public func changeEventStoreProvider(_ newProvider: EventStoreProvider, withSignOut: Bool = false) async {

--- a/MeetingBar/Core/Models/GoogleAccount.swift
+++ b/MeetingBar/Core/Models/GoogleAccount.swift
@@ -1,0 +1,20 @@
+//
+//  GoogleAccount.swift
+//  MeetingBar
+//
+//  Created for multi-account Google Calendar support.
+//  Copyright © 2026 Andrii Leitsius. All rights reserved.
+//
+
+import Defaults
+import Foundation
+
+public struct GoogleAccount: Identifiable, Codable, Hashable, Sendable, Defaults.Serializable {
+    public let id: String
+    public let email: String
+
+    public init(id: String, email: String) {
+        self.id = id
+        self.email = email
+    }
+}

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -19,6 +19,8 @@ extension Defaults.Keys {
     static let selectedCalendarIDs = Key<[String]>("selectedCalendarIDs", default: [])
     static let eventStoreProvider = Key<EventStoreProvider>("eventStoreProvider", default: .macOSEventKit)
 
+    static let googleAccounts = Key<[GoogleAccount]>("googleAccounts", default: [])
+
     static let onboardingCompleted = Key<Bool>("onboardingCompleted", default: false)
 
     static let showEventsForPeriod = Key<ShowEventsForPeriod>("showEventsForPeriod", default: .today)

--- a/MeetingBar/UI/Views/Preferences/CalendarsTab.swift
+++ b/MeetingBar/UI/Views/Preferences/CalendarsTab.swift
@@ -20,11 +20,23 @@ struct CalendarsTab: View {
                 ProviderPicker(eventManager: eventManager)
             }
             .padding(.bottom, 5)
+
+            if Defaults[.eventStoreProvider] == .googleCalendar {
+                GroupBox(label: Label("Google Accounts", systemImage: "person.3")) {
+                    GoogleAccountsSection(eventManager: eventManager)
+                }
+                .padding(.bottom, 5)
+            }
+
             Label("preferences_calendars_select_calendars_title".loco(), systemImage: "calendar").padding(5)
             List {
                 if eventManager.calendars.isEmpty {
                     if Defaults[.eventStoreProvider] == .macOSEventKit {
                         AccessDeniedBanner()
+                    } else {
+                        Text("No accounts connected. Add a Google account to get started.")
+                            .foregroundColor(.secondary)
+                            .padding()
                     }
                     Button("Refresh") {
                         Task { try await eventManager.refreshSources() }
@@ -39,10 +51,159 @@ struct CalendarsTab: View {
     }
 }
 
+struct GoogleAccountsSection: View {
+    @ObservedObject var eventManager: EventManager
+    @State private var accounts: [GoogleAccount] = []
+    @State private var showingAddAccount = false
+    @State private var accountToRemove: GoogleAccount?
+    @State private var showingRemoveConfirmation = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            if accounts.isEmpty {
+                Text("No Google accounts connected")
+                    .foregroundColor(.secondary)
+                    .font(.caption)
+            }
+
+            ForEach(accounts) { account in
+                HStack {
+                    Image(systemName: "person.circle.fill")
+                        .foregroundColor(.blue)
+                    VStack(alignment: .leading) {
+                        Text(account.email)
+                            .font(.system(size: 13))
+                        Text("Connected")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                    Spacer()
+                    Button(action: {
+                        accountToRemove = account
+                        showingRemoveConfirmation = true
+                    }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .foregroundColor(.red)
+                    }
+                    .buttonStyle(.plain)
+                    .help("Remove \(account.email)")
+                }
+                .padding(.vertical, 2)
+            }
+
+            Divider()
+
+            Button(action: {
+                showingAddAccount = true
+            }) {
+                Label("Add Google Account", systemImage: "plus.circle.fill")
+            }
+            .sheet(isPresented: $showingAddAccount) {
+                AddAccountSheet(onAccountAdded: {
+                    Task {
+                        await refreshAccounts()
+                        try? await eventManager.refreshSources()
+                    }
+                })
+            }
+        }
+        .padding(5)
+        .onAppear {
+            Task { await refreshAccounts() }
+        }
+        .onChange(of: Defaults[.googleAccounts]) { _ in
+            Task { await refreshAccounts() }
+        }
+        .confirmationDialog(
+            "Remove Account",
+            isPresented: $showingRemoveConfirmation,
+            titleVisibility: .visible,
+            presenting: accountToRemove
+        ) { account in
+            Button("Remove \(account.email)", role: .destructive) {
+                Task {
+                    await GCEventStore.shared.removeAccount(account)
+                    await refreshAccounts()
+                    try? await eventManager.refreshSources()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: { account in
+            Text("This will remove \(account.email) and all its calendars from MeetingBar. You can add it back later.")
+        }
+    }
+
+    private func refreshAccounts() async {
+        await MainActor.run {
+            accounts = Defaults[.googleAccounts]
+        }
+    }
+}
+
+struct AddAccountSheet: View {
+    @Environment(\.presentationMode) var presentationMode
+    @State private var errorMessage: String?
+    @State private var isAdding = false
+    var onAccountAdded: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Add Google Account")
+                .font(.headline)
+
+            Text("You'll be redirected to Google to sign in and grant calendar access.")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            if let error = errorMessage {
+                Text(error)
+                    .foregroundColor(.red)
+                    .font(.caption)
+            }
+
+            if isAdding {
+                ProgressView("Waiting for authentication...")
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+
+            HStack(spacing: 12) {
+                Button("Cancel") {
+                    presentationMode.wrappedValue.dismiss()
+                }
+                .keyboardShortcut(.escape, modifiers: [])
+
+                Button(action: {
+                    Task {
+                        isAdding = true
+                        do {
+                            _ = try await GCEventStore.shared.addAccount()
+                            onAccountAdded()
+                            presentationMode.wrappedValue.dismiss()
+                        } catch {
+                            errorMessage = error.localizedDescription
+                            isAdding = false
+                        }
+                    }
+                }) {
+                    if isAdding {
+                        ProgressView()
+                    } else {
+                        Text("Sign in with Google")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isAdding)
+            }
+        }
+        .padding()
+        .frame(width: 320, height: 180)
+    }
+}
+
 struct CalendarSectionsView: View {
     let calendars: [MBCalendar]
 
-    // 1. Compute once, with explicit types
     private var grouped: [String: [MBCalendar]] {
         Dictionary(grouping: calendars, by: \.source)
     }
@@ -74,14 +235,6 @@ struct ProviderPicker: View {
             }
             .onChange(of: picker) { provider in
                 Task { await eventManager.changeEventStoreProvider(provider) }
-            }
-
-            if Defaults[.eventStoreProvider] == .googleCalendar {
-                Button("preferences_calendars_provider_gcalendar_change_account".loco()) {
-                    Task {
-                        await eventManager.changeEventStoreProvider(.googleCalendar, withSignOut: true)
-                    }
-                }
             }
         }
     }
@@ -126,7 +279,7 @@ struct CalendarRow: View {
             } else {
                 Defaults[.selectedCalendarIDs].removeAll { $0 == calendar.id }
             }
-            Defaults[.selectedCalendarIDs] = Array(Set(Defaults[.selectedCalendarIDs])) // Deduplication
+            Defaults[.selectedCalendarIDs] = Array(Set(Defaults[.selectedCalendarIDs]))
         }
     }
 }

--- a/MeetingBarTests/GoogleAccountTests.swift
+++ b/MeetingBarTests/GoogleAccountTests.swift
@@ -1,0 +1,95 @@
+//
+//  GoogleAccountTests.swift
+//  MeetingBar
+//
+//  Created for multi-account Google Calendar support.
+//  Copyright © 2026 Andrii Leitsius. All rights reserved.
+//
+
+@testable import MeetingBar
+import Defaults
+import XCTest
+
+@MainActor
+final class GoogleAccountTests: BaseTestCase {
+
+    func test_googleAccountCreation() {
+        let account = GoogleAccount(id: "test-id", email: "test@example.com")
+
+        XCTAssertEqual(account.id, "test-id")
+        XCTAssertEqual(account.email, "test@example.com")
+    }
+
+    func test_googleAccountHashable() {
+        let account1 = GoogleAccount(id: "id-1", email: "a@example.com")
+        let account2 = GoogleAccount(id: "id-1", email: "a@example.com")
+        let account3 = GoogleAccount(id: "id-2", email: "b@example.com")
+
+        XCTAssertEqual(account1, account2)
+        XCTAssertEqual(account1.hashValue, account2.hashValue)
+        XCTAssertNotEqual(account1, account3)
+    }
+
+    func test_googleAccountCodable() throws {
+        let account = GoogleAccount(id: "enc-id", email: "encoded@example.com")
+        let data = try JSONEncoder().encode(account)
+        let decoded = try JSONDecoder().decode(GoogleAccount.self, from: data)
+
+        XCTAssertEqual(decoded.id, "enc-id")
+        XCTAssertEqual(decoded.email, "encoded@example.com")
+    }
+
+    func test_googleAccountPersistedInDefaults() {
+        let accounts = [
+            GoogleAccount(id: "personal", email: "personal@example.com"),
+            GoogleAccount(id: "work", email: "work@example.com")
+        ]
+
+        Defaults[.googleAccounts] = accounts
+
+        let loaded = Defaults[.googleAccounts]
+        XCTAssertEqual(loaded.count, 2)
+        XCTAssertEqual(loaded[0].email, "personal@example.com")
+        XCTAssertEqual(loaded[1].email, "work@example.com")
+    }
+}
+
+@MainActor
+final class MultiAccountCalendarTests: BaseTestCase {
+
+    func test_calendarIdPrefixing() {
+        let accountId = "acc-123"
+        let originalCalendarId = "primary"
+        let prefixedId = "\(accountId):\(originalCalendarId)"
+
+        XCTAssertEqual(prefixedId, "acc-123:primary")
+
+        let extractedPrefix = prefixedId.components(separatedBy: ":").first ?? ""
+        XCTAssertEqual(extractedPrefix, accountId)
+
+        let extractedOriginal = String(prefixedId.dropFirst("\(accountId):".count))
+        XCTAssertEqual(extractedOriginal, originalCalendarId)
+    }
+
+    func test_multiAccountCalendarGrouping() {
+        let cal1 = MBCalendar(title: "Personal", id: "acc1:primary", source: "personal@example.com", email: "personal@example.com", color: .blue)
+        let cal2 = MBCalendar(title: "Work", id: "acc2:primary", source: "work@example.com", email: "work@example.com", color: .red)
+        let cal3 = MBCalendar(title: "Birthdays", id: "acc1:birthday", source: "personal@example.com", email: "personal@example.com", color: .green)
+
+        let calendars = [cal1, cal2, cal3]
+        let grouped = Dictionary(grouping: calendars, by: \.source)
+
+        XCTAssertEqual(grouped["personal@example.com"]?.count, 2)
+        XCTAssertEqual(grouped["work@example.com"]?.count, 1)
+    }
+
+    func test_calendarIdsAreUniqueAcrossAccounts() {
+        let personalCalId = "acc1:primary"
+        let workCalId = "acc2:primary"
+
+        XCTAssertNotEqual(personalCalId, workCalId)
+
+        let allIds = [personalCalId, workCalId]
+        XCTAssertEqual(allIds.count, Set(allIds).count)
+    }
+}

--- a/MeetingBarTests/TimelineLogicTests.swift
+++ b/MeetingBarTests/TimelineLogicTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 @testable import MeetingBar
-import SwiftUICore
+import SwiftUI
 
 final class TimelineLogicTests: XCTestCase {
 


### PR DESCRIPTION
## Summary
- Allow users to connect multiple Google accounts (e.g., personal and work) simultaneously
- Each account's calendars are fetched and displayed grouped by email address
- Add/remove accounts directly from Preferences with confirmation dialog

## Changes
- **New model**: `GoogleAccount` for tracking multiple accounts
- **GCEventStore refactored**: manages per-account OAuth states, each stored under a unique Keychain entry
- **Calendar ID prefixing**: `accountId:calendarId` prevents collisions across accounts
- **UI**: New "Google Accounts" section in Preferences with add/remove functionality
- **Persistence**: Accounts stored in Defaults, auth states in Keychain

## UX Improvements
- Confirmation dialog before removing an account (shows email and warns about consequences)
- Clear empty state when no accounts are connected
- "Connected" status shown under each account email
- Reactive UI that stays in sync with account changes
- Disabled button while adding to prevent double-clicks

## Testing
- Build succeeds with no new SwiftLint violations
- All pre-existing lint violations are in unrelated files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-account support for Google Calendar — connect, view, and remove multiple Google accounts; events from all connected accounts are fetched and shown.
* **Improvements**
  * Per-account token handling, refresh, and error recovery for more reliable access.
  * Preferences UI updated with a Google Accounts section and clearer empty-account messaging.
  * Global access to the active event manager instance for coordination.
* **Tests**
  * Added tests covering account model, persistence, and multi-account calendar behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->