### PR TITLE
Gate FullscreenNotification #Preview behind #if DEBUG

### DIFF
--- a/MeetingBar/UI/Views/FullscreenNotification.swift
+++ b/MeetingBar/UI/Views/FullscreenNotification.swift
@@ -102,6 +102,8 @@ struct VisualEffect: NSViewRepresentable {
     func updateNSView(_: NSView, context _: Context) {}
 }
 
+#if DEBUG
 #Preview {
     FullscreenNotification(event: generateFakeEvent(), window: nil)
 }
+#endif


### PR DESCRIPTION
### Status
**READY**

### Description
`FullscreenNotification.swift` has a SwiftUI `#Preview` that calls `generateFakeEvent()`, but that helper is defined in `Helpers.swift` inside `#if DEBUG` ("Sample event for SwiftUI previews only"). The `#Preview` block itself was not gated, so Release builds fail to compile with `cannot find 'generateFakeEvent' in scope`.

Wrap the preview in `#if DEBUG` so it's only compiled in Debug, matching where its dependency exists. Previews are a dev-time feature and never ship in Release, so this is behavior-preserving: Debug builds and the Xcode canvas preview are unchanged; Release just no longer tries to compile a Debug-only preview.

Build-only change — no runtime behavior change, and no dependency, entitlement, localization, or user-facing changes. (CI builds Debug, so this surfaces only when building the Release configuration / an archive.)

### Steps to Test or Reproduce
1. Build the **Release** configuration, e.g.:`xcodebuild -scheme MeetingBar -configuration Release build` (or `make build-release`).
2. Before this change it fails: `cannot find 'generateFakeEvent' in scope`.
3. After this change it compiles. Debug builds and Xcode previews are unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted a preview-only UI component to debug builds, helping keep non-debug builds cleaner and more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->