### PR TITLE
Fix infinite loop in Outlook SafeLink cleanup

### DIFF
--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -220,6 +220,23 @@ func detectMeetingLink(_ rawText: String, customRegexes: [String] = []) -> Meeti
     return nil
 }
 
+/// Rewrites Outlook SafeLink wrappers in `rawText` back to their real
+/// targets, so meeting-link detection sees the underlying URL rather than the
+/// `…safelinks.protection.outlook.com/…url=<encoded>` redirect. Each pass
+/// unwraps the first SafeLink and re-scans, which also resolves SafeLinks
+/// nested inside one another.
+///
+/// The loop is deliberately bounded and only continues while it makes forward
+/// progress. It stops when:
+///
+/// 1. the `url=` value can't be percent-decoded — a malformed or truncated
+///    `%` escape, which `removingPercentEncoding` reports as `nil`;
+/// 2. a rewrite leaves the text unchanged, so the same match would be found
+///    again; or
+/// 3. a hard pass cap is reached, as a final backstop.
+///
+/// Without these guards a single event carrying a malformed SafeLink would
+/// loop forever and wedge calendar sync.
 func cleanupOutlookSafeLinks(rawText: String) -> String {
     guard let outlookSafeLinkRegex else { return rawText }
 

--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -225,24 +225,28 @@ func cleanupOutlookSafeLinks(rawText: String) -> String {
 
     var text = rawText
     autoreleasepool {
-        var links = outlookSafeLinkRegex.matches(
-            in: text, range: NSRange(text.startIndex..., in: text))
-        if !links.isEmpty {
-            repeat {
-                let urlRange = links[0].range(at: 1)
-                let safeLinks = links.compactMap { match -> String? in
-                    guard let range = Range(match.range, in: text) else { return nil }
-                    return String(text[range])
-                }
-                if !safeLinks.isEmpty {
-                    let serviceURL = (text as NSString).substring(with: urlRange)
-                    if let decodedServiceURL = serviceURL.removingPercentEncoding {
-                        text = text.replacingOccurrences(of: safeLinks[0], with: decodedServiceURL)
-                    }
-                }
-                links = outlookSafeLinkRegex.matches(
-                    in: text, range: NSRange(text.startIndex..., in: text))
-            } while !links.isEmpty
+        // Each pass unwraps the first remaining SafeLink and re-scans, which
+        // also handles nested SafeLinks. The loop MUST make forward progress on
+        // every iteration or it spins forever: if the `url=` value can't be
+        // percent-decoded (an invalid `%` sequence) or the rewrite leaves the
+        // text unchanged, the same match is found again every pass. Bound it by
+        // a no-progress break and a hard cap so a single malformed SafeLink can
+        // never wedge calendar sync.
+        let maxPasses = 32
+        for _ in 0 ..< maxPasses {
+            let matches = outlookSafeLinkRegex.matches(
+                in: text, range: NSRange(text.startIndex..., in: text))
+            guard let match = matches.first,
+                  let fullRange = Range(match.range, in: text)
+            else { break }
+
+            let safeLink = String(text[fullRange])
+            let encodedTarget = (text as NSString).substring(with: match.range(at: 1))
+            guard let decodedTarget = encodedTarget.removingPercentEncoding else { break }
+
+            let updated = text.replacingOccurrences(of: safeLink, with: decodedTarget)
+            guard updated != text else { break }
+            text = updated
         }
     }
     return text

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -524,8 +524,11 @@ final class MeetingLinkDetectorTests: XCTestCase {
         let selfReferential = "https://nam11.safelinks.protection.outlook.com/" +
             "?url=https://nam11.safelinks.protection.outlook.com/?url=x"
 
-        // Should return promptly regardless of the exact unwrapped value.
-        _ = cleanupOutlookSafeLinks(rawText: selfReferential)
+        let result = cleanupOutlookSafeLinks(rawText: selfReferential)
+
+        // Terminates, fully unwrapping the nested wrappers to the inner target
+        // rather than looping on the self-reference.
+        XCTAssertEqual(result, "x")
     }
 
     func testDetectionSucceedsForEventCarryingUndecodableSafeLink() {

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -495,4 +495,54 @@ final class MeetingLinkDetectorTests: XCTestCase {
         XCTAssertTrue(stripped.contains("https://meet.google.com/abc-defg-hij"))
         XCTAssertFalse(stripped.contains("<p>"))
     }
+
+    func testCleanupOutlookSafeLinksUnwrapsValidLink() {
+        let target = "https://zoom.us/j/123456789"
+        let safe = outlookSafeLink(for: target)
+
+        XCTAssertEqual(cleanupOutlookSafeLinks(rawText: "Join \(safe) today"), "Join \(target) today")
+    }
+
+    func testCleanupOutlookSafeLinksTerminatesOnUndecodableTarget() {
+        // Regression: a SafeLink whose `url=` value contains an invalid percent
+        // escape ("%xx") makes `removingPercentEncoding` return nil, so the old
+        // `repeat … while !links.isEmpty` loop never rewrote the text and spun
+        // forever — wedging calendar sync on a single malformed event. The
+        // cleanup must now terminate (test would hang/time out if it regressed).
+        let malformed = "Join https://nam11.safelinks.protection.outlook.com/" +
+            "?data=x&url=https%3A%2F%2Fzoom.us%2Fj%2F1%xx end"
+
+        let result = cleanupOutlookSafeLinks(rawText: malformed)
+
+        // Undecodable target is left untouched, but crucially the call returns.
+        XCTAssertEqual(result, malformed)
+    }
+
+    func testCleanupOutlookSafeLinksTerminatesWhenRewriteMakesNoProgress() {
+        // A SafeLink whose decoded `url=` value still contains the same SafeLink
+        // (self-referential) must not loop forever.
+        let selfReferential = "https://nam11.safelinks.protection.outlook.com/" +
+            "?url=https://nam11.safelinks.protection.outlook.com/?url=x"
+
+        // Should return promptly regardless of the exact unwrapped value.
+        _ = cleanupOutlookSafeLinks(rawText: selfReferential)
+    }
+
+    func testDetectionSucceedsForEventCarryingUndecodableSafeLink() {
+        // The end-to-end path that hung in the field: an event whose notes carry
+        // a malformed SafeLink must still produce a detection result (here: the
+        // plain Zoom link present alongside it) without hanging.
+        let notes = "Backup https://nam11.safelinks.protection.outlook.com/" +
+            "?data=x&url=https%3A%2F%2Fbad%xx\nReal: https://zoom.us/j/9999"
+
+        let link = MeetingLinkDetector.detect(
+            location: nil,
+            eventURL: nil,
+            notes: notes,
+            calendarEmail: nil,
+            currentUserEmail: nil
+        )
+
+        XCTAssertEqual(link?.service, .zoom)
+    }
 }


### PR DESCRIPTION
## What's going on

I ran into MeetingBar getting stuck on "Initializing" in the Calendars view on 5.0.0 — no events, and Refresh did nothing. After a fair bit of digging it turned out to be a single calendar event sending `cleanupOutlookSafeLinks` into an infinite loop, which quietly wedges the whole calendar sync.

## Why it happens

`cleanupOutlookSafeLinks` re-matches the first SafeLink each pass and rewrites it to its decoded `url=` target, repeating `while !links.isEmpty`. The loop doesn't guarantee it makes progress:

- If the captured `url=` value isn't valid percent-encoding, `removingPercentEncoding` returns `nil`, the text is never rewritten, and the same match is found again on the next pass — round and round forever.
- Same thing if a rewrite doesn't actually change the text.

The capture stops at the first whitespace, so a meeting URL that's wrapped or truncated in the middle of a `%XX` escape leaves a dangling/incomplete escape, which is exactly what trips `removingPercentEncoding`.

Since the event build runs on a background task, the loop doesn't beachball the UI — it just spins a core and the menu sits on "Initializing". (On older versions, when this ran on the main thread, it showed up as a beachball / high CPU instead.)

This isn't new — it goes back to #199 (2022), so any version with an affected event could hit it.

## The fix

Make the unwrap loop always move forward: stop if the target can't be decoded or if a rewrite leaves the text unchanged, with a hard cap as a backstop. Valid and nested SafeLinks still unwrap exactly as before.

## Tests

Added regression coverage in `MeetingLinkDetectorTests`: an undecodable target, a self-referential SafeLink, a normal SafeLink, nested SafeLinks, and an event that carries a malformed SafeLink next to a valid link. All `MeetingBarLogic` tests pass via `swift test`.

## Possibly related

This might be behind a few existing reports, though I can't say for sure:
- #888 — "becomes unresponsive" with an Outlook account; the reporter even guessed a malformed event was causing a hang. Would be worth checking with them.
- #478 (one appointment pegging 100% CPU) and the #762 / #776 / #796 / #671 hang/freeze cluster look like they could be the same thing.

## Not included

Events whose SafeLink target is genuinely truncated still won't surface a join link — the URL text past the wrap is just gone (similar theme to #791). Recovering those would be a separate change; this PR is only about not hanging.

## A note on the branch

I branched off `master`. Not sure if `v5` is the right base here — happy to do either, just let me know.

## Checklist
- [x] Tests added
- [ ] Localised — no user-facing strings
- [ ] Changelog — happy to add an entry if you'd like


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of Outlook SafeLinks to safely and deterministically unwrap redirect targets, including malformed/undecodable payloads.
  * Added safeguards to prevent non-terminating rewriting loops while ensuring valid meeting links in the same text are still detected correctly.
* **Tests**
  * Added regression tests covering SafeLink unwrapping, malformed `url=` handling, self-referential cases, and end-to-end meeting link detection with mixed valid and invalid links.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->