### PR TITLE
Fix hung Google token refresh permanently freezing calendar sync

### DIFF
--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
@@ -297,7 +297,7 @@ final class GCEventStore: NSObject,
 
         let task = Task<Void, Error> {
             defer { signInTask = nil }
-            try await TimeoutGuardedCompletion.run(timeout: Self.signInTimeout) { [weak self] completion in
+            try await TimeoutGuardedCompletion.run(timeout: Self.signInTimeout) { [weak self] (completion: @escaping @Sendable (Result<Void, Error>) -> Void) in
                 guard let self else {
                     completion(.failure(AuthError.cancelled))
                     return

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
@@ -50,6 +50,13 @@ final class GCEventStore: NSObject,
     private static let kClientSecret = googleClientSecret
     private static let kRedirectURI  = "com.googleusercontent.apps.\(googleClientNumber):/oauthredirect"
     private static let kKeychainName = googleAuthKeychainName
+    /// A stuck AppAuth token-refresh callback (observed parked across sleep/wake)
+    /// must not wedge every future refresh attempt forever.
+    private static let tokenRefreshTimeout: TimeInterval = 30
+    /// Interactive sign-in can legitimately take minutes, so it gets a much longer
+    /// leash than a token refresh, but still must eventually give up and let the
+    /// next attempt start fresh rather than being awaited forever.
+    private static let signInTimeout: TimeInterval = 300
 
     // MARK: Stored properties
     @MainActor var currentAuthorizationFlow: OIDExternalUserAgentSession?
@@ -288,11 +295,24 @@ final class GCEventStore: NSObject,
         let forceConsent = authState?.refreshToken == nil
         if let running = signInTask { return try await running.value }
 
-        let task = Task {
-            try await signIn(forcePrompt: forceConsent)
+        let task = Task<Void, Error> {
+            defer { signInTask = nil }
+            try await TimeoutGuardedCompletion.run(timeout: Self.signInTimeout) { [weak self] completion in
+                guard let self else {
+                    completion(.failure(AuthError.cancelled))
+                    return
+                }
+                Task {
+                    do {
+                        try await self.signIn(forcePrompt: forceConsent)
+                        completion(.success(()))
+                    } catch {
+                        completion(.failure(error))
+                    }
+                }
+            }
         }
         signInTask = task
-        defer { signInTask = nil }
         try await task.value
     }
 
@@ -320,25 +340,29 @@ final class GCEventStore: NSObject,
 
         let task = Task<String, Error> {
             defer { refreshTask = nil }
-            return try await withCheckedThrowingContinuation { cont in
-                if forceRefresh { state.setNeedsTokenRefresh() }
+            if forceRefresh { state.setNeedsTokenRefresh() }
 
-                state.performAction { [weak self] accessToken, _, error in
-                    guard let self else { return }
-                    if let token = accessToken {
-                        cont.resume(returning: token) // stateChangeDelegate persists new tokens
-                    } else if let error {
-                        let nsError = error as NSError
-                        if nsError.domain == OIDOAuthTokenErrorDomain {
-                            self.clearAuthState()
-                            cont.resume(throwing: AuthError.notSignedIn)
+            do {
+                return try await TimeoutGuardedCompletion.run(timeout: Self.tokenRefreshTimeout) { completion in
+                    state.performAction { accessToken, _, error in
+                        if let token = accessToken {
+                            completion(.success(token)) // stateChangeDelegate persists new tokens
+                        } else if let error {
+                            completion(.failure(error))
                         } else {
-                            cont.resume(throwing: error)
+                            completion(.failure(AuthError.refreshFailed))
                         }
-                    } else {
-                        cont.resume(throwing: AuthError.refreshFailed)
                     }
                 }
+            } catch is OperationTimedOut {
+                throw AuthError.refreshFailed
+            } catch {
+                let nsError = error as NSError
+                if nsError.domain == OIDOAuthTokenErrorDomain {
+                    self.clearAuthState()
+                    throw AuthError.notSignedIn
+                }
+                throw error
             }
         }
 

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
@@ -98,7 +98,7 @@ struct OperationTimedOut: Error {}
 enum TimeoutGuardedCompletion {
     static func run<T: Sendable>(
         timeout: TimeInterval,
-        operation: @escaping (@escaping @Sendable (Result<T, Error>) -> Void) -> Void
+        operation: sending @escaping (@escaping @Sendable (Result<T, Error>) -> Void) -> Void
     ) async throws -> T {
         try await withCheckedThrowingContinuation { continuation in
             let resumer = SingleResume(continuation)

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
@@ -86,3 +86,56 @@ enum GoogleCalendarBatchPolicy {
         return events
     }
 }
+
+/// Thrown by `TimeoutGuardedCompletion.run` when `operation` doesn't call back in time.
+struct OperationTimedOut: Error {}
+
+/// Runs a completion-callback-based `operation`, racing it against a hard timeout so a
+/// callback that never fires (e.g. AppAuth's token refresh parked across sleep/wake)
+/// can't wedge the awaiting call forever. Whichever of the real callback or the timeout
+/// fires first wins; the other is a no-op, so `operation`'s completion is safe to invoke
+/// late without double-resuming the caller.
+enum TimeoutGuardedCompletion {
+    static func run<T: Sendable>(
+        timeout: TimeInterval,
+        operation: @escaping (@escaping @Sendable (Result<T, Error>) -> Void) -> Void
+    ) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            let resumer = SingleResume(continuation)
+
+            let timeoutTask = Task {
+                try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+                resumer.resume(with: .failure(OperationTimedOut()))
+            }
+
+            operation { result in
+                timeoutTask.cancel()
+                resumer.resume(with: result)
+            }
+        }
+    }
+}
+
+/// Resumes a `CheckedContinuation` at most once, even when the real completion and the
+/// timeout race to resume it concurrently.
+private final class SingleResume<T: Sendable>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<T, Error>?
+
+    init(_ continuation: CheckedContinuation<T, Error>) {
+        self.continuation = continuation
+    }
+
+    func resume(with result: Result<T, Error>) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        lock.unlock()
+
+        guard let pending else { return }
+        switch result {
+        case let .success(value): pending.resume(returning: value)
+        case let .failure(error): pending.resume(throwing: error)
+        }
+    }
+}

--- a/MeetingBarLogicTests/TimeoutGuardedCompletionTests.swift
+++ b/MeetingBarLogicTests/TimeoutGuardedCompletionTests.swift
@@ -1,0 +1,99 @@
+//
+//  TimeoutGuardedCompletionTests.swift
+//  MeetingBarLogicTests
+//
+
+import XCTest
+
+@testable import MeetingBarLogic
+
+final class TimeoutGuardedCompletionTests: XCTestCase {
+    private struct StubError: Error {}
+
+    func testCallbackThatNeverFiresThrowsWithinTimeoutInsteadOfHanging() async {
+        let start = Date()
+
+        do {
+            _ = try await TimeoutGuardedCompletion.run(timeout: 0.05) { (completion: (Result<String, Error>) -> Void) in
+                // Simulates a hung AppAuth callback: completion is never called.
+                _ = completion
+            }
+            XCTFail("Expected OperationTimedOut")
+        } catch is OperationTimedOut {
+            // expected
+        } catch {
+            XCTFail("Expected OperationTimedOut, got \(error)")
+        }
+
+        XCTAssertLessThan(Date().timeIntervalSince(start), 1.0, "must not hang past the timeout")
+    }
+
+    func testFastCallbackResolvesWithoutWaitingForTimeout() async throws {
+        let start = Date()
+
+        let value = try await TimeoutGuardedCompletion.run(timeout: 10) { (completion: (Result<String, Error>) -> Void) in
+            completion(.success("token"))
+        }
+
+        XCTAssertEqual(value, "token")
+        XCTAssertLessThan(Date().timeIntervalSince(start), 1.0, "should resolve immediately, not wait for the timeout")
+    }
+
+    func testCallbackFailureIsPropagated() async {
+        do {
+            _ = try await TimeoutGuardedCompletion.run(timeout: 10) { (completion: (Result<String, Error>) -> Void) in
+                completion(.failure(StubError()))
+            }
+            XCTFail("Expected StubError")
+        } catch is StubError {
+            // expected
+        } catch {
+            XCTFail("Expected StubError, got \(error)")
+        }
+    }
+
+    func testLateCallbackAfterTimeoutIsIgnoredAndDoesNotCrash() async throws {
+        final class LateCompletionBox: @unchecked Sendable {
+            var completion: (@Sendable (Result<String, Error>) -> Void)?
+        }
+        let box = LateCompletionBox()
+
+        do {
+            _ = try await TimeoutGuardedCompletion.run(timeout: 0.05) { (completion: @escaping @Sendable (Result<String, Error>) -> Void) in
+                box.completion = completion
+            }
+            XCTFail("Expected OperationTimedOut")
+        } catch is OperationTimedOut {
+            // expected
+        }
+
+        // The real callback fires after we've already timed out. This must not
+        // crash (double-resuming a CheckedContinuation is a fatal error) or
+        // otherwise have any observable effect.
+        box.completion?(.success("late-token"))
+    }
+
+    func testSubsequentCallIsNotBlockedByAnEarlierHungOperation() async throws {
+        do {
+            _ = try await TimeoutGuardedCompletion.run(timeout: 0.05) { (completion: (Result<String, Error>) -> Void) in
+                // never calls back — simulates the wedged refresh
+                _ = completion
+            }
+            XCTFail("Expected OperationTimedOut")
+        } catch is OperationTimedOut {
+            // expected
+        }
+
+        let start = Date()
+        let value = try await TimeoutGuardedCompletion.run(timeout: 10) { (completion: (Result<String, Error>) -> Void) in
+            completion(.success("fresh-token"))
+        }
+
+        XCTAssertEqual(value, "fresh-token")
+        XCTAssertLessThan(
+            Date().timeIntervalSince(start),
+            1.0,
+            "a later call must not be blocked by the earlier hung operation"
+        )
+    }
+}


### PR DESCRIPTION
### Status
**READY**

### Description

Fixes a reliability bug in the Google Calendar provider where a single hung OAuth token refresh permanently freezes all calendar refreshes with no error, no retry, and no user-visible signal.

This caused a real user-facing failure (observed on v4.11.6; the same pattern exists on master): token refreshes stopped silently after a sleep/wake cycle, the menu kept showing the previous day's events all greyed out (past-event styling), the status bar lost its countdown, and no notifications fired until the app was manually restarted.

**Root cause** (`GCEventStore.validAccessToken`): token refreshes are serialized through a stored `refreshTask`, and the task body wraps AppAuth's `OIDAuthState.performAction` callback in a continuation. If `performAction` never invokes its callback (observed in the wild — e.g. its internal token-endpoint request gets parked across sleep/wake), the continuation never resumes, `defer { refreshTask = nil }` never runs, and every subsequent fetch awaits the dead task forever. There was no timeout anywhere in this path. Additionally, the `guard let self else { return }` inside the callback could leak the continuation outright, and the same serialize-through-a-stored-task pattern in `ensureSignedIn`/`signInTask` had the same wedge risk.

**Fix**:

* New `TimeoutGuardedCompletion` helper (in `GoogleCalendarPolicy.swift`, part of the `MeetingBarLogic` package) that races a completion-callback-based operation against a hard timeout and guarantees the continuation resumes exactly once, even when the timeout and a late callback race.
* `validAccessToken` wraps `performAction` with a 30s timeout; on timeout it throws `AuthError.refreshFailed`, `refreshTask` is always cleared, and the existing `ProviderHealth` machinery surfaces the stale-data warning as it already does for thrown errors.
* `ensureSignedIn` gets the same protection with a 5-minute timeout (interactive sign-in can legitimately take a while), so a never-completing sign-in can no longer block all future refreshes.
* The `guard let self` continuation leak is gone — the AppAuth callback no longer touches `self`.

No public API changes; EventKit provider untouched.

## Checklist
- [ ] Localized (no user-facing strings added)
- [ ] Added to changelog — no unreleased section exists yet; happy to add entries once the target version is known:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/UI/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce

1. `make test` — new unit tests in `MeetingBarLogicTests/TimeoutGuardedCompletionTests.swift` cover: a callback that never fires throws within the timeout instead of hanging; a late callback after timeout is safely ignored (no double-resume crash); a subsequent call is not blocked by an earlier hung operation; fast success/failure paths are unaffected.
2. Full CI (SwiftPM logic tests + app-hosted tests + lint) is green on the fork: 213 + 429 tests, 0 failures.
3. The hung-callback condition itself only reproduces on rare network/sleep-wake edge cases, so end-to-end verification was regression-focused: sign-in and calendar refresh flow through the new timeout wrapper unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Google Calendar sign-in now completes with a clear cancellation or timeout result instead of remaining indefinitely.
  * Token refresh operations are time-limited and report a refresh failure when they exceed the allowed duration.
  * Authentication state continues to be cleared appropriately when authorization is no longer valid.
* **Tests**
  * Added coverage for sign-in and token-refresh timeout behavior, delayed callbacks, failures, and subsequent operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->