### PR TITLE
feat(meet): open attached Google Doc notes when joining

### DIFF
--- a/MeetingBar/Core/EventStores/GCEventStore.swift
+++ b/MeetingBar/Core/EventStores/GCEventStore.swift
@@ -405,6 +405,16 @@ final class GCEventStore: NSObject,
                 }
             }
 
+            var meetingNotesDocLink: URL?
+            if let attachments = item["attachments"] as? [[String: Any]] {
+                if let docAttachment = attachments.first(where: {
+                    ($0["mimeType"] as? String) == "application/vnd.google-apps.document"
+                        || (($0["fileUrl"] as? String)?.contains("docs.google.com") ?? false)
+                }) {
+                    meetingNotesDocLink = URL(string: docAttachment["fileUrl"] as? String ?? "")
+                }
+            }
+
             let organizerRaw = item["organizer"] as? [String: String]
             let organizer = MBEventOrganizer(email: organizerRaw?["email"], name: organizerRaw?["name"])
 
@@ -463,6 +473,7 @@ final class GCEventStore: NSObject,
                 notes: notes,
                 location: location,
                 url: url,
+                meetingNotesDocLink: meetingNotesDocLink,
                 organizer: organizer,
                 attendees: attendees,
                 startDate: startDate,

--- a/MeetingBar/Core/EventStores/GCEventStore.swift
+++ b/MeetingBar/Core/EventStores/GCEventStore.swift
@@ -406,13 +406,12 @@ final class GCEventStore: NSObject,
             }
 
             var meetingNotesDocLink: URL?
