### PR TITLE
Detect new Microsoft Teams short meeting URL format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ For next releases info look here: <https://github.com/leits/MeetingBar/releases>
 * Fix multiple typos in the repo (#875)
 * Fix URL in PR template (#875) 
 * Add Riverside meeting service (#875)
-* Detect Microsoft Teams' new short meeting URL format `teams.microsoft.com/meet/<id>?p=<hash>`
+* Detect Microsoft Teams' new short meeting URL format (#926)
 
 ## Version 4.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For next releases info look here: <https://github.com/leits/MeetingBar/releases>
 * Fix multiple typos in the repo (#875)
 * Fix URL in PR template (#875) 
 * Add Riverside meeting service (#875)
+* Detect Microsoft Teams' new short meeting URL format `teams.microsoft.com/meet/<id>?p=<hash>`
 
 ## Version 4.11.0
 

--- a/MeetingBar/Services/MeetingServices.swift
+++ b/MeetingBar/Services/MeetingServices.swift
@@ -288,7 +288,7 @@ private let meetingLinkRegexes: [MeetingServices: NSRegularExpression] = [
     .meet: try! NSRegularExpression(pattern: #"https?://meet.google.com/(_meet/)?[a-z-]+"#),
     .zoom: try! NSRegularExpression(pattern: #"https:\/\/(?:[a-zA-Z0-9-.]+)?zoom(-x)?\.(?:us|com|com\.cn|de)\/(?:my|[a-z]{1,2}|webinar)\/[-a-zA-Z0-9()@:%_\+.~#?&=\/]*"#),
     .zoom_native: try! NSRegularExpression(pattern: #"zoommtg://([a-z0-9-.]+)?zoom(-x)?\.(?:us|com|com\.cn|de)/join[-a-zA-Z0-9()@:%_\+.~#?&=\/]*"#),
-    .teams: try! NSRegularExpression(pattern: #"https?://(gov.)?teams\.microsoft\.(com|us)/l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+"#),
+    .teams: try! NSRegularExpression(pattern: #"https?://(gov\.)?teams\.microsoft\.(com|us)/(l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+|meet/\d+\?p=[A-Za-z0-9_\-]+(?:&[^\s]+)?)"#),
     .webex: try! NSRegularExpression(pattern: #"https?://(?:[A-Za-z0-9-]+\.)?webex\.com(?:(?:/[-A-Za-z0-9]+/j\.php\?MTID=[A-Za-z0-9]+(?:&\S*)?)|(?:/(?:meet|join)/[A-Za-z0-9\-._@]+(?:\?\S*)?))"#),
     .chime: try! NSRegularExpression(pattern: #"https?://([a-z0-9-.]+)?chime\.aws/[0-9]*"#),
     .jitsi: try! NSRegularExpression(pattern: #"https?://meet\.jit\.si/[^\s]*"#),

--- a/MeetingBar/Services/MeetingServices.swift
+++ b/MeetingBar/Services/MeetingServices.swift
@@ -288,7 +288,7 @@ private let meetingLinkRegexes: [MeetingServices: NSRegularExpression] = [
     .meet: try! NSRegularExpression(pattern: #"https?://meet.google.com/(_meet/)?[a-z-]+"#),
     .zoom: try! NSRegularExpression(pattern: #"https:\/\/(?:[a-zA-Z0-9-.]+)?zoom(-x)?\.(?:us|com|com\.cn|de)\/(?:my|[a-z]{1,2}|webinar)\/[-a-zA-Z0-9()@:%_\+.~#?&=\/]*"#),
     .zoom_native: try! NSRegularExpression(pattern: #"zoommtg://([a-z0-9-.]+)?zoom(-x)?\.(?:us|com|com\.cn|de)/join[-a-zA-Z0-9()@:%_\+.~#?&=\/]*"#),
-    .teams: try! NSRegularExpression(pattern: #"https?://(gov\.)?teams\.microsoft\.(com|us)/(l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+|meet/\d+\?p=[A-Za-z0-9_\-]+(?:&[^\s]+)?)"#),
+    .teams: try! NSRegularExpression(pattern: #"https?://(gov\.)?teams\.microsoft\.(com|us)/(l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+(?:&[^\s]+)?|meet/\d+\?p=[A-Za-z0-9_\-]+(?:&[^\s]+)?)"#),
     .webex: try! NSRegularExpression(pattern: #"https?://(?:[A-Za-z0-9-]+\.)?webex\.com(?:(?:/[-A-Za-z0-9]+/j\.php\?MTID=[A-Za-z0-9]+(?:&\S*)?)|(?:/(?:meet|join)/[A-Za-z0-9\-._@]+(?:\?\S*)?))"#),
     .chime: try! NSRegularExpression(pattern: #"https?://([a-z0-9-.]+)?chime\.aws/[0-9]*"#),
     .jitsi: try! NSRegularExpression(pattern: #"https?://meet\.jit\.si/[^\s]*"#),

--- a/MeetingBarTests/MeetingServicesTests.swift
+++ b/MeetingBarTests/MeetingServicesTests.swift
@@ -48,6 +48,10 @@ let meetings = [
     MeetingLink(service: .livekit, url: URL(string: "https://meet.livekit.io/rooms/et5r-y80t#r56ryirofs8jjfi3rnxu8ab3qhjsRn6die6mvjhwux82opmkao8bfjb9wggnr2L6")!),
     MeetingLink(service: .livekit, url: URL(string: "https://meet.staging.livekit.io/rooms/of4q-y10s")!),
     MeetingLink(service: .meetecho, url: URL(string: "https://meetings.conf.meetecho.com/ietf122/?session=34071")!),
+    // teams
+    MeetingLink(service: .teams, url: URL(string: "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ABC123%40thread.v2/0?context=%7b%22Tid%22%3a%22tid-guid%22%2c%22Oid%22%3a%22oid-guid%22%7d")!),
+    MeetingLink(service: .teams, url: URL(string: "https://teams.microsoft.com/meet/1234567890123?p=Aa1Bb2Cc3Dd4Ee5")!),
+    MeetingLink(service: .teams, url: URL(string: "https://teams.microsoft.com/meet/1234567890123?p=Aa1Bb2Cc3Dd4Ee5&anon=true")!),
     // webex
     MeetingLink(service: .webex, url: URL(string: "https://yourmeetingsite.webex.com/meet/username")!),
     MeetingLink(service: .webex, url: URL(string: "https://yourmeetingsite.webex.com/yourbusinessID/j.php?MTID=aO5678eFGH")!),

--- a/MeetingBarTests/MeetingServicesTests.swift
+++ b/MeetingBarTests/MeetingServicesTests.swift
@@ -50,6 +50,7 @@ let meetings = [
     MeetingLink(service: .meetecho, url: URL(string: "https://meetings.conf.meetecho.com/ietf122/?session=34071")!),
     // teams
     MeetingLink(service: .teams, url: URL(string: "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ABC123%40thread.v2/0?context=%7b%22Tid%22%3a%22tid-guid%22%2c%22Oid%22%3a%22oid-guid%22%7d")!),
+    MeetingLink(service: .teams, url: URL(string: "https://teams.microsoft.com/l/meetup-join/19%3ameeting_ABC123%40thread.v2/0?context=%7b%22Tid%22%3a%22tid-guid%22%7d&anon=true")!),
     MeetingLink(service: .teams, url: URL(string: "https://teams.microsoft.com/meet/1234567890123?p=Aa1Bb2Cc3Dd4Ee5")!),
     MeetingLink(service: .teams, url: URL(string: "https://teams.microsoft.com/meet/1234567890123?p=Aa1Bb2Cc3Dd4Ee5&anon=true")!),
     // webex


### PR DESCRIPTION
### Description
Microsoft rolled out a new shorter URL format for Teams meetings, completing worldwide GA in **January 2026** ([MC772556](https://m365admin.handsontek.net/microsoft-teams-shorter-meeting-urls/)). All newly scheduled Teams meetings now use:

```
https://teams.microsoft.com/meet/<meeting_id>?p=<hashed_passcode>
```

instead of the legacy `https://teams.microsoft.com/l/meetup-join/19%3ameeting_...` form. Existing meetings keep their old URL, but no new meetings are created in the legacy form.

The current Teams regex only matches the legacy form, so MeetingBar fails to detect any post-Jan-2026 Teams meeting and displays the event without a service icon (and clicking "Join with MeetingBar" does nothing).

#### Change
- Extended the `.teams` regex with an alternation to also match `meet/<digits>?p=<alphanumeric>`. Legacy detection is unchanged.
- Added detection tests for both the legacy form and the new short form (there were no Teams cases in `MeetingServicesTests` before).
- Added a `CHANGELOG.md` entry under *Unreleased*.

#### Regex diff
```diff
- #"https?://(gov.)?teams\.microsoft\.(com|us)/l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+"#
+ #"https?://(gov.)?teams\.microsoft\.(com|us)/(l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+|meet/\d+\?p=[A-Za-z0-9_\-]+)"#
```

## Checklist
- [ ] Localized — *no user-facing strings changed; please confirm this isn't required for regex-only fixes*
- [x] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/UI/Views/Changelog/Changelog.swift) — *will add once the target release version is known; happy to add now if preferred*
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
1. Schedule a Teams meeting on a tenant that has the new short URL format enabled (any tenant scheduling new meetings as of 2026).
2. Add an event to the calendar whose description
3. **Before this patch:** the event shows no Teams icon in the menu, and "Join meeting" does nothing.
4. **After this patch:** the event shows the Teams icon and joining works via the configured browser/Teams app.

The added unit tests in `MeetingBarTests/MeetingServicesTests.swift` cover both forms.

### References
- Topedia Blog (Jan 2026): https://blog-en.topedia.com/2026/01/shorter-meet-now-urls-and-an-updated-meeting-url-lifecycle-in-microsoft-teams/
- M365 Admin / MC772556: https://m365admin.handsontek.net/microsoft-teams-shorter-meeting-urls/
- Petri: https://petri.com/microsoft-changelog/m365-changelog-microsoft-teams-shorter-meeting-urls/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for additional Microsoft Teams short and join URL formats, covering more join link variants including those used by government cloud instances.

* **Tests**
  * Expanded test coverage to validate recognition of the new Teams meeting URL variations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/leits/MeetingBar/pull/926?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->