### PR TITLE
Fix Zhumu meeting link detection

### DIFF
--- a/MeetingBar/Meetings/MeetingProvider.swift
+++ b/MeetingBar/Meetings/MeetingProvider.swift
@@ -454,7 +454,7 @@ extension MeetingProvider {
             make(
                 .zhumu,
                 icon: "zhumu_icon",
-                pattern: #"https://welink\.zhumu\.com/(?:j|wc/join)/[0-9]+(?:\?(?:pwd|wpk)=[a-zA-Z0-9]+)?"#),
+                pattern: #"https://welink\.zhumu\.com/(?:j/[0-9]+(?:\?pwd=[A-Za-z0-9]+)?|wc/join/[0-9]+\?wpk=[A-Za-z0-9]+)"#),
 
             // Lark
             make(

--- a/MeetingBar/Meetings/MeetingProvider.swift
+++ b/MeetingBar/Meetings/MeetingProvider.swift
@@ -454,7 +454,7 @@ extension MeetingProvider {
             make(
                 .zhumu,
                 icon: "zhumu_icon",
-                pattern: #"https://welink\.zhumu\.com/j/[0-9]+?pwd=[a-zA-Z0-9]+"#),
+                pattern: #"https://welink\.zhumu\.com/(?:j|wc/join)/[0-9]+(?:\?(?:pwd|wpk)=[a-zA-Z0-9]+)?"#),
 
             // Lark
             make(

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -123,6 +123,36 @@ final class MeetingLinkDetectorTests: XCTestCase {
         }
     }
 
+    func testDetectsZhumuMeetingLinkVariants() {
+        // Real Zhumu/WeMeeting join formats: a `/j/` link with an optional
+        // `?pwd=` passcode, and the web-client `/wc/join/` link with a `?wpk=`
+        // key. The original pattern used `[0-9]+?pwd=` (a lazy quantifier that
+        // ate the `?`), so it never matched a real link.
+        let urls = [
+            "https://welink.zhumu.com/j/154051242?pwd=abc123",
+            "https://welink.zhumu.com/j/150525986",
+            "https://welink.zhumu.com/wc/join/150525986?wpk=wcpk5b53"
+        ]
+
+        for url in urls {
+            let link = detectMeetingLink(url)
+
+            XCTAssertEqual(link?.service, .zhumu, url)
+            XCTAssertEqual(link?.url.absoluteString, url, url)
+        }
+    }
+
+    func testDoesNotMatchNonMeetingZhumuPages() {
+        let urls = [
+            "https://welink.zhumu.com/download",
+            "https://welink.zhumu.com/j/"
+        ]
+
+        for url in urls {
+            XCTAssertNil(detectMeetingLink(url), url)
+        }
+    }
+
     func testDetectsCustomRegexLinkFromNotes() {
         let link = MeetingLinkDetector.detect(
             location: nil,

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -145,7 +145,10 @@ final class MeetingLinkDetectorTests: XCTestCase {
     func testDoesNotMatchNonMeetingZhumuPages() {
         let urls = [
             "https://welink.zhumu.com/download",
-            "https://welink.zhumu.com/j/"
+            "https://welink.zhumu.com/j/",
+            // The web-client form is only a real meeting link with its `?wpk=`
+            // key; a bare `/wc/join/<id>` is not.
+            "https://welink.zhumu.com/wc/join/150525986"
         ]
 
         for url in urls {


### PR DESCRIPTION
I was playing around with all the meeting-link recognitions and noticed this one's regex looked a bit odd: `[0-9]+?pwd=`. That `?` isn't a literal query separator — it's a lazy quantifier on the digits — so the pattern only matches `/j/123pwd=abc`, which isn't a URL Zhumu actually produces. Real links carry a `?` (`/j/123?pwd=abc`) and slip straight through. It's been this way since Zhumu support first landed in 3d9e841 (resolving #369).

I did a bit of digging into what Zhumu links look like in the wild and broadened the pattern to the real formats:
- `/j/<id>` with an optional `?pwd=` passcode
- the web-client `/wc/join/<id>?wpk=` links

Added detector tests for all three, plus a couple confirming non-meeting Zhumu pages still don't match.

**Big caveat:** I've honestly never used Zhumu myself *shrug*, and I'm going purely off links I found online — so I might be misunderstanding the syntax. And given it apparently never worked and nobody reported it, I'm genuinely not sure this is worth fixing. If I've got the format wrong or you'd rather leave it, no hard feelings — feel free to close. :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting link detection for Zhumu/WeMeeting by recognizing more join URL variants and handling optional query parameters more accurately.
  * Reduced false positives by rejecting non-meeting Zhumu pages and incomplete/invalid join link formats.
* **Tests**
  * Added unit tests covering supported `/j/...` and `/wc/join/...` links (including required/optional query parameters) and ensuring invalid URLs return no result.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->