-            if let attachments = item["attachments"] as? [[String: Any]] {
-                if let docAttachment = attachments.first(where: {
-                    ($0["mimeType"] as? String) == "application/vnd.google-apps.document"
-                        || (($0["fileUrl"] as? String)?.contains("docs.google.com") ?? false)
-                }) {
-                    meetingNotesDocLink = URL(string: docAttachment["fileUrl"] as? String ?? "")
-                }
+            if let attachments = item["attachments"] as? [[String: Any]],
+               let docAttachment = attachments.first(where: {
+                   ($0["mimeType"] as? String) == "application/vnd.google-apps.document"
+               }),
+               let fileUrl = docAttachment["fileUrl"] as? String {
+                meetingNotesDocLink = URL(string: fileUrl)
             }
 
             let organizerRaw = item["organizer"] as? [String: String]

--- a/MeetingBar/Core/Models/MBEvent.swift
+++ b/MeetingBar/Core/Models/MBEvent.swift
@@ -62,6 +62,7 @@ public struct MBEvent: Identifiable, Hashable, Sendable {
     public var status: MBEventStatus
     public var participationStatus: MBEventAttendeeStatus = .unknown
     public var meetingLink: MeetingLink?
+    public var meetingNotesDocLink: URL?
     public var organizer: MBEventOrganizer?
     public let url: URL?
     public let notes: String?
@@ -79,6 +80,7 @@ public struct MBEvent: Identifiable, Hashable, Sendable {
          notes: String?,
          location: String?,
          url: URL?,
+         meetingNotesDocLink: URL? = nil,
          organizer: MBEventOrganizer?,
          attendees: [MBEventAttendee] = [],
          startDate: Date,
@@ -105,6 +107,7 @@ public struct MBEvent: Identifiable, Hashable, Sendable {
         self.notes = notes
         self.location = location
         self.url = url
+        self.meetingNotesDocLink = meetingNotesDocLink
 
         self.organizer = organizer
         self.attendees = attendees
@@ -162,6 +165,11 @@ public struct MBEvent: Identifiable, Hashable, Sendable {
                 }
             }
             openMeetingURL(meetingLink.service, meetingLink.url, nil)
+            if Defaults[.openGoogleMeetingNotesOnJoin],
+               meetingLink.service == .meet,
+               let notesURL = meetingNotesDocLink {
+                notesURL.openInDefaultBrowser()
+            }
         } else if let eventUrl = url {
             eventUrl.openInDefaultBrowser()
         } else {

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -95,6 +95,7 @@ extension Defaults.Keys {
     static let createMeetingServiceUrl = Key<String>("createMeetingServiceUrl", default: "")
 
     static let meetBrowser = Key<Browser>("meetBrowser", default: systemDefaultBrowser)
+    static let openGoogleMeetingNotesOnJoin = Key<Bool>("openGoogleMeetingNotesOnJoin", default: false)
     static let zoomBrowser = Key<Browser>("zoomBrowser", default: systemDefaultBrowser)
     static let teamsBrowser = Key<Browser>("teamsBrowser", default: systemDefaultBrowser)
     static let jitsiBrowser = Key<Browser>("jitsiBrowser", default: systemDefaultBrowser)

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -119,6 +119,7 @@
 
 "preferences_services_link_meeting_title" = "Open all meeting links in";
 "preferences_services_link_service_title" = "Open %@ links in";
+"preferences_services_meet_open_notes_on_join" = "Open attached Google Doc notes when joining";
 "preferences_services_link_default_browser_value" = "Default web browser";
 "preferences_services_supported_links_list" = "Supported links for services:\n%@";
 "preferences_services_supported_links_mailback" = "If the service you use isn't supported, you can send an e-mail to the developers";

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -120,6 +120,7 @@
 "preferences_services_link_meeting_title" = "Open all meeting links in";
 "preferences_services_link_service_title" = "Open %@ links in";
 "preferences_services_meet_open_notes_on_join" = "Open attached Google Doc notes when joining";
+"preferences_services_meet_open_notes_on_join_help" = "Requires the Google Calendar API provider (Preferences > Calendars).";
 "preferences_services_link_default_browser_value" = "Default web browser";
 "preferences_services_supported_links_list" = "Supported links for services:\n%@";
 "preferences_services_supported_links_mailback" = "If the service you use isn't supported, you can send an e-mail to the developers";

--- a/MeetingBar/UI/Views/Preferences/LinksTab.swift
+++ b/MeetingBar/UI/Views/Preferences/LinksTab.swift
@@ -12,6 +12,7 @@ import SwiftUI
 struct LinksTab: View {
     @Default(.meetBrowser) var meetBrowser
     @Default(.openGoogleMeetingNotesOnJoin) var openGoogleMeetingNotesOnJoin
+    @Default(.eventStoreProvider) var eventStoreProvider
     @Default(.browserForCreateMeeting) var browserForCreateMeeting
     @Default(.defaultBrowser) var defaultBrowser
     @Default(.zoomBrowser) var zoomBrowser
@@ -59,6 +60,8 @@ struct LinksTab: View {
 
                 Toggle("preferences_services_meet_open_notes_on_join".loco(), isOn: $openGoogleMeetingNotesOnJoin)
                     .frame(maxWidth: .infinity, alignment: .leading)
+                    .disabled(eventStoreProvider != .googleCalendar)
+                    .help("preferences_services_meet_open_notes_on_join_help".loco())
 
                 Picker(
                     selection: $zoomBrowser,

--- a/MeetingBar/UI/Views/Preferences/LinksTab.swift
+++ b/MeetingBar/UI/Views/Preferences/LinksTab.swift
@@ -58,10 +58,13 @@ struct LinksTab: View {
                     }
                 }
 
-                Toggle("preferences_services_meet_open_notes_on_join".loco(), isOn: $openGoogleMeetingNotesOnJoin)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .disabled(eventStoreProvider != .googleCalendar)
-                    .help("preferences_services_meet_open_notes_on_join_help".loco())
+                Toggle("preferences_services_meet_open_notes_on_join".loco(), isOn: Binding(
+                    get: { eventStoreProvider == .googleCalendar && openGoogleMeetingNotesOnJoin },
+                    set: { openGoogleMeetingNotesOnJoin = $0 }
+                ))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .disabled(eventStoreProvider != .googleCalendar)
+                .help("preferences_services_meet_open_notes_on_join_help".loco())
 
                 Picker(
                     selection: $zoomBrowser,

--- a/MeetingBar/UI/Views/Preferences/LinksTab.swift
+++ b/MeetingBar/UI/Views/Preferences/LinksTab.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct LinksTab: View {
     @Default(.meetBrowser) var meetBrowser
+    @Default(.openGoogleMeetingNotesOnJoin) var openGoogleMeetingNotesOnJoin
     @Default(.browserForCreateMeeting) var browserForCreateMeeting
     @Default(.defaultBrowser) var defaultBrowser
     @Default(.zoomBrowser) var zoomBrowser
@@ -55,6 +56,9 @@ struct LinksTab: View {
                         Text(browser.name).tag(browser)
                     }
                 }
+
+                Toggle("preferences_services_meet_open_notes_on_join".loco(), isOn: $openGoogleMeetingNotesOnJoin)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 Picker(
                     selection: $zoomBrowser,

--- a/MeetingBarTests/GCEventStoreTests.swift
+++ b/MeetingBarTests/GCEventStoreTests.swift
@@ -1,0 +1,59 @@
+//
+//  GCEventStoreTests.swift
+//  MeetingBarTests
+//
+
+import XCTest
+
+@testable import MeetingBar
+
+final class GCEventStoreTests: XCTestCase {
+    private let calendar = MBCalendar(title: "Test", id: "test", source: nil, email: nil, color: .black)
+
+    private func baseItem() -> [String: Any] {
+        [
+            "id": "evt1",
+            "start": ["dateTime": "2025-01-01T10:00:00Z"],
+            "end": ["dateTime": "2025-01-01T11:00:00Z"]
+        ]
+    }
+
+    func testParsesGoogleDocAttachmentAsMeetingNotes() {
+        var item = baseItem()
+        item["attachments"] = [
+            [
+                "fileUrl": "https://docs.google.com/document/d/abc123/edit",
+                "title": "Standup - Notes",
+                "mimeType": "application/vnd.google-apps.document",
+                "fileId": "abc123"
+            ]
+        ]
+
+        let event = GCEventStore.GCParser.event(from: item, calendar: calendar)
+
+        XCTAssertEqual(event?.meetingNotesDocLink?.absoluteString,
+                       "https://docs.google.com/document/d/abc123/edit")
+    }
+
+    func testIgnoresNonDocumentAttachment() {
+        var item = baseItem()
+        item["attachments"] = [
+            [
+                "fileUrl": "https://drive.google.com/file/d/xyz/view",
+                "title": "Slides.pdf",
+                "mimeType": "application/pdf",
+                "fileId": "xyz"
+            ]
+        ]
+
+        let event = GCEventStore.GCParser.event(from: item, calendar: calendar)
+
+        XCTAssertNil(event?.meetingNotesDocLink)
+    }
+
+    func testNoAttachmentsLeavesMeetingNotesNil() {
+        let event = GCEventStore.GCParser.event(from: baseItem(), calendar: calendar)
+
+        XCTAssertNil(event?.meetingNotesDocLink)
+    }
+}

--- a/MeetingBarTests/GCEventStoreTests.swift
+++ b/MeetingBarTests/GCEventStoreTests.swift
@@ -35,7 +35,7 @@ final class GCEventStoreTests: XCTestCase {
                        "https://docs.google.com/document/d/abc123/edit")
     }
 
-    func testIgnoresNonDocumentAttachment() {
+    func testIgnoresNonDocumentAttachment() throws {
         var item = baseItem()
         item["attachments"] = [
             [
@@ -46,14 +46,14 @@ final class GCEventStoreTests: XCTestCase {
             ]
         ]
 
-        let event = GCEventStore.GCParser.event(from: item, calendar: calendar)
+        let event = try XCTUnwrap(GCEventStore.GCParser.event(from: item, calendar: calendar))
 
-        XCTAssertNil(event?.meetingNotesDocLink)
+        XCTAssertNil(event.meetingNotesDocLink)
     }
 
-    func testNoAttachmentsLeavesMeetingNotesNil() {
-        let event = GCEventStore.GCParser.event(from: baseItem(), calendar: calendar)
+    func testNoAttachmentsLeavesMeetingNotesNil() throws {
+        let event = try XCTUnwrap(GCEventStore.GCParser.event(from: baseItem(), calendar: calendar))
 
-        XCTAssertNil(event?.meetingNotesDocLink)
+        XCTAssertNil(event.meetingNotesDocLink)
     }
 }

--- a/MeetingBarTests/TimelineLogicTests.swift
+++ b/MeetingBarTests/TimelineLogicTests.swift
@@ -8,7 +8,7 @@
 
 import XCTest
 @testable import MeetingBar
-import SwiftUICore
+import SwiftUI
 
 final class TimelineLogicTests: XCTestCase {
 


### PR DESCRIPTION
🇺🇦 Слава Україні! 👋 

If available, auto-open the 1:1 / meeting notes doc when also auto-opening a meeting.

### Status
**READY**

### Description
Opt-in preference: when joining a Google Meet, also open the event's attached Google Doc (the GCal "Take meeting notes" doc).

GCal's "Take meeting notes" creates a Doc and attaches it to the event. Opening it alongside the Meet tab saves a click on every meeting.

**How**
- `MBEvent` gains `meetingNotesDocLink: URL?`
- `GCEventStore` populates it from `attachments[]` (first `application/vnd.google-apps.document`)
- `openMeeting()` opens it after the Meet link when the pref is on
- New toggle in Preferences > Services, default off

**Scope note:** Google Calendar provider only. `EKEvent` has no public attachments API, so EventKit events leave the field `nil`. Happy to add a description-regex fallback in a follow-up if wanted.

## Checklist
- [x] Localized (en; Weblate for others)
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/UI/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
1. Connect a Google account in MeetingBar
2. Create a calendar event with a Meet link, click "Take meeting notes" in GCal to attach a Doc
3. Preferences > Services > enable "Open attached Google Doc notes when joining"
4. Join the event from MeetingBar — both the Meet link and the Doc should open
5. Toggle off → only Meet opens (no behavior change)
6. Event with no attachment → only Meet opens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatically open attached Google Docs when joining Google Meet meetings (when enabled).

* **Chores / Preferences**
  * New preference (off by default) to enable/disable opening attached Google Doc notes; visible in Preferences and only active for the Google Calendar provider.

* **Localization**
  * Added strings for the new preference and its help text.

* **Tests**
  * Added tests validating parsing and handling of Google Doc attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->