### PR TITLE
Add optional event locations to menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ For next releases info look here: <https://github.com/leits/MeetingBar/releases>
 * Fix multiple typos in the repo (#875)
 * Fix URL in PR template (#875) 
 * Add Riverside meeting service (#875)
+* Show event locations in the menu
 
 ## Version 4.11.0
 

--- a/MeetingBar/Core/Models/MBEvent+Helpers.swift
+++ b/MeetingBar/Core/Models/MBEvent+Helpers.swift
@@ -27,7 +27,8 @@ extension MBEvent {
         if normalizedLocation.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
            let url = URL(string: normalizedLocation),
            url.scheme?.isEmpty == false,
-           url.host?.isEmpty == false {
+           url.host?.isEmpty == false,
+           detectMeetingLink(normalizedLocation) != nil {
             return nil
         }
 

--- a/MeetingBar/Core/Models/MBEvent+Helpers.swift
+++ b/MeetingBar/Core/Models/MBEvent+Helpers.swift
@@ -9,7 +9,7 @@
 import Defaults
 import Foundation
 
-public extension MBEvent {
+extension MBEvent {
     var displayLocation: String? {
         guard let location else {
             return nil
@@ -24,7 +24,8 @@ public extension MBEvent {
             return nil
         }
 
-        if let url = URL(string: normalizedLocation),
+        if normalizedLocation.rangeOfCharacter(from: .whitespacesAndNewlines) == nil,
+           let url = URL(string: normalizedLocation),
            url.scheme?.isEmpty == false,
            url.host?.isEmpty == false {
             return nil

--- a/MeetingBar/Core/Models/MBEvent+Helpers.swift
+++ b/MeetingBar/Core/Models/MBEvent+Helpers.swift
@@ -9,6 +9,31 @@
 import Defaults
 import Foundation
 
+public extension MBEvent {
+    var displayLocation: String? {
+        guard let location else {
+            return nil
+        }
+
+        let normalizedLocation = location
+            .components(separatedBy: .whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+
+        guard !normalizedLocation.isEmpty else {
+            return nil
+        }
+
+        if let url = URL(string: normalizedLocation),
+           url.scheme?.isEmpty == false,
+           url.host?.isEmpty == false {
+            return nil
+        }
+
+        return normalizedLocation
+    }
+}
+
 public extension Array where Element == MBEvent {
     /// Returns only those events that pass all the user’s Defaults filters.
 

--- a/MeetingBar/Extensions/DefaultsKeys.swift
+++ b/MeetingBar/Extensions/DefaultsKeys.swift
@@ -54,6 +54,7 @@ extension Defaults.Keys {
 
     static let showEventDetails = Key<Bool>("showEventDetails", default: false)
     static let showMeetingServiceIcon = Key<Bool>("showMeetingServiceIcon", default: true)
+    static let showEventLocation = Key<Bool>("showEventLocation", default: true)
 
     static let declinedEventsAppereance = Key<DeclinedEventsAppereance>("declinedEventsAppereance", default: .strikethrough)
     static let pastEventsAppereance = Key<PastEventsAppereance>("pastEventsAppereance", default: .show_inactive)

--- a/MeetingBar/Resources /Localization /bg.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /bg.lproj/Localizable.strings
@@ -113,6 +113,7 @@
 "preferences_appearance_menu_show_event_title" = "Показвай за събитието:";
 "preferences_appearance_menu_show_event_end_time_value" = "краен час";
 "preferences_appearance_menu_show_event_icon_value" = "икона";
+"preferences_appearance_menu_show_event_location_value" = "местоположение";
 "preferences_appearance_menu_show_event_details_value" = "детайли като подменю";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /cs.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /cs.lproj/Localizable.strings
@@ -233,6 +233,7 @@
 "preferences_appearance_events_past_title" = "Dřívější události:";
 "preferences_appearance_events_value_inactive_without_meeting_link" = "zobrazit všechny bez odkazů na schůzku jako neaktivní";
 "preferences_appearance_menu_show_event_icon_value" = "ikonu";
+"preferences_appearance_menu_show_event_location_value" = "místo";
 "preferences_appearance_menu_show_event_end_time_value" = "čas konce";
 "preferences_appearance_menu_shorten_event_title_stepper" = "%d znaků";
 "preferences_appearance_menu_shorten_event_title_toggle" = "Zkrátit název události na";

--- a/MeetingBar/Resources /Localization /de.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /de.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 "preferences_services_link_meeting_title" = "Meeting-Links öffnen mit";
 "preferences_appearance_menu_show_event_details_value" = "Details als Untermenü";
 "preferences_appearance_menu_show_event_icon_value" = "symbol";
+"preferences_appearance_menu_show_event_location_value" = "Ort";
 "preferences_appearance_menu_show_event_end_time_value" = "Endzeit";
 "preferences_appearance_menu_show_event_title" = "Ereignis anzeigen:";
 "preferences_appearance_menu_time_format_24_hour_value" = "24-Stunden";

--- a/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /en.lproj/Localizable.strings
@@ -113,6 +113,7 @@
 "preferences_appearance_menu_show_event_title" = "Show event:";
 "preferences_appearance_menu_show_event_end_time_value" = "end time";
 "preferences_appearance_menu_show_event_icon_value" = "icon";
+"preferences_appearance_menu_show_event_location_value" = "location";
 "preferences_appearance_menu_show_event_details_value" = "details as submenu";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /enm.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /enm.lproj/Localizable.strings
@@ -1,1 +1,2 @@
 
+"preferences_appearance_menu_show_event_location_value" = "location";

--- a/MeetingBar/Resources /Localization /es.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /es.lproj/Localizable.strings
@@ -107,6 +107,7 @@
 "preferences_appearance_menu_show_event_title" = "Mostrar evento:";
 "preferences_appearance_menu_show_event_end_time_value" = "hora fin";
 "preferences_appearance_menu_show_event_icon_value" = "icono";
+"preferences_appearance_menu_show_event_location_value" = "ubicación";
 "preferences_appearance_menu_show_event_details_value" = "detalles como submenú";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /fr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /fr.lproj/Localizable.strings
@@ -216,6 +216,7 @@
 "preferences_services_link_meeting_title" = "Ouvrir tous les liens de réunion dans";
 "preferences_appearance_menu_show_event_details_value" = "détails comme sous-menu";
 "preferences_appearance_menu_show_event_icon_value" = "icône";
+"preferences_appearance_menu_show_event_location_value" = "lieu";
 "preferences_appearance_menu_show_event_end_time_value" = "heure de fin";
 "preferences_appearance_menu_show_event_title" = "Afficher l'évènement :";
 "preferences_appearance_menu_time_format_24_hour_value" = "24 heures";

--- a/MeetingBar/Resources /Localization /he.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /he.lproj/Localizable.strings
@@ -69,6 +69,7 @@
 "preferences_appearance_menu_show_event_title" = "הצגת אירוע:";
 "preferences_appearance_menu_show_event_end_time_value" = "זמן הסיום";
 "preferences_appearance_menu_show_event_icon_value" = "סמל";
+"preferences_appearance_menu_show_event_location_value" = "מיקום";
 "preferences_appearance_menu_show_event_details_value" = "פרטים כתת־תפריט";
 "preferences_services_link_service_title" = "לפתוח קישורי %@ עם";
 "preferences_services_link_default_browser_value" = "דפדפן בררת המחדל";

--- a/MeetingBar/Resources /Localization /hr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /hr.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "preferences_appearance_menu_show_event_title" = "Prikaži događaj:";
 "preferences_appearance_menu_show_event_end_time_value" = "vrijeme kraja";
 "preferences_appearance_menu_show_event_icon_value" = "ikona";
+"preferences_appearance_menu_show_event_location_value" = "lokacija";
 "preferences_appearance_menu_show_event_details_value" = "detalji kao podizbornik";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /hu.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /hu.lproj/Localizable.strings
@@ -30,6 +30,7 @@
 "preferences_appearance_status_bar_next_event_toggle" = "Csak olyan események mutatása, ami ezelőtt kezdődnek";
 "preferences_appearance_status_bar_next_event_stepper" = "%d perc";
 "preferences_appearance_menu_show_event_icon_value" = "ikon";
+"preferences_appearance_menu_show_event_location_value" = "helyszín";
 "preferences_appearance_menu_show_event_details_value" = "részletek almenüként";
 "preferences_services_link_meeting_title" = "Minden találkozó link megnyitása ebben";
 "preferences_services_create_meeting_title" = "Találkozók létrehozása ezzel";

--- a/MeetingBar/Resources /Localization /it.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /it.lproj/Localizable.strings
@@ -103,6 +103,7 @@
 "preferences_appearance_menu_show_event_title" = "Mostra evento:";
 "preferences_appearance_menu_show_event_end_time_value" = "ora di fine";
 "preferences_appearance_menu_show_event_icon_value" = "icona";
+"preferences_appearance_menu_show_event_location_value" = "luogo";
 "preferences_appearance_menu_show_event_details_value" = "dettagli come sottomenu";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ja.lproj/Localizable.strings
@@ -108,6 +108,7 @@
 "preferences_appearance_menu_show_event_title" = "イベント表示:";
 "preferences_appearance_menu_show_event_end_time_value" = "終了時刻";
 "preferences_appearance_menu_show_event_icon_value" = "アイコン";
+"preferences_appearance_menu_show_event_location_value" = "場所";
 "preferences_appearance_menu_show_event_details_value" = "サブメニューに詳細表示";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /ko.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ko.lproj/Localizable.strings
@@ -93,6 +93,7 @@
 "preferences_appearance_menu_show_event_title" = "이벤트 표시:";
 "preferences_appearance_menu_show_event_end_time_value" = "종료 시간";
 "preferences_appearance_menu_show_event_icon_value" = "아이콘";
+"preferences_appearance_menu_show_event_location_value" = "위치";
 "preferences_appearance_menu_show_event_details_value" = "세부사항";
 "preferences_services_link_meeting_title" = "모든 회의 연결 시";
 "preferences_services_link_service_title" = "%@ 연결 시";

--- a/MeetingBar/Resources /Localization /nb-NO.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /nb-NO.lproj/Localizable.strings
@@ -242,6 +242,7 @@
 "preferences_services_link_meeting_title" = "Åpne alle møtelenker i";
 "preferences_appearance_menu_show_event_details_value" = "detaljer som undermeny";
 "preferences_appearance_menu_show_event_icon_value" = "ikon";
+"preferences_appearance_menu_show_event_location_value" = "sted";
 "preferences_appearance_menu_show_event_end_time_value" = "slutt-tid";
 "preferences_appearance_menu_show_event_title" = "Vis begivenhet:";
 "preferences_appearance_menu_time_format_24_hour_value" = "24-timersklokke";

--- a/MeetingBar/Resources /Localization /nl.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /nl.lproj/Localizable.strings
@@ -56,6 +56,7 @@
 "preferences_appearance_menu_time_format_24_hour_value" = "24 uur";
 "preferences_appearance_menu_show_event_end_time_value" = "eindtijd";
 "preferences_appearance_menu_show_event_icon_value" = "icoon";
+"preferences_appearance_menu_show_event_location_value" = "locatie";
 "preferences_appearance_menu_shorten_event_title_toggle" = "Verkort de titel van de meeting tot";
 "preferences_appearance_menu_show_event_title" = "Toon meeting:";
 "preferences_appearance_menu_show_event_details_value" = "details als submenu";

--- a/MeetingBar/Resources /Localization /pl.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /pl.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "preferences_appearance_menu_show_event_title" = "Pokaż zdarzenie:";
 "preferences_appearance_menu_show_event_end_time_value" = "czas zakończenia";
 "preferences_appearance_menu_show_event_icon_value" = "ikona";
+"preferences_appearance_menu_show_event_location_value" = "lokalizacja";
 "preferences_appearance_menu_show_event_details_value" = "szczegóły jako podmenu";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /pt-BR.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /pt-BR.lproj/Localizable.strings
@@ -108,6 +108,7 @@
 "preferences_appearance_menu_show_event_title" = "Mostrar evento:";
 "preferences_appearance_menu_show_event_end_time_value" = "horário do fim";
 "preferences_appearance_menu_show_event_icon_value" = "ícone";
+"preferences_appearance_menu_show_event_location_value" = "local";
 "preferences_appearance_menu_show_event_details_value" = "detalhes como submenu";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /pt.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /pt.lproj/Localizable.strings
@@ -85,6 +85,7 @@
 "preferences_appearance_menu_show_event_title" = "Mostrar evento:";
 "preferences_appearance_menu_show_event_end_time_value" = "horário do fim";
 "preferences_appearance_menu_show_event_icon_value" = "ícone";
+"preferences_appearance_menu_show_event_location_value" = "local";
 "preferences_appearance_menu_show_event_details_value" = "pormenores como submenu";
 "preferences_services_link_meeting_title" = "Abrir todas as ligações de reunião em";
 "preferences_services_link_default_browser_value" = "Navegador padrão";

--- a/MeetingBar/Resources /Localization /sk.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /sk.lproj/Localizable.strings
@@ -171,6 +171,7 @@
 "preferences_appearance_menu_time_format_24_hour_value" = "24-hodinový";
 "preferences_appearance_menu_show_event_end_time_value" = "čas ukončenia";
 "preferences_appearance_menu_show_event_icon_value" = "ikona";
+"preferences_appearance_menu_show_event_location_value" = "miesto";
 "preferences_appearance_menu_show_event_details_value" = "podrobnosti ako podmenu";
 "preferences_services_create_meeting_title" = "Vytvárať stretnutia cez";
 "preferences_services_google_meet_tip" = "Tip: Google Meet podporuje výber účtu v URL adrese, napr. https://meet.google.com/new?authuser=1";

--- a/MeetingBar/Resources /Localization /ta.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /ta.lproj/Localizable.strings
@@ -100,6 +100,7 @@
 "preferences_appearance_menu_show_event_title" = "நிகழ்வைக் காட்டு:";
 "preferences_appearance_menu_show_event_end_time_value" = "இறுதி நேரம்";
 "preferences_appearance_menu_show_event_icon_value" = "படவுரு";
+"preferences_appearance_menu_show_event_location_value" = "இடம்";
 "preferences_appearance_menu_show_event_details_value" = "விவரங்கள் துணை";
 "preferences_services_link_meeting_title" = "அனைத்து சந்திப்பு இணைப்புகளையும் திறக்கவும்";
 "preferences_services_link_service_title" = "திறந்த %@ இணைப்புகள்";

--- a/MeetingBar/Resources /Localization /tr.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /tr.lproj/Localizable.strings
@@ -87,6 +87,7 @@
 "preferences_appearance_menu_time_format_24_hour_value" = "24-saat";
 "preferences_appearance_menu_show_event_title" = "Etkinliği göster:";
 "preferences_appearance_menu_show_event_icon_value" = "simge";
+"preferences_appearance_menu_show_event_location_value" = "konum";
 "preferences_appearance_menu_show_event_details_value" = "detaylar alt menüde";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /uk.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /uk.lproj/Localizable.strings
@@ -104,6 +104,7 @@
 "preferences_appearance_menu_show_event_title" = "Показувати для події:";
 "preferences_appearance_menu_show_event_end_time_value" = "час закінчення";
 "preferences_appearance_menu_show_event_icon_value" = "значок";
+"preferences_appearance_menu_show_event_location_value" = "місце";
 "preferences_appearance_menu_show_event_details_value" = "деталі як підменю";
 
 // MARK: - Preferences Services

--- a/MeetingBar/Resources /Localization /zh-Hans.lproj/Localizable.strings
+++ b/MeetingBar/Resources /Localization /zh-Hans.lproj/Localizable.strings
@@ -44,3 +44,4 @@
 "preferences_general_feedback_title" = "如有疑问或建议，\n尽管联系：";
 "preferences_general_feedback_email" = "邮箱";
 "preferences_appearance_events_title" = "活动";
+"preferences_appearance_menu_show_event_location_value" = "地点";

--- a/MeetingBar/UI/StatusBar/MenuBuilder.swift
+++ b/MeetingBar/UI/StatusBar/MenuBuilder.swift
@@ -656,7 +656,7 @@ struct MenuBuilder {
         paragraphStyle.headIndent = titleIndent
 
         let locationAttributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.systemFont(ofSize: 12),
+            .font: NSFont.systemFont(ofSize: MenuStyleConstants.secondaryFontSize),
             .foregroundColor: shouldShowAsInactive ? NSColor.disabledControlTextColor : NSColor.secondaryLabelColor,
             .paragraphStyle: paragraphStyle
         ]

--- a/MeetingBar/UI/StatusBar/MenuBuilder.swift
+++ b/MeetingBar/UI/StatusBar/MenuBuilder.swift
@@ -316,12 +316,14 @@ struct MenuBuilder {
             eventEndTime = eventTimeFormatter.string(from: event.endDate)
         }
 
-        let itemTitle: String
+        let itemTitlePrefix: String
         if Defaults[.showEventEndTime] {
-            itemTitle = "\(eventStartTime) \t \(eventEndTime) \t \(eventTitle)"
+            itemTitlePrefix = "\(eventStartTime) \t \(eventEndTime) \t "
         } else {
-            itemTitle = "\(eventStartTime) \t \(eventTitle)"
+            itemTitlePrefix = "\(eventStartTime) \t "
         }
+        let itemTitle = "\(itemTitlePrefix)\(eventTitle)"
+        let itemLocation = eventItemLocation(event)
 
         // Event Item
 
@@ -337,6 +339,7 @@ struct MenuBuilder {
         }
 
         var shouldShowAsActive = true
+        var shouldShowLocationAsInactive = false
         var styles = [NSAttributedString.Key: Any]()
 
         if event.participationStatus == .declined || eventStatus == .canceled {
@@ -346,15 +349,18 @@ struct MenuBuilder {
                 styles[NSAttributedString.Key.strikethroughStyle] = NSUnderlineStyle.thick.rawValue
             }
             shouldShowAsActive = false
+            shouldShowLocationAsInactive = true
         }
 
         if !event.isAllDay, Defaults[.nonAllDayEvents] == .show_inactive_without_meeting_link, event.meetingLink == nil {
             styles[NSAttributedString.Key.foregroundColor] = NSColor.disabledControlTextColor
+            shouldShowLocationAsInactive = true
         }
 
         if event.participationStatus == .pending {
             if Defaults[.showPendingEvents] == .show_inactive {
                 styles[NSAttributedString.Key.foregroundColor] = NSColor.disabledControlTextColor
+                shouldShowLocationAsInactive = true
             } else if Defaults[.showPendingEvents] == .show_underlined {
                 styles[NSAttributedString.Key.underlineStyle] = NSUnderlineStyle.single.rawValue | NSUnderlineStyle.patternDot.rawValue | NSUnderlineStyle.byWord.rawValue
             }
@@ -363,6 +369,7 @@ struct MenuBuilder {
         if event.participationStatus == .tentative {
             if Defaults[.showTentativeEvents] == .show_inactive {
                 styles[NSAttributedString.Key.foregroundColor] = NSColor.disabledControlTextColor
+                shouldShowLocationAsInactive = true
             } else if Defaults[.showTentativeEvents] == .show_underlined {
                 styles[NSAttributedString.Key.underlineStyle] = NSUnderlineStyle.single.rawValue | NSUnderlineStyle.patternDot.rawValue | NSUnderlineStyle.byWord.rawValue
             }
@@ -371,6 +378,7 @@ struct MenuBuilder {
         if event.attendees.isEmpty, Defaults[.personalEventsAppereance] == .show_inactive {
             styles[NSAttributedString.Key.foregroundColor] = NSColor.disabledControlTextColor
             shouldShowAsActive = false
+            shouldShowLocationAsInactive = true
         }
 
         if event.endDate < now, eventStatus != .canceled {
@@ -379,12 +387,24 @@ struct MenuBuilder {
             if Defaults[.pastEventsAppereance] == .show_inactive {
                 styles[NSAttributedString.Key.foregroundColor] = NSColor.disabledControlTextColor
                 styles[NSAttributedString.Key.font] = NSFont.systemFont(ofSize: 14)
+                shouldShowLocationAsInactive = true
 
-                eventItem.attributedTitle = NSAttributedString(
-                    string: itemTitle,
-                    attributes: styles
+                eventItem.attributedTitle = eventItemAttributedTitle(
+                    title: itemTitle,
+                    titlePrefix: itemTitlePrefix,
+                    location: itemLocation,
+                    titleAttributes: styles,
+                    shouldShowLocationAsInactive: shouldShowLocationAsInactive
                 )
                 eventItem.image = eventItem.image?.tintedDisabled()
+            } else {
+                eventItem.attributedTitle = eventItemAttributedTitle(
+                    title: itemTitle,
+                    titlePrefix: itemTitlePrefix,
+                    location: itemLocation,
+                    titleAttributes: styles,
+                    shouldShowLocationAsInactive: shouldShowLocationAsInactive
+                )
             }
         } else if event.startDate < now, event.endDate > now, eventStatus != .canceled {
             eventItem.state = .mixed
@@ -422,12 +442,25 @@ struct MenuBuilder {
                 eventTitle.append(NSAttributedString(string: " "))
                 eventTitle.append(runningIcon)
             }
+            appendLocation(
+                itemLocation,
+                to: eventTitle,
+                titlePrefix: itemTitlePrefix,
+                titleAttributes: styles,
+                shouldShowAsInactive: shouldShowLocationAsInactive
+            )
 
             eventItem.attributedTitle = eventTitle
         } else {
             eventItem.state = .off
             eventItem.offStateImage = nil
-            eventItem.attributedTitle = NSAttributedString(string: itemTitle, attributes: styles)
+            eventItem.attributedTitle = eventItemAttributedTitle(
+                title: itemTitle,
+                titlePrefix: itemTitlePrefix,
+                location: itemLocation,
+                titleAttributes: styles,
+                shouldShowLocationAsInactive: shouldShowLocationAsInactive
+            )
         }
 
         eventItem.representedObject = event
@@ -574,5 +607,94 @@ struct MenuBuilder {
             eventItem.toolTip = event.title
         }
         return eventItem
+    }
+
+    private func eventItemLocation(_ event: MBEvent) -> String? {
+        guard Defaults[.showEventLocation], var location = event.displayLocation else {
+            return nil
+        }
+
+        if Defaults[.shortenEventTitle] {
+            location = shortenTitle(title: location, offset: Defaults[.menuEventTitleLength])
+        }
+
+        return location
+    }
+
+    private func eventItemAttributedTitle(
+        title: String,
+        titlePrefix: String,
+        location: String?,
+        titleAttributes: [NSAttributedString.Key: Any],
+        shouldShowLocationAsInactive: Bool
+    ) -> NSAttributedString {
+        let attributedTitle = NSMutableAttributedString(string: title, attributes: titleAttributes)
+        appendLocation(
+            location,
+            to: attributedTitle,
+            titlePrefix: titlePrefix,
+            titleAttributes: titleAttributes,
+            shouldShowAsInactive: shouldShowLocationAsInactive
+        )
+        return attributedTitle
+    }
+
+    private func appendLocation(
+        _ location: String?,
+        to attributedTitle: NSMutableAttributedString,
+        titlePrefix: String,
+        titleAttributes: [NSAttributedString.Key: Any],
+        shouldShowAsInactive: Bool
+    ) {
+        guard let location else {
+            return
+        }
+
+        let paragraphStyle = NSMutableParagraphStyle()
+        let titleIndent = eventTitleIndent(for: titlePrefix, attributes: titleAttributes)
+        paragraphStyle.firstLineHeadIndent = titleIndent
+        paragraphStyle.headIndent = titleIndent
+
+        let locationAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: 12),
+            .foregroundColor: shouldShowAsInactive ? NSColor.disabledControlTextColor : NSColor.secondaryLabelColor,
+            .paragraphStyle: paragraphStyle
+        ]
+
+        attributedTitle.append(NSAttributedString(string: "\n"))
+        attributedTitle.append(NSAttributedString(string: location, attributes: locationAttributes))
+    }
+
+    private func eventTitleIndent(for titlePrefix: String, attributes: [NSAttributedString.Key: Any]) -> CGFloat {
+        var position: CGFloat = 0
+        var segment = ""
+
+        for character in titlePrefix {
+            if character == "\t" {
+                position += width(of: segment, attributes: attributes)
+                position = nextDefaultTabStop(after: position)
+                segment = ""
+            } else {
+                segment.append(character)
+            }
+        }
+
+        position += width(of: segment, attributes: attributes)
+        return position
+    }
+
+    private func nextDefaultTabStop(after position: CGFloat) -> CGFloat {
+        let appKitFallbackTabInterval: CGFloat = 28
+        let defaultTabInterval = NSParagraphStyle.default.defaultTabInterval
+        let tabInterval = defaultTabInterval > 0 ? defaultTabInterval : appKitFallbackTabInterval
+        return (floor(position / tabInterval) + 1) * tabInterval
+    }
+
+    private func width(of string: String, attributes: [NSAttributedString.Key: Any]) -> CGFloat {
+        var measurementAttributes = attributes
+        if measurementAttributes[.font] == nil {
+            measurementAttributes[.font] = NSFont.systemFont(ofSize: MenuStyleConstants.defaultFontSize)
+        }
+        return (string as NSString).size(withAttributes: measurementAttributes).width
     }
 }

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -15,6 +15,7 @@ import SwiftUI
 
 enum MenuStyleConstants {
     static let defaultFontSize: CGFloat = 13
+    static let secondaryFontSize: CGFloat = defaultFontSize - 1
     static let runningIconName = "running_icon"
     static let appIconName = "AppIcon"
     static let calendarCheckmarkIconName = "iconCalendarCheckmark"
@@ -281,7 +282,7 @@ final class StatusBarItemController {
                     paragraphStyle.alignment = .center
 
                     var styles = [NSAttributedString.Key: Any]()
-                    styles[NSAttributedString.Key.font] = NSFont.systemFont(ofSize: 12)
+                    styles[NSAttributedString.Key.font] = NSFont.systemFont(ofSize: MenuStyleConstants.secondaryFontSize)
                     styles[NSAttributedString.Key.baselineOffset] = -3
 
                     if nextEvent.participationStatus == .pending, Defaults[.showPendingEvents] == .show_inactive {

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -282,7 +282,7 @@ final class StatusBarItemController {
                     paragraphStyle.alignment = .center
 
                     var styles = [NSAttributedString.Key: Any]()
-                    styles[NSAttributedString.Key.font] = NSFont.systemFont(ofSize: MenuStyleConstants.secondaryFontSize)
+                    styles[NSAttributedString.Key.font] = NSFont.systemFont(ofSize: 12)
                     styles[NSAttributedString.Key.baselineOffset] = -3
 
                     if nextEvent.participationStatus == .pending, Defaults[.showPendingEvents] == .show_inactive {

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -68,7 +68,7 @@ final class StatusBarItemController {
             .showEventMaxTimeUntilEventEnabled, .showEventDetails,
             .shortenEventTitle, .menuEventTitleLength,
             .showEventEndTime, .showMeetingServiceIcon,
-            .timeFormat, .bookmarks, .eventTitleFormat,
+            .showEventLocation, .timeFormat, .bookmarks, .eventTitleFormat,
             .personalEventsAppereance, .pastEventsAppereance,
             .declinedEventsAppereance, .ongoingEventVisibility,
             .showTimelineInMenu,

--- a/MeetingBar/UI/Views/Changelog/Changelog.swift
+++ b/MeetingBar/UI/Views/Changelog/Changelog.swift
@@ -186,6 +186,7 @@ struct ChangelogView: View {
                             Text("• Added action to dismiss the event from the notification")
                             Text("• Added support for LiveKit Meet, Meetecho, and StreamYard links")
                             Text("• You can now set any executable as a \"browser\" to open meeting links")
+                            Text("\u{2022} Show event locations in the menu")
                             Text("and a lot of bug fixes and translations updates")
                         }
                     }

--- a/MeetingBar/UI/Views/Preferences/AppearanceTab.swift
+++ b/MeetingBar/UI/Views/Preferences/AppearanceTab.swift
@@ -262,6 +262,7 @@ struct MenuSection: View {
     @Default(.showEventEndTime) var showEventEndTime
     @Default(.showEventDetails) var showEventDetails
     @Default(.showMeetingServiceIcon) var showMeetingServiceIcon
+    @Default(.showEventLocation) var showEventLocation
     @Default(.showTimelineInMenu) var showTimelineInMenu
 
     var body: some View {
@@ -300,6 +301,10 @@ struct MenuSection: View {
                     Toggle(
                         "preferences_appearance_menu_show_event_icon_value".loco(),
                         isOn: $showMeetingServiceIcon
+                    )
+                    Toggle(
+                        "preferences_appearance_menu_show_event_location_value".loco(),
+                        isOn: $showEventLocation
                     )
                     Toggle(
                         "preferences_appearance_menu_show_event_details_value".loco(),

--- a/MeetingBarTests/Helpers/FakeEvent.swift
+++ b/MeetingBarTests/Helpers/FakeEvent.swift
@@ -16,7 +16,8 @@ func makeFakeEvent(
     isAllDay: Bool = false,
     status: MBEventStatus = .confirmed,
     withLink: Bool = false,
-    participationStatus: MBEventAttendeeStatus = .accepted
+    participationStatus: MBEventAttendeeStatus = .accepted,
+    location: String? = nil
 ) -> MBEvent {
     let calendar = MBCalendar(
         title: "Test Calendar",
@@ -36,7 +37,7 @@ func makeFakeEvent(
         title: "Event \(id)",
         status: status,
         notes: nil,
-        location: nil,
+        location: location,
         url: link,
         organizer: nil,
         startDate: start,

--- a/MeetingBarTests/HelpersTests.swift
+++ b/MeetingBarTests/HelpersTests.swift
@@ -118,6 +118,18 @@ class HelpersTests: XCTestCase {
         XCTAssertNil(event.displayLocation)
     }
 
+    func test_displayLocation_urlOnlyPhysicalLocation_returnLocation() {
+        let location = "https://maps.example.com/floor/2"
+        let event = makeFakeEvent(
+            id: "url-only-physical-location",
+            start: Date(),
+            end: Date().addingTimeInterval(60),
+            location: location
+        )
+
+        XCTAssertEqual(event.displayLocation, location)
+    }
+
     func test_displayLocation_mixedPhysicalLocationAndUrl_returnLocation() {
         let location = "Room A https://maps.example.com/floor/2"
         let event = makeFakeEvent(

--- a/MeetingBarTests/HelpersTests.swift
+++ b/MeetingBarTests/HelpersTests.swift
@@ -130,6 +130,18 @@ class HelpersTests: XCTestCase {
         XCTAssertEqual(event.displayLocation, location)
     }
 
+    func test_displayLocation_urlFirstMixedPhysicalLocation_returnLocation() {
+        let location = "https://maps.example.com/floor/2 Room A"
+        let event = makeFakeEvent(
+            id: "url-first-mixed-location",
+            start: Date(),
+            end: Date().addingTimeInterval(60),
+            location: location
+        )
+
+        XCTAssertEqual(event.displayLocation, location)
+    }
+
     func test_displayLocation_hostlessUri_returnLocation() {
         let location = "mailto:frontdesk@example.com"
         let event = makeFakeEvent(

--- a/MeetingBarTests/HelpersTests.swift
+++ b/MeetingBarTests/HelpersTests.swift
@@ -73,4 +73,72 @@ class HelpersTests: XCTestCase {
         let result = hexStringToUIColor(hex: "#FFFF00")
         XCTAssertEqual(result, NSColor.yellow)
     }
+
+    func test_displayLocation_emptyLocation_returnNil() {
+        let event = makeFakeEvent(
+            id: "empty-location",
+            start: Date(),
+            end: Date().addingTimeInterval(60),
+            location: " \n\t "
+        )
+
+        XCTAssertNil(event.displayLocation)
+    }
+
+    func test_displayLocation_normalizesWhitespace() {
+        let event = makeFakeEvent(
+            id: "room-location",
+            start: Date(),
+            end: Date().addingTimeInterval(60),
+            location: "  Room A\nFloor\t2  "
+        )
+
+        XCTAssertEqual(event.displayLocation, "Room A Floor 2")
+    }
+
+    func test_displayLocation_urlOnlyLocation_returnNil() {
+        let event = makeFakeEvent(
+            id: "url-location",
+            start: Date(),
+            end: Date().addingTimeInterval(60),
+            location: "https://zoom.us/j/5551112222"
+        )
+
+        XCTAssertNil(event.displayLocation)
+    }
+
+    func test_displayLocation_urlOnlyCustomSchemeWithHost_returnNil() {
+        let event = makeFakeEvent(
+            id: "custom-url-location",
+            start: Date(),
+            end: Date().addingTimeInterval(60),
+            location: "zoommtg://zoom.us/join?action=join&confno=5551112222"
+        )
+
+        XCTAssertNil(event.displayLocation)
+    }
+
+    func test_displayLocation_mixedPhysicalLocationAndUrl_returnLocation() {
+        let location = "Room A https://maps.example.com/floor/2"
+        let event = makeFakeEvent(
+            id: "mixed-location",
+            start: Date(),
+            end: Date().addingTimeInterval(60),
+            location: location
+        )
+
+        XCTAssertEqual(event.displayLocation, location)
+    }
+
+    func test_displayLocation_hostlessUri_returnLocation() {
+        let location = "mailto:frontdesk@example.com"
+        let event = makeFakeEvent(
+            id: "hostless-location",
+            start: Date(),
+            end: Date().addingTimeInterval(60),
+            location: location
+        )
+
+        XCTAssertEqual(event.displayLocation, location)
+    }
 }

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -201,7 +201,11 @@ final class MenuBuilderEventItemTests: BaseTestCase {
 
         let textStorage = NSTextStorage(attributedString: attributedTitle)
         let layoutManager = NSLayoutManager()
-        let textContainer = NSTextContainer(size: NSSize(width: 1_000, height: CGFloat.greatestFiniteMagnitude))
+        let textContainerSize = NSSize(
+            width: attributedTitle.size().width + MenuStyleConstants.defaultFontSize,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        let textContainer = NSTextContainer(size: textContainerSize)
         textContainer.lineFragmentPadding = 0
 
         layoutManager.addTextContainer(textContainer)

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -7,6 +7,7 @@
 //
 
 import XCTest
+import AppKit
 import Defaults
 @testable import MeetingBar
 
@@ -173,6 +174,47 @@ final class MenuBuilderEventItemTests: BaseTestCase {
                               title: "T",
                               events: [event])
         return items.count > 1 ? items[1] : nil              // 0 = header
+    }
+
+    private func assertLocationAlignsWithEventTitle(
+        event: MBEvent,
+        location: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let attributedTitle = buildItem(event: event)?.attributedTitle else {
+            XCTFail("Expected an attributed event title", file: file, line: line)
+            return
+        }
+
+        let titleRange = (attributedTitle.string as NSString).range(of: event.title)
+        let locationRange = (attributedTitle.string as NSString).range(of: location)
+
+        guard titleRange.location != NSNotFound else {
+            XCTFail("Expected event title in attributed string", file: file, line: line)
+            return
+        }
+        guard locationRange.location != NSNotFound else {
+            XCTFail("Expected event location in attributed string", file: file, line: line)
+            return
+        }
+
+        let textStorage = NSTextStorage(attributedString: attributedTitle)
+        let layoutManager = NSLayoutManager()
+        let textContainer = NSTextContainer(size: NSSize(width: 1_000, height: CGFloat.greatestFiniteMagnitude))
+        textContainer.lineFragmentPadding = 0
+
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+        layoutManager.ensureLayout(for: textContainer)
+
+        let titleGlyphRange = layoutManager.glyphRange(forCharacterRange: titleRange, actualCharacterRange: nil)
+        let locationGlyphRange = layoutManager.glyphRange(forCharacterRange: locationRange, actualCharacterRange: nil)
+        let titleRect = layoutManager.boundingRect(forGlyphRange: titleGlyphRange, in: textContainer)
+        let locationRect = layoutManager.boundingRect(forGlyphRange: locationGlyphRange, in: textContainer)
+
+        XCTAssertEqual(titleRect.minX, locationRect.minX, accuracy: 0.5, file: file, line: line)
+        XCTAssertGreaterThan(locationRect.minY, titleRect.minY, file: file, line: line)
     }
 
     // MARK: – Tests -----------------------------------------------------------
@@ -381,6 +423,50 @@ final class MenuBuilderEventItemTests: BaseTestCase {
 
         XCTAssertTrue(attributedTitle.string.contains(expectedLocation))
         XCTAssertFalse(attributedTitle.string.contains(location))
+    }
+
+    func test_locationAlignsWithTitleForAllDayEvents() {
+        let now = Date()
+        let location = "Room A"
+        let event = makeFakeEvent(
+            id: "ALIGNAD",
+            start: now.addingTimeInterval(-3600),
+            end: now.addingTimeInterval(3600),
+            isAllDay: true,
+            location: location
+        )
+
+        assertLocationAlignsWithEventTitle(event: event, location: location)
+    }
+
+    func test_locationAlignsWithTitleForAmPmTimeFormat() {
+        Defaults[.timeFormat] = .am_pm
+
+        let now = Date()
+        let location = "Room A"
+        let event = makeFakeEvent(
+            id: "ALIGNAMPM",
+            start: now.addingTimeInterval(-300),
+            end: now.addingTimeInterval(900),
+            location: location
+        )
+
+        assertLocationAlignsWithEventTitle(event: event, location: location)
+    }
+
+    func test_locationAlignsWithTitleWhenEndTimeIsHidden() {
+        Defaults[.showEventEndTime] = false
+
+        let now = Date()
+        let location = "Room A"
+        let event = makeFakeEvent(
+            id: "ALIGNNOEND",
+            start: now.addingTimeInterval(-300),
+            end: now.addingTimeInterval(900),
+            location: location
+        )
+
+        assertLocationAlignsWithEventTitle(event: event, location: location)
     }
 }
 

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -252,6 +252,136 @@ final class MenuBuilderEventItemTests: BaseTestCase {
         XCTAssertTrue(font?.fontDescriptor.symbolicTraits.contains(.bold) ?? false,
                       "running event title should be bold")
     }
+
+    func test_eventLocationShownByDefault() {
+        let event = makeFakeEvent(
+            id: "LOC",
+            start: Date().addingTimeInterval(600),
+            end: Date().addingTimeInterval(1200),
+            location: "Room A"
+        )
+
+        let item = buildItem(event: event)
+
+        XCTAssertTrue(Defaults[.showEventLocation])
+        XCTAssertTrue(item?.attributedTitle?.string.contains("\nRoom A") ?? false)
+    }
+
+    func test_eventLocationHiddenWhenSettingIsFalse() {
+        Defaults[.showEventLocation] = false
+
+        let event = makeFakeEvent(
+            id: "HIDELOC",
+            start: Date().addingTimeInterval(600),
+            end: Date().addingTimeInterval(1200),
+            location: "Room A"
+        )
+
+        let item = buildItem(event: event)
+
+        XCTAssertFalse(item?.attributedTitle?.string.contains("Room A") ?? true)
+    }
+
+    func test_urlOnlyLocationHiddenFromCompactRowButShownInDetails() {
+        Defaults[.showEventDetails] = true
+        let location = "https://zoom.us/j/5551112222"
+        let event = makeFakeEvent(
+            id: "URLLOC",
+            start: Date().addingTimeInterval(600),
+            end: Date().addingTimeInterval(1200),
+            location: location
+        )
+
+        let item = buildItem(event: event)
+
+        XCTAssertFalse(item?.attributedTitle?.string.contains(location) ?? true)
+        XCTAssertTrue(item?.submenu?.items.contains { $0.title == location } ?? false)
+    }
+
+    func test_locationDoesNotInheritPendingUnderline() {
+        Defaults[.showPendingEvents] = .show_underlined
+
+        let event = makeFakeEvent(
+            id: "PLOC",
+            start: Date().addingTimeInterval(600),
+            end: Date().addingTimeInterval(1200),
+            participationStatus: .pending,
+            location: "Room A"
+        )
+
+        let attributedTitle = buildItem(event: event)!.attributedTitle!
+        let locationRange = (attributedTitle.string as NSString).range(of: "Room A")
+
+        XCTAssertNotNil(attributedTitle.attribute(.underlineStyle, at: 0, effectiveRange: nil))
+        XCTAssertNotEqual(locationRange.location, NSNotFound)
+        guard locationRange.location != NSNotFound else {
+            return
+        }
+        XCTAssertNil(attributedTitle.attribute(.underlineStyle, at: locationRange.location, effectiveRange: nil))
+
+        let color = attributedTitle.attribute(.foregroundColor, at: locationRange.location, effectiveRange: nil) as? NSColor
+        XCTAssertTrue(color?.isEqual(NSColor.secondaryLabelColor) ?? false)
+    }
+
+    func test_inactiveEventLocationUsesDisabledColor() {
+        Defaults[.showPendingEvents] = .show_inactive
+
+        let event = makeFakeEvent(
+            id: "ILOC",
+            start: Date().addingTimeInterval(600),
+            end: Date().addingTimeInterval(1200),
+            participationStatus: .pending,
+            location: "Room A"
+        )
+
+        let attributedTitle = buildItem(event: event)!.attributedTitle!
+        let locationRange = (attributedTitle.string as NSString).range(of: "Room A")
+
+        XCTAssertNotEqual(locationRange.location, NSNotFound)
+        guard locationRange.location != NSNotFound else {
+            return
+        }
+        let color = attributedTitle.attribute(.foregroundColor, at: locationRange.location, effectiveRange: nil) as? NSColor
+        XCTAssertTrue(color?.isEqual(NSColor.disabledControlTextColor) ?? false)
+    }
+
+    func test_runningEventLocationDoesNotInheritBoldFont() {
+        let now = Date()
+        let runEvent = makeFakeEvent(
+            id: "RUNLOC",
+            start: now.addingTimeInterval(-300),
+            end: now.addingTimeInterval(900),
+            location: "Room A"
+        )
+
+        let attributedTitle = buildItem(event: runEvent)!.attributedTitle!
+        let locationRange = (attributedTitle.string as NSString).range(of: "Room A")
+
+        XCTAssertNotEqual(locationRange.location, NSNotFound)
+        guard locationRange.location != NSNotFound else {
+            return
+        }
+        let font = attributedTitle.attribute(.font, at: locationRange.location, effectiveRange: nil) as? NSFont
+        XCTAssertNotNil(font)
+        XCTAssertFalse(font?.fontDescriptor.symbolicTraits.contains(.bold) ?? true)
+    }
+
+    func test_eventLocationUsesMenuTitleTruncation() {
+        Defaults[.menuEventTitleLength] = 20
+        let location = "Conference room with very long location"
+        let expectedLocation = shortenTitle(title: location, offset: Defaults[.menuEventTitleLength])
+        let event = makeFakeEvent(
+            id: "LONGLOC",
+            start: Date().addingTimeInterval(600),
+            end: Date().addingTimeInterval(1200),
+            location: location
+        )
+
+        let attributedTitle = buildItem(event: event)!.attributedTitle!
+
+        XCTAssertTrue(attributedTitle.string.contains(expectedLocation))
+        XCTAssertFalse(attributedTitle.string.contains(location))
+    }
 }
 
 @MainActor


### PR DESCRIPTION
### Status
**READY**

### Description
Adds a new menu option, enabled by default, to show an event's room or location under the event title in the status menu.

This keeps room names visible for in-person meetings, while hiding locations that are only meeting links so the menu does not get cluttered with Zoom, Teams, or similar URLs. If a location includes both a room and a link, it is still shown. The full original location remains available in the event details menu.

The second line is also kept aligned with the event title across the existing time display options.

## Checklist
- [x] Localized
- [x] Added to changelog:
  - [x] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/UI/Views/Changelog/Changelog.swift)
  - [x] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
1. Build and launch MeetingBar.
2. Open Appearance preferences and check that the new menu location option is available and enabled by default.
3. Use an event with a room location such as `Room A`; open the status menu and check that the room appears under the event title.
4. Use an event whose location is only a meeting link; check that the link is not shown in the compact menu row.
5. Use an event with both a room and a link; check that the location is still shown.
6. Turn the new location option off and check that the status menu no longer shows the second line.
7. Check the row layout with all-day events, 12-hour time, and hidden end time.

Validation run here:
- Checked the diff formatting.
- GitHub checks passed, including Tests, SwiftLint, and Codecov.
- Could not run the macOS test suite locally because this Windows machine does not have Xcode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Event locations now display in the menu.
  * New preference toggle to show or hide event locations in appearance settings.
  * Meeting link URLs are intelligently filtered from location display.

* **Localization**
  * Event location preference label added in 24+ languages.

* **Tests**
  * Added comprehensive test coverage for location display and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->