### PR TITLE
Fix empty edit box when editing a custom regex

### DIFF
--- a/MeetingBar/Preferences/AdvancedTab.swift
+++ b/MeetingBar/Preferences/AdvancedTab.swift
@@ -251,8 +251,7 @@ struct NSScrollableTextViewWrapper: NSViewRepresentable {
 struct FilterEventRegexesSection: View {
     @Default(.filterEventRegexes) var filterEventRegexes
 
-    @State private var showingEditRegexModal = false
-    @State private var regexDraft = RegexEditDraft.adding()
+    @State private var regexDraft: RegexEditDraft?
 
     var body: some View {
         DisclosureGroup("preferences_advanced_event_regex_title".loco()) {
@@ -272,25 +271,24 @@ struct FilterEventRegexesSection: View {
                 Button("preferences_advanced_regex_add_button".loco(), action: openAddRegexModal)
             }
             .padding(.vertical, 4)
-            .sheet(isPresented: $showingEditRegexModal) {
-                EditRegexModal(regex: regexDraft.value, onSave: saveRegex)
+            .sheet(item: $regexDraft) { draft in
+                EditRegexModal(regex: draft.value, onSave: saveRegex)
             }
         }
     }
 
     func openAddRegexModal() {
         regexDraft = .adding()
-        showingEditRegexModal = true
     }
 
     func openEditRegexModal(for regex: String) {
         regexDraft = .editing(regex)
-        showingEditRegexModal = true
     }
 
     func saveRegex(_ regex: String) -> Bool {
-        regexDraft.value = regex
-        switch RegexListEditingPolicy.saving(regexDraft, in: filterEventRegexes) {
+        guard var draft = regexDraft else { return false }
+        draft.value = regex
+        switch RegexListEditingPolicy.saving(draft, in: filterEventRegexes) {
         case .saved(let updated):
             filterEventRegexes = updated
             return true
@@ -309,8 +307,7 @@ struct FilterEventRegexesSection: View {
 struct MeetingRegexesSection: View {
     @Default(.customRegexes) var customRegexes
 
-    @State private var showingEditRegexModal = false
-    @State private var regexDraft = RegexEditDraft.adding()
+    @State private var regexDraft: RegexEditDraft?
     @State private var regexTestText = ""
     @State private var regexTestResult: String?
     @State private var regexTestMatched = false
@@ -352,25 +349,24 @@ struct MeetingRegexesSection: View {
                 }
             }
             .padding(.vertical, 4)
-            .sheet(isPresented: $showingEditRegexModal) {
-                EditRegexModal(regex: regexDraft.value, onSave: saveRegex)
+            .sheet(item: $regexDraft) { draft in
+                EditRegexModal(regex: draft.value, onSave: saveRegex)
             }
         }
     }
 
     func openAddRegexModal() {
         regexDraft = .adding()
-        showingEditRegexModal = true
     }
 
     func openEditRegexModal(for regex: String) {
         regexDraft = .editing(regex)
-        showingEditRegexModal = true
     }
 
     func saveRegex(_ regex: String) -> Bool {
-        regexDraft.value = regex
-        switch RegexListEditingPolicy.saving(regexDraft, in: customRegexes) {
+        guard var draft = regexDraft else { return false }
+        draft.value = regex
+        switch RegexListEditingPolicy.saving(draft, in: customRegexes) {
         case .saved(let updated):
             customRegexes = updated
             return true
@@ -408,12 +404,15 @@ struct MeetingRegexesSection: View {
 
 struct EditRegexModal: View {
     @Environment(\.presentationMode) var presentationMode
-    @State private var draftRegex: String
     let onSave: (_ regex: String) -> Bool
 
+    @State private var draftRegex: String
     @State private var showingAlert = false
     @State private var errorMessage = ""
 
+    // Seeded in init rather than onAppear: `.sheet(item:)` gives the modal a
+    // fresh identity per presentation, so the initial value is applied before
+    // the first render and the field never flashes empty.
     init(regex: String, onSave: @escaping (_ regex: String) -> Bool) {
         _draftRegex = State(initialValue: regex)
         self.onSave = onSave

--- a/MeetingBar/Preferences/PreferencesPresentation.swift
+++ b/MeetingBar/Preferences/PreferencesPresentation.swift
@@ -285,9 +285,14 @@ enum BrowserPickerOptions {
     }
 }
 
-struct RegexEditDraft: Equatable {
+struct RegexEditDraft: Equatable, Identifiable {
     let originalValue: String?
     var value: String
+
+    /// Identity for `.sheet(item:)` presentation. `nil` originalValue (an add)
+    /// gets a distinct id from any edit so the editor rebuilds with the right
+    /// seed value each time it is presented.
+    var id: String { originalValue ?? "" }
 
     static func adding() -> RegexEditDraft {
         RegexEditDraft(originalValue: nil, value: "")


### PR DESCRIPTION
Clicking **edit** on a custom regex (either the "filter out meetings" or "meeting link" list) opened an empty box instead of the pattern I clicked on — so I had to retype the whole thing to make a small change.

The editor was presented with `.sheet(isPresented:)`, whose content gets built once while the draft is still empty and then reused, so the real value never made it in. Switching both sections to `.sheet(item:)` rebuilds the editor with the draft I actually picked, and `RegexEditDraft` is now `Identifiable` to drive that.

After the change: **Add** opens empty as before, **edit** pre-fills with the existing pattern, and the two no longer step on each other.

No logic changed — this is purely the preferences view wiring, so the existing `RegexListEditingPolicy` tests still pass. There is no UI-test target to cover the presentation itself, so I verified it by hand in a local build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the add/edit flow for regex entries in Preferences so the correct edit dialog opens consistently.
  * Updated how the edit draft is managed, reducing mix-ups when switching between adding and editing.
  * Ensured the edit dialog seeds and refreshes its text reliably when presented.
  * Fixed save behavior so it only proceeds when a valid draft is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->