### PR TITLE
Don't let a YouTube link in the notes beat the real meeting link

### DIFF
--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -151,30 +151,44 @@ enum MeetingLinkCandidatePolicy {
     /// Picks the best candidate for an event:
     ///
     /// 1. by source priority — provider conference data beats notes;
-    /// 2. within the same source, the longer URL wins so a Zoom link that
+    /// 2. within the same source, catalogue order (`MeetingServices.allCases`)
+    ///    decides between different services, so an incidental YouTube link in
+    ///    the notes cannot shadow the real Meet link;
+    /// 3. within the same service, the longer URL wins so a Zoom link that
     ///    carries a password/token suffix beats a truncated form of the
     ///    same URL found in another source slot.
     static func best(from candidates: [MeetingLinkCandidate]) -> MeetingLinkCandidate? {
-        candidates.max { lhs, rhs in
-            if lhs.source.priority != rhs.source.priority {
-                return lhs.source.priority < rhs.source.priority
-            }
-            return lhs.url.absoluteString.count < rhs.url.absoluteString.count
-        }
+        candidates.min(by: isRankedBefore)
     }
 
     /// Returns candidates ranked best-to-worst, deduplicated by URL string.
     /// Useful for a "open with another link" menu without re-running detection.
     static func ranked(from candidates: [MeetingLinkCandidate]) -> [MeetingLinkCandidate] {
-        let unique = Dictionary(grouping: candidates, by: { $0.url.absoluteString })
+        Dictionary(grouping: candidates, by: { $0.url.absoluteString })
             .compactMapValues { best(from: $0) }
             .values
-        return Array(unique).sorted { lhs, rhs in
-            if lhs.source.priority != rhs.source.priority {
-                return lhs.source.priority > rhs.source.priority
-            }
-            return lhs.url.absoluteString.count > rhs.url.absoluteString.count
+            .sorted(by: isRankedBefore)
+    }
+
+    /// True when `lhs` outranks `rhs`. Candidates with a `nil` service rank
+    /// after every catalogued service.
+    private static func isRankedBefore(_ lhs: MeetingLinkCandidate, _ rhs: MeetingLinkCandidate) -> Bool {
+        if lhs.source.priority != rhs.source.priority {
+            return lhs.source.priority > rhs.source.priority
         }
+        if lhs.service != rhs.service {
+            return catalogueRank(of: lhs.service) < catalogueRank(of: rhs.service)
+        }
+        return lhs.url.absoluteString.count > rhs.url.absoluteString.count
+    }
+
+    private static let catalogueRanks: [MeetingServices: Int] = Dictionary(
+        uniqueKeysWithValues: MeetingServices.allCases.enumerated().map { ($0.element, $0.offset) }
+    )
+
+    private static func catalogueRank(of service: MeetingServices?) -> Int {
+        guard let service else { return Int.max }
+        return catalogueRanks[service, default: Int.max]
     }
 }
 

--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -91,6 +91,18 @@ enum MeetingServices: String, Codable, CaseIterable, Sendable {
     case streamyard = "StreamYard"
     case riverside = "Riverside"
     case other = "Other"
+
+    /// Ranking tier used to break same-source ties between different services.
+    /// Known conferencing services (0) beat content links (1) such as YouTube
+    /// or Vimeo, which beat generic catch-alls like "Any Link"/"Other" (2). An
+    /// untagged (`nil`) service ranks below all of these at the call site.
+    var rankTier: Int {
+        switch self {
+        case .youtube, .vimeo: return 1
+        case .url, .other: return 2
+        default: return 0
+        }
+    }
 }
 
 public struct MeetingLink: Hashable, Equatable, Sendable {
@@ -145,50 +157,122 @@ struct MeetingLinkCandidate: Hashable, Sendable {
     let url: URL
     let service: MeetingServices?
     let source: MeetingLinkSource
+    /// Character offset of the match within its source field's text. Breaks
+    /// same-tier ties in appearance order. Non-scan sources (provider
+    /// conference data, custom regex) use 0.
+    var matchLocation: Int = 0
+
+    // `matchLocation` is ranking metadata, not identity: exclude it from
+    // equality/hashing so candidate identity stays (url, service, source) and
+    // `MBEvent` equality doesn't shift when a link's position in the text moves.
+    static func == (lhs: MeetingLinkCandidate, rhs: MeetingLinkCandidate) -> Bool {
+        lhs.url == rhs.url && lhs.service == rhs.service && lhs.source == rhs.source
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+        hasher.combine(service)
+        hasher.combine(source)
+    }
 }
 
 enum MeetingLinkCandidatePolicy {
     /// Picks the best candidate for an event:
     ///
     /// 1. by source priority — provider conference data beats notes;
-    /// 2. within the same source, catalogue order (`MeetingServices.allCases`)
-    ///    decides between different services, so an incidental YouTube link in
-    ///    the notes cannot shadow the real Meet link;
-    /// 3. within the same service, the longer URL wins so a Zoom link that
-    ///    carries a password/token suffix beats a truncated form of the
-    ///    same URL found in another source slot.
+    /// 2. within the same source, a lower service tier wins — known
+    ///    conferencing links beat content links (YouTube, Vimeo), which beat
+    ///    generic catch-alls, which beat untagged links, so an incidental
+    ///    YouTube link in the notes cannot shadow the real Meet link;
+    /// 3. within the same tier, the service appearing earliest in the field
+    ///    wins, preserving the author's ordering between different services;
+    /// 4. within the same service, the longer URL wins so a Zoom link that
+    ///    carries a password/token suffix beats a truncated form of it.
+    ///
+    /// Position is compared per service group (a service's earliest match), so
+    /// the ordering stays a strict weak ordering: candidates of one service
+    /// cluster together and order among themselves by URL length, while
+    /// distinct services order by first appearance.
     static func best(from candidates: [MeetingLinkCandidate]) -> MeetingLinkCandidate? {
-        candidates.min(by: isRankedBefore)
+        let positions = serviceEarliestPositions(candidates)
+        return candidates.min { isRankedBefore($0, $1, servicePositions: positions) }
     }
 
     /// Returns candidates ranked best-to-worst, deduplicated by URL string.
     /// Useful for a "open with another link" menu without re-running detection.
     static func ranked(from candidates: [MeetingLinkCandidate]) -> [MeetingLinkCandidate] {
-        Dictionary(grouping: candidates, by: { $0.url.absoluteString })
-            .compactMapValues { best(from: $0) }
-            .values
-            .sorted(by: isRankedBefore)
+        let deduped = Array(
+            Dictionary(grouping: candidates, by: { $0.url.absoluteString })
+                .compactMapValues { best(from: $0) }
+                .values
+        )
+        let positions = serviceEarliestPositions(deduped)
+        return deduped.sorted { isRankedBefore($0, $1, servicePositions: positions) }
     }
 
-    /// True when `lhs` outranks `rhs`. Candidates with a `nil` service rank
-    /// after every catalogued service.
-    private static func isRankedBefore(_ lhs: MeetingLinkCandidate, _ rhs: MeetingLinkCandidate) -> Bool {
+    /// Identifies a service within one source field, so a service's earliest
+    /// match position is computed per source (positions from different fields
+    /// are never comparable — source priority separates them first).
+    private struct ServiceGroupKey: Hashable {
+        let source: MeetingLinkSource
+        let service: MeetingServices?
+    }
+
+    /// Earliest `matchLocation` per (source, service) across `candidates`.
+    private static func serviceEarliestPositions(
+        _ candidates: [MeetingLinkCandidate]
+    ) -> [ServiceGroupKey: Int] {
+        var positions: [ServiceGroupKey: Int] = [:]
+        for candidate in candidates {
+            let key = ServiceGroupKey(source: candidate.source, service: candidate.service)
+            positions[key] = Swift.min(positions[key] ?? candidate.matchLocation, candidate.matchLocation)
+        }
+        return positions
+    }
+
+    /// True when `lhs` outranks `rhs`. A total lexicographic ordering over
+    /// (source priority, service tier, service group position, URL length, URL
+    /// string), satisfying the strict-weak-ordering contract `min`/`sorted`
+    /// require. Candidates with a `nil` service rank below every catalogued
+    /// conferencing, content, and generic service.
+    private static func isRankedBefore(
+        _ lhs: MeetingLinkCandidate,
+        _ rhs: MeetingLinkCandidate,
+        servicePositions: [ServiceGroupKey: Int]
+    ) -> Bool {
         if lhs.source.priority != rhs.source.priority {
             return lhs.source.priority > rhs.source.priority
         }
-        if lhs.service != rhs.service {
-            return catalogueRank(of: lhs.service) < catalogueRank(of: rhs.service)
+        let lhsTier = rankTier(of: lhs.service)
+        let rhsTier = rankTier(of: rhs.service)
+        if lhsTier != rhsTier {
+            return lhsTier < rhsTier
         }
-        return lhs.url.absoluteString.count > rhs.url.absoluteString.count
+        let lhsPos = groupPosition(of: lhs, in: servicePositions)
+        let rhsPos = groupPosition(of: rhs, in: servicePositions)
+        if lhsPos != rhsPos {
+            return lhsPos < rhsPos
+        }
+        let lhsLength = lhs.url.absoluteString.count
+        let rhsLength = rhs.url.absoluteString.count
+        if lhsLength != rhsLength {
+            return lhsLength > rhsLength
+        }
+        return lhs.url.absoluteString < rhs.url.absoluteString
     }
 
-    private static let catalogueRanks: [MeetingServices: Int] = Dictionary(
-        uniqueKeysWithValues: MeetingServices.allCases.enumerated().map { ($0.element, $0.offset) }
-    )
+    private static func groupPosition(
+        of candidate: MeetingLinkCandidate,
+        in servicePositions: [ServiceGroupKey: Int]
+    ) -> Int {
+        let key = ServiceGroupKey(source: candidate.source, service: candidate.service)
+        return servicePositions[key] ?? candidate.matchLocation
+    }
 
-    private static func catalogueRank(of service: MeetingServices?) -> Int {
-        guard let service else { return Int.max }
-        return catalogueRanks[service, default: Int.max]
+    /// Untagged (`nil`) services rank below the generic tier; otherwise the
+    /// service's own tier.
+    private static func rankTier(of service: MeetingServices?) -> Int {
+        service?.rankTier ?? 3
     }
 }
 
@@ -331,9 +415,11 @@ extension String {
 /// Picks the best meeting link from an event's available fields.
 ///
 /// Each available field becomes a `MeetingLinkCandidate` tagged with its
-/// `MeetingLinkSource`. Candidates are then ranked by source priority and
-/// — within the same source — by URL length, so a Zoom URL with a
-/// password/token suffix beats a truncated form of the same link.
+/// `MeetingLinkSource`. Candidates are then ranked by source priority and,
+/// within the same source, by service tier (conferencing beats content beats
+/// generic), then URL length for same-service links so a Zoom URL with a
+/// password/token suffix beats a truncated form, and finally the order the
+/// links appear in the field.
 ///
 /// Source order (highest priority first):
 ///
@@ -508,7 +594,8 @@ enum MeetingLinkDetector {
                 return MeetingLinkCandidate(
                     url: url,
                     service: service,
-                    source: source
+                    source: source,
+                    matchLocation: match.range.location
                 )
             }
         }
@@ -539,7 +626,8 @@ enum MeetingLinkDetector {
         return MeetingLinkCandidate(
             url: urlWithAuth,
             service: candidate.service,
-            source: candidate.source
+            source: candidate.source,
+            matchLocation: candidate.matchLocation
         )
     }
 

--- a/MeetingBarLogicTests/MeetingLinkCandidateTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkCandidateTests.swift
@@ -11,9 +11,15 @@ final class MeetingLinkCandidateTests: XCTestCase {
     private func make(
         _ url: String,
         service: MeetingServices? = .other,
-        source: MeetingLinkSource
+        source: MeetingLinkSource,
+        matchLocation: Int = 0
     ) -> MeetingLinkCandidate {
-        MeetingLinkCandidate(url: URL(string: url)!, service: service, source: source)
+        MeetingLinkCandidate(
+            url: URL(string: url)!,
+            service: service,
+            source: source,
+            matchLocation: matchLocation
+        )
     }
 
     // MARK: - best(from:)
@@ -76,7 +82,8 @@ final class MeetingLinkCandidateTests: XCTestCase {
     func testMeetBeatsLongerYouTubeWithinSameSource() {
         // Headline bug: an incidental agenda link in the notes (YouTube) must
         // not beat the real meeting link (Meet) just because its URL is longer.
-        // Same source, different services -> catalogue order decides.
+        // Same source, different services -> service tier decides (conferencing
+        // beats content).
         let youtube = make(
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL2026-team-agenda-recordings",
             service: .youtube, source: .notes)
@@ -84,8 +91,35 @@ final class MeetingLinkCandidateTests: XCTestCase {
         XCTAssertEqual(MeetingLinkCandidatePolicy.best(from: [youtube, meet]), meet)
     }
 
-    func testSourcePriorityWinsOverCatalogueOrder() {
-        // Catalogue order only breaks ties WITHIN a source: a YouTube link the
+    func testConferencingBeatsContentDeclaredEarlierInCatalogue() {
+        // Slack is declared AFTER YouTube in MeetingServices.allCases and here
+        // it also appears later in the field, so the old catalogue-order and
+        // appearance-order tiebreaks would both pick YouTube. Service tiering is
+        // what makes the real conferencing link win.
+        let youtube = make(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL2026-team-agenda-recordings",
+            service: .youtube, source: .notes, matchLocation: 0)
+        let slack = make(
+            "https://app.slack.com/huddle/T1/C1",
+            service: .slack, source: .notes, matchLocation: 90)
+        XCTAssertEqual(MeetingLinkCandidatePolicy.best(from: [youtube, slack]), slack)
+    }
+
+    func testSameTierOrdersByFieldPositionNotCatalogue() {
+        // Two conferencing services, same source and tier: the link appearing
+        // earliest in the field wins. Teams is declared after Zoom in the
+        // catalogue but appears first here, so Teams wins.
+        let teams = make(
+            "https://teams.microsoft.com/l/meetup-join/xyz",
+            service: .teams, source: .notes, matchLocation: 0)
+        let zoom = make(
+            "https://us02web.zoom.us/j/123456",
+            service: .zoom, source: .notes, matchLocation: 60)
+        XCTAssertEqual(MeetingLinkCandidatePolicy.best(from: [zoom, teams]), teams)
+    }
+
+    func testSourcePriorityWinsOverServiceTier() {
+        // Service tier only breaks ties WITHIN a source: a YouTube link the
         // provider explicitly tagged as the conference still beats a Meet link
         // found in free-text notes.
         let youtubeConf = make("https://www.youtube.com/watch?v=abc123", service: .youtube, source: .providerConferenceData)
@@ -127,9 +161,9 @@ final class MeetingLinkCandidateTests: XCTestCase {
         XCTAssertEqual(ranked.first?.source, .providerConferenceData)
     }
 
-    func testRankedOrdersSameSourceByCatalogueOrderNotLength() {
-        // Within one source, ranked(from:) must order by catalogue position
-        // (.meet before .youtube), not by URL length.
+    func testRankedOrdersSameSourceByServiceTierNotLength() {
+        // Within one source, ranked(from:) must order by service tier
+        // (.meet conferencing before .youtube content), not by URL length.
         let youtube = make(
             "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL2026-team-agenda-recordings",
             service: .youtube, source: .notes)
@@ -164,5 +198,85 @@ final class MeetingLinkCandidateTests: XCTestCase {
         XCTAssertGreaterThan(MeetingLinkSource.location.priority, MeetingLinkSource.notes.priority)
         XCTAssertGreaterThan(MeetingLinkSource.notes.priority, MeetingLinkSource.strippedHTMLNotes.priority)
         XCTAssertGreaterThan(MeetingLinkSource.strippedHTMLNotes.priority, MeetingLinkSource.customRegex.priority)
+    }
+
+    // MARK: - MeetingLinkDetector.detect
+
+    func testDetectPrefersMeetOverYouTubeInNotes() {
+        // End-to-end: YouTube appears first in the notes, but the real Meet
+        // link must still win the Join action / status bar icon.
+        let notes = """
+        Agenda recording: https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL2026-team-agenda-recordings
+        Join: https://meet.google.com/abc-defg-hij
+        """
+        let link = MeetingLinkDetector.detect(
+            location: nil,
+            eventURL: nil,
+            notes: notes,
+            calendarEmail: nil,
+            currentUserEmail: nil
+        )
+        XCTAssertEqual(link?.service, .meet)
+        XCTAssertEqual(link?.url.absoluteString, "https://meet.google.com/abc-defg-hij")
+    }
+
+    func testDetectKeepsFieldOrderBetweenSameTierServices() {
+        // Two conferencing links in the notes; the earlier one in the text wins
+        // even though Teams is declared after Zoom in the catalogue.
+        let notes = "First https://teams.microsoft.com/l/meetup-join/abc "
+            + "then https://us02web.zoom.us/j/9999"
+        let link = MeetingLinkDetector.detect(
+            location: nil,
+            eventURL: nil,
+            notes: notes,
+            calendarEmail: nil,
+            currentUserEmail: nil
+        )
+        XCTAssertEqual(link?.service, .teams)
+    }
+
+    // MARK: - ordering contract & metadata
+
+    func testRankingIsTransitiveAcrossSameServiceDuplicates() {
+        // Two Meet links (equal length, so they resolve by URL string) with a
+        // Teams link interleaved by position. A naive "position only between
+        // different services" comparator is intransitive here and picks Teams;
+        // grouping a service's candidates by its earliest position keeps the
+        // order total, so a Meet link wins and the result is permutation-stable.
+        let meetLate = make(
+            "https://meet.google.com/zzz-zzz-zzz", service: .meet, source: .notes, matchLocation: 10)
+        let meetEarly = make(
+            "https://meet.google.com/aaa-aaa-aaa", service: .meet, source: .notes, matchLocation: 30)
+        let teams = make(
+            "https://teams.microsoft.com/l/x0000", service: .teams, source: .notes, matchLocation: 20)
+
+        let best = MeetingLinkCandidatePolicy.best(from: [meetLate, meetEarly, teams])
+        XCTAssertEqual(best, meetEarly, "a Meet link must win, not the interleaved Teams link")
+
+        let expected = [meetEarly, meetLate, teams]
+        for permutation in [[meetLate, meetEarly, teams], [teams, meetLate, meetEarly], [meetEarly, teams, meetLate]] {
+            XCTAssertEqual(
+                MeetingLinkCandidatePolicy.ranked(from: permutation), expected,
+                "ranked order must be stable regardless of input order")
+        }
+    }
+
+    func testAllCandidatesPreservesMatchLocationThroughAuthuser() {
+        // Meet links get an authuser query appended after ranking; that rebuild
+        // must carry matchLocation, not reset it to 0.
+        let notes = "Prefix text before https://meet.google.com/abc-defg-hij"
+        let candidates = MeetingLinkDetector.allCandidates(
+            location: nil,
+            eventURL: nil,
+            notes: notes,
+            calendarEmail: nil,
+            currentUserEmail: "me@example.com"
+        )
+        let meet = candidates.first { $0.service == .meet }
+        XCTAssertNotNil(meet)
+        XCTAssertTrue(
+            meet?.url.absoluteString.contains("authuser=me@example.com") == true,
+            "Meet URL should carry the authuser query")
+        XCTAssertEqual(meet?.matchLocation, 19, "matchLocation must survive the authuser rebuild")
     }
 }

--- a/MeetingBarLogicTests/MeetingLinkCandidateTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkCandidateTests.swift
@@ -73,6 +73,37 @@ final class MeetingLinkCandidateTests: XCTestCase {
         XCTAssertEqual(MeetingLinkCandidatePolicy.best(from: [longNotes, shortConf]), shortConf)
     }
 
+    func testMeetBeatsLongerYouTubeWithinSameSource() {
+        // Headline bug: an incidental agenda link in the notes (YouTube) must
+        // not beat the real meeting link (Meet) just because its URL is longer.
+        // Same source, different services -> catalogue order decides.
+        let youtube = make(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL2026-team-agenda-recordings",
+            service: .youtube, source: .notes)
+        let meet = make("https://meet.google.com/abc-defg-hij", service: .meet, source: .notes)
+        XCTAssertEqual(MeetingLinkCandidatePolicy.best(from: [youtube, meet]), meet)
+    }
+
+    func testSourcePriorityWinsOverCatalogueOrder() {
+        // Catalogue order only breaks ties WITHIN a source: a YouTube link the
+        // provider explicitly tagged as the conference still beats a Meet link
+        // found in free-text notes.
+        let youtubeConf = make("https://www.youtube.com/watch?v=abc123", service: .youtube, source: .providerConferenceData)
+        let meetNotes = make("https://meet.google.com/abc-defg-hij", service: .meet, source: .notes)
+        XCTAssertEqual(MeetingLinkCandidatePolicy.best(from: [meetNotes, youtubeConf]), youtubeConf)
+    }
+
+    func testCataloguedServiceBeatsNilServiceWithinSameSource() {
+        // A candidate matched by any catalogued service — even .other, the
+        // last case — outranks an untagged (service: nil) candidate from the
+        // same source, regardless of URL length.
+        let untagged = make(
+            "https://example.com/some/very/long/incidental/link/found/in/notes",
+            service: nil, source: .notes)
+        let catalogued = make("https://example.com/x", service: .other, source: .notes)
+        XCTAssertEqual(MeetingLinkCandidatePolicy.best(from: [untagged, catalogued]), catalogued)
+    }
+
     // MARK: - ranked(from:)
 
     func testRankedSortsByPriorityDescending() {
@@ -94,6 +125,17 @@ final class MeetingLinkCandidateTests: XCTestCase {
         let ranked = MeetingLinkCandidatePolicy.ranked(from: [notesSame, confSame])
         XCTAssertEqual(ranked.count, 1, "duplicates by URL string collapse to one entry")
         XCTAssertEqual(ranked.first?.source, .providerConferenceData)
+    }
+
+    func testRankedOrdersSameSourceByCatalogueOrderNotLength() {
+        // Within one source, ranked(from:) must order by catalogue position
+        // (.meet before .youtube), not by URL length.
+        let youtube = make(
+            "https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL2026-team-agenda-recordings",
+            service: .youtube, source: .notes)
+        let meet = make("https://meet.google.com/abc", service: .meet, source: .notes)
+        let ranked = MeetingLinkCandidatePolicy.ranked(from: [youtube, meet])
+        XCTAssertEqual(ranked.map(\.service), [.meet, .youtube])
     }
 
     func testRankedReturnsEmptyForEmptyInput() {

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -284,7 +284,7 @@ providerConferenceData  (Google conferenceData.entryPoints)
       > customRegex     (user-defined fallback)
 ```
 
-Within one source, longer URLs win when one is a prefix of another (Zoom truncation case). The chosen candidate becomes `MBEvent.meetingLinkCandidate`; the rest stay as `MBEvent.alternateMeetingLinkCandidates` so the menu can offer "join with another link".
+Within one source, candidates are ranked by service tier (known conferencing services beat content links like YouTube/Vimeo, which beat generic catch-alls, which beat untagged links), then by the order services first appear in the field, and finally — between links of the same service — the longer URL wins so a Zoom link keeps its `?pwd=` token. The chosen candidate becomes `MBEvent.meetingLinkCandidate`; the rest stay as `MBEvent.alternateMeetingLinkCandidates` so the menu can offer "join with another link".
 
 **Do not put link-choosing logic in `MBEvent.init`.** Models are data; the detector is a policy.
 


### PR DESCRIPTION
### Status
**READY**

### Description
Fixes a link-ranking regression from the candidate-based detection work: `MeetingLinkCandidatePolicy` breaks same-source-priority ties by raw URL length across *all* services, so a longer incidental link in an event's notes (e.g. YouTube) beats the actual meeting link (e.g. a shorter Google Meet URL) for the menu bar icon, the join action, and auto-join.

The length tiebreak came in with e6460c0 for the Zoom `?pwd=` truncation case, back when each source field produced at most one candidate — different services could never tie. It became reachable across services in 9199682, when collection started gathering every regex match per source.

`best` and `ranked` now share a single comparator: source priority first (unchanged), then `MeetingServices.allCases` catalogue order when services differ (a `nil` service ranks last), and URL length only between candidates of the same service — preserving the original Zoom-password intent.

## Checklist
- [ ] Localized — n/a, no user-facing strings changed
- [ ] Added to changelog — n/a, fixes an unreleased regression (introduced during 5.0 development)

### Steps to Test or Reproduce
1. Create a calendar event whose notes contain both a YouTube link and a shorter Meet link, e.g. `https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=PL2026-team-agenda-recordings` and `https://meet.google.com/abc-defg-hij`.
2. Without this change, the status bar and join action target the YouTube URL; with it, the Meet link wins. The "open with another link" list also orders Meet ahead of YouTube.
3. `swift test --filter MeetingLinkCandidateTests` — 18 tests: 3 new regression tests (watched fail against the old comparator), a pin that provider conference data still beats notes across services (mutation-tested), and the pre-existing Zoom-truncation test guarding the same-service length rule.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting-link selection with consistent ranking across source priority, conferencing service, match position, and URL details.
  * More reliably distinguishes known conferencing services from generic links and preserves match context when rewriting Meet URLs.
  * Recognizes and decodes nested Google Calendar redirects and Outlook SafeLinks before selecting meeting links.

* **Tests**
  * Expanded coverage for candidate selection, deduplication, tie-breaking, redirects, and alternate-join ordering.

* **Documentation**
  * Updated the meeting-link ranking description to reflect current behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->