### PR TITLE
Fix authAccount retrieval logic in email link detection

### DIFF
--- a/MeetingBar/Core/Models/MBEvent.swift
+++ b/MeetingBar/Core/Models/MBEvent.swift
@@ -126,7 +126,7 @@ public struct MBEvent: Identifiable, Hashable, Sendable {
         for linkField in linkFields {
             if var detectedLink = detectMeetingLink(linkField) {
                 if detectedLink.service == .meet,
-                   let authAccount = calendar.email ?? attendees.first(where: { $0.isCurrentUser })?.email,
+                   let authAccount = attendees.first(where: { $0.isCurrentUser })?.email ?? calendar.email,
                    let urlEncodedAccount = authAccount.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) {
                     detectedLink.url = URL(string: (detectedLink.url.absoluteString) + "?authuser=\(urlEncodedAccount)")!
                 }


### PR DESCRIPTION
### Status
**READY**

### Description
For folks who have multiple calendar connected to one account this is a better way of resolving the correct account to use for meet link.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting link authentication handling for users with multiple Google accounts, ensuring the correct account is automatically selected when accessing meeting links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->