### PR TITLE
Strip HTML notes without leaking mach ports

### DIFF
--- a/MeetingBar/Extensions/String.swift
+++ b/MeetingBar/Extensions/String.swift
@@ -28,20 +28,16 @@ extension String {
     }
 
     /// Returns a version of the string with all HTML tags removed, if any.
+    ///
+    /// Uses the pure-Foundation `HTMLPlainText` strip rather than
+    /// `NSAttributedString(html:)`, which leaks mach ports via TextKit's
+    /// `nsattributedstringagent` XPC service (see `htmlTagsStrippedForMeetingLinks`).
     /// - Returns: The string without HTML tags.
     func htmlTagsStripped() -> String {
         if !containsHTML {
             return self
         }
-        return autoreleasepool {
-            guard let dataUTF16 = self.data(using: .utf16) else {
-                return self
-            }
-
-            let attributedString = NSAttributedString(html: dataUTF16, options: [.documentType: NSAttributedString.DocumentType.html], documentAttributes: nil)
-
-            return attributedString?.string ?? self
-        }
+        return HTMLPlainText.from(self)
     }
 
     func fileName() -> String {

--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -314,24 +314,40 @@ extension String {
 /// symbols, and the full Latin-1 accented-letter set (café, München, …). Named
 /// entities outside this table are left as written; numeric coverage is total.
 enum HTMLPlainText {
+    private static let scriptStyleRegex = makeRegex(#"(?is)<(script|style)\b[^>]*>.*?</\1>"#)
+    private static let blockTagRegex =
+        makeRegex(#"(?i)<br\s*/?>|</p>|</div>|</li>|</tr>|</h[1-6]>|</blockquote>"#)
+    private static let anyTagRegex = makeRegex("<[^>]+>")
+    private static let trailingSpaceRegex = makeRegex(#"[ \t]+\n"#)
+    private static let blankLinesRegex = makeRegex(#"\n{3,}"#)
+
     static func from(_ html: String) -> String {
         // Drop <script>/<style> elements entirely (tag *and* body); stripping
         // only the tags would leak their CSS/JS text into the output.
-        var text = html.replacingOccurrences(
-            of: #"(?is)<(script|style)\b[^>]*>.*?</\1>"#,
-            with: "",
-            options: .regularExpression
-        )
-        text = text.replacingOccurrences(
-            of: #"(?i)<br\s*/?>|</p>|</div>|</li>|</tr>|</h[1-6]>|</blockquote>"#,
-            with: "\n",
-            options: .regularExpression
-        )
-        text = text.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+        var text = replacingMatches(scriptStyleRegex, in: html, with: "")
+        // Block-level boundaries become newlines so notes keep their structure.
+        text = replacingMatches(blockTagRegex, in: text, with: "\n")
+        text = replacingMatches(anyTagRegex, in: text, with: "")
         text = decodeEntities(in: text)
-        text = text.replacingOccurrences(of: #"[ \t]+\n"#, with: "\n", options: .regularExpression)
-        text = text.replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
+        text = replacingMatches(trailingSpaceRegex, in: text, with: "\n")
+        text = replacingMatches(blankLinesRegex, in: text, with: "\n\n")
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// Patterns are compile-time constants (a bad one is a programmer error), so
+    /// compile once at first use and reuse — `from(_:)` runs per event on every
+    /// calendar refresh, and recompiling each call was pure overhead.
+    private static func makeRegex(_ pattern: String) -> NSRegularExpression {
+        try! NSRegularExpression(pattern: pattern)
+    }
+
+    private static func replacingMatches(
+        _ regex: NSRegularExpression,
+        in text: String,
+        with template: String
+    ) -> String {
+        let range = NSRange(text.startIndex..., in: text)
+        return regex.stringByReplacingMatches(in: text, range: range, withTemplate: template)
     }
 
     private static func decodeEntities(in text: String) -> String {

--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -315,7 +315,14 @@ extension String {
 /// entities outside this table are left as written; numeric coverage is total.
 enum HTMLPlainText {
     static func from(_ html: String) -> String {
+        // Drop <script>/<style> elements entirely (tag *and* body); stripping
+        // only the tags would leak their CSS/JS text into the output.
         var text = html.replacingOccurrences(
+            of: #"(?is)<(script|style)\b[^>]*>.*?</\1>"#,
+            with: "",
+            options: .regularExpression
+        )
+        text = text.replacingOccurrences(
             of: #"(?i)<br\s*/?>|</p>|</div>|</li>|</tr>|</h[1-6]>|</blockquote>"#,
             with: "\n",
             options: .regularExpression
@@ -333,13 +340,21 @@ enum HTMLPlainText {
         result.reserveCapacity(text.count)
         var cursor = text.startIndex
         while cursor < text.endIndex {
-            guard text[cursor] == "&",
-                  let semicolon = text[cursor...].firstIndex(of: ";"),
-                  text.distance(from: cursor, to: semicolon) <= 12,
-                  let decoded = decode(entity: text[text.index(after: cursor)..<semicolon])
-            else {
+            guard text[cursor] == "&" else {
                 result.append(text[cursor])
                 cursor = text.index(after: cursor)
+                continue
+            }
+            // Bound the `;` search to a short window (`&` + up to 12 chars) so
+            // pathological input with many stray `&` stays linear, not quadratic.
+            let windowEnd = text.index(cursor, offsetBy: 13, limitedBy: text.endIndex)
+                ?? text.endIndex
+            let afterAmp = text.index(after: cursor)
+            guard let semicolon = text[afterAmp..<windowEnd].firstIndex(of: ";"),
+                  let decoded = decode(entity: text[afterAmp..<semicolon])
+            else {
+                result.append(text[cursor])
+                cursor = afterAmp
                 continue
             }
             result.append(decoded)

--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -287,29 +287,86 @@ func getMatch(text: String, regex: NSRegularExpression) -> String? {
     return match
 }
 
+/// Converts an HTML notes fragment to plain text.
+///
+/// Deliberately avoids `NSAttributedString(html:)`: that initializer spins up
+/// TextKit's `com.apple.textkit.nsattributedstringagent` XPC service and leaks
+/// ~2 mach ports per call that are never reclaimed. Meeting-link detection runs
+/// this for every event with HTML notes on every calendar refresh, so over a
+/// day of refreshes the process port table fills and the kernel kills the app
+/// with EXC_GUARD ("allocating too many mach ports"). `HTMLPlainText` is a
+/// pure-Foundation strip with no XPC.
 func htmlTagsStrippedForMeetingLinks(_ text: String) -> String {
-    if !text.containsHTMLTags {
-        return text
-    }
-
-    return autoreleasepool {
-        guard let dataUTF16 = text.data(using: .utf16) else {
-            return text
-        }
-
-        let attributedString = NSAttributedString(
-            html: dataUTF16,
-            options: [.documentType: NSAttributedString.DocumentType.html],
-            documentAttributes: nil
-        )
-        return attributedString?.string ?? text
-    }
+    guard text.containsHTMLTags else { return text }
+    return HTMLPlainText.from(text)
 }
 
 extension String {
     fileprivate var containsHTMLTags: Bool {
         range(of: #"</?[A-z][ \t\S]*>"#, options: .regularExpression) != nil
     }
+}
+
+/// Pure-Foundation HTML→plain-text conversion (no TextKit / XPC). Maps
+/// block-level tags to newlines, removes every other tag, and decodes HTML
+/// entities including decimal (`&#123;`) and hex (`&#x7B;`) numeric forms.
+enum HTMLPlainText {
+    static func from(_ html: String) -> String {
+        var text = html.replacingOccurrences(
+            of: #"(?i)<br\s*/?>|</p>|</div>|</li>|</tr>|</h[1-6]>|</blockquote>"#,
+            with: "\n",
+            options: .regularExpression
+        )
+        text = text.replacingOccurrences(of: "<[^>]+>", with: "", options: .regularExpression)
+        text = decodeEntities(in: text)
+        text = text.replacingOccurrences(of: #"[ \t]+\n"#, with: "\n", options: .regularExpression)
+        text = text.replacingOccurrences(of: #"\n{3,}"#, with: "\n\n", options: .regularExpression)
+        return text.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func decodeEntities(in text: String) -> String {
+        guard text.contains("&") else { return text }
+        var result = ""
+        result.reserveCapacity(text.count)
+        var cursor = text.startIndex
+        while cursor < text.endIndex {
+            guard text[cursor] == "&",
+                  let semicolon = text[cursor...].firstIndex(of: ";"),
+                  text.distance(from: cursor, to: semicolon) <= 12,
+                  let decoded = decode(entity: text[text.index(after: cursor)..<semicolon])
+            else {
+                result.append(text[cursor])
+                cursor = text.index(after: cursor)
+                continue
+            }
+            result.append(decoded)
+            cursor = text.index(after: semicolon)
+        }
+        return result
+    }
+
+    private static func decode(entity: Substring) -> Character? {
+        if entity.first == "#" {
+            let digits = entity.dropFirst()
+            let value: UInt32?
+            if let marker = digits.first, marker == "x" || marker == "X" {
+                value = UInt32(digits.dropFirst(), radix: 16)
+            } else {
+                value = UInt32(digits, radix: 10)
+            }
+            guard let value, let scalar = Unicode.Scalar(value) else { return nil }
+            return Character(scalar)
+        }
+        return namedEntities[String(entity)]
+    }
+
+    private static let namedEntities: [String: Character] = [
+        "amp": "&", "lt": "<", "gt": ">", "quot": "\"", "apos": "'",
+        "nbsp": " ", "copy": "\u{00A9}", "reg": "\u{00AE}", "trade": "\u{2122}",
+        "mdash": "\u{2014}", "ndash": "\u{2013}", "hellip": "\u{2026}",
+        "lsquo": "\u{2018}", "rsquo": "\u{2019}", "ldquo": "\u{201C}",
+        "rdquo": "\u{201D}", "middot": "\u{00B7}", "bull": "\u{2022}"
+    ]
 }
 
 // MARK: - Detector

--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -309,7 +309,10 @@ extension String {
 
 /// Pure-Foundation HTML→plain-text conversion (no TextKit / XPC). Maps
 /// block-level tags to newlines, removes every other tag, and decodes HTML
-/// entities including decimal (`&#123;`) and hex (`&#x7B;`) numeric forms.
+/// entities: any numeric entity (decimal `&#123;` or hex `&#x7B;`), plus the
+/// named entities below — the five XML predefined names, common typographic
+/// symbols, and the full Latin-1 accented-letter set (café, München, …). Named
+/// entities outside this table are left as written; numeric coverage is total.
 enum HTMLPlainText {
     static func from(_ html: String) -> String {
         var text = html.replacingOccurrences(
@@ -361,11 +364,45 @@ enum HTMLPlainText {
     }
 
     private static let namedEntities: [String: Character] = [
-        "amp": "&", "lt": "<", "gt": ">", "quot": "\"", "apos": "'",
-        "nbsp": " ", "copy": "\u{00A9}", "reg": "\u{00AE}", "trade": "\u{2122}",
+        // XML predefined + structural
+        "amp": "&", "lt": "<", "gt": ">", "quot": "\"", "apos": "'", "nbsp": " ",
+        // Typographic symbols
+        "copy": "\u{00A9}", "reg": "\u{00AE}", "trade": "\u{2122}",
         "mdash": "\u{2014}", "ndash": "\u{2013}", "hellip": "\u{2026}",
         "lsquo": "\u{2018}", "rsquo": "\u{2019}", "ldquo": "\u{201C}",
-        "rdquo": "\u{201D}", "middot": "\u{00B7}", "bull": "\u{2022}"
+        "rdquo": "\u{201D}", "middot": "\u{00B7}", "bull": "\u{2022}",
+        "euro": "\u{20AC}", "pound": "\u{00A3}", "cent": "\u{00A2}",
+        "yen": "\u{00A5}", "sect": "\u{00A7}", "para": "\u{00B6}",
+        "deg": "\u{00B0}", "plusmn": "\u{00B1}", "times": "\u{00D7}",
+        "divide": "\u{00F7}", "micro": "\u{00B5}", "laquo": "\u{00AB}",
+        "raquo": "\u{00BB}", "iexcl": "\u{00A1}", "iquest": "\u{00BF}",
+        "frac12": "\u{00BD}", "frac14": "\u{00BC}", "frac34": "\u{00BE}",
+        "ordm": "\u{00BA}", "ordf": "\u{00AA}", "sup1": "\u{00B9}",
+        "sup2": "\u{00B2}", "sup3": "\u{00B3}",
+        // Latin-1 accented letters (uppercase)
+        "Agrave": "\u{00C0}", "Aacute": "\u{00C1}", "Acirc": "\u{00C2}",
+        "Atilde": "\u{00C3}", "Auml": "\u{00C4}", "Aring": "\u{00C5}",
+        "AElig": "\u{00C6}", "Ccedil": "\u{00C7}", "Egrave": "\u{00C8}",
+        "Eacute": "\u{00C9}", "Ecirc": "\u{00CA}", "Euml": "\u{00CB}",
+        "Igrave": "\u{00CC}", "Iacute": "\u{00CD}", "Icirc": "\u{00CE}",
+        "Iuml": "\u{00CF}", "ETH": "\u{00D0}", "Ntilde": "\u{00D1}",
+        "Ograve": "\u{00D2}", "Oacute": "\u{00D3}", "Ocirc": "\u{00D4}",
+        "Otilde": "\u{00D5}", "Ouml": "\u{00D6}", "Oslash": "\u{00D8}",
+        "Ugrave": "\u{00D9}", "Uacute": "\u{00DA}", "Ucirc": "\u{00DB}",
+        "Uuml": "\u{00DC}", "Yacute": "\u{00DD}", "THORN": "\u{00DE}",
+        "szlig": "\u{00DF}",
+        // Latin-1 accented letters (lowercase)
+        "agrave": "\u{00E0}", "aacute": "\u{00E1}", "acirc": "\u{00E2}",
+        "atilde": "\u{00E3}", "auml": "\u{00E4}", "aring": "\u{00E5}",
+        "aelig": "\u{00E6}", "ccedil": "\u{00E7}", "egrave": "\u{00E8}",
+        "eacute": "\u{00E9}", "ecirc": "\u{00EA}", "euml": "\u{00EB}",
+        "igrave": "\u{00EC}", "iacute": "\u{00ED}", "icirc": "\u{00EE}",
+        "iuml": "\u{00EF}", "eth": "\u{00F0}", "ntilde": "\u{00F1}",
+        "ograve": "\u{00F2}", "oacute": "\u{00F3}", "ocirc": "\u{00F4}",
+        "otilde": "\u{00F5}", "ouml": "\u{00F6}", "oslash": "\u{00F8}",
+        "ugrave": "\u{00F9}", "uacute": "\u{00FA}", "ucirc": "\u{00FB}",
+        "uuml": "\u{00FC}", "yacute": "\u{00FD}", "thorn": "\u{00FE}",
+        "yuml": "\u{00FF}"
     ]
 }
 

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -568,6 +568,23 @@ final class MeetingLinkDetectorTests: XCTestCase {
         XCTAssertEqual(stripped, "First line\nSecond line")
     }
 
+    func testHTMLStripDropsScriptAndStyleBodies() {
+        // Only the tags were stripped before, leaking CSS/JS text into notes.
+        let stripped = htmlTagsStrippedForMeetingLinks(
+            "<style>body{color:red}</style><p>Meeting</p><script>alert(1)</script>"
+        )
+
+        XCTAssertEqual(stripped, "Meeting")
+    }
+
+    func testHTMLStripDecodesEntityNearEnd() {
+        // The bounded entity scan must still decode an entity that sits within
+        // fewer than 13 characters of the end of the string.
+        let stripped = htmlTagsStrippedForMeetingLinks("<p>5&euro;</p>")
+
+        XCTAssertEqual(stripped, "5€")
+    }
+
     func testHTMLStripDoesNotLeakMachPorts() {
         // Regression guard for the EXC_GUARD mach-port exhaustion crash:
         // NSAttributedString(html:) leaked ~2 mach ports per call via TextKit's

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -552,6 +552,16 @@ final class MeetingLinkDetectorTests: XCTestCase {
         XCTAssertEqual(stripped, "A & B @ Co—end")
     }
 
+    func testHTMLStripDecodesLatin1NamedEntities() {
+        // The expanded named-entity table must decode accented letters and
+        // symbols so notes like a Paris/Munich meeting render as written.
+        let stripped = htmlTagsStrippedForMeetingLinks(
+            "<p>Caf&eacute; sync in M&uuml;nchen &mdash; 5&nbsp;&euro;</p>"
+        )
+
+        XCTAssertEqual(stripped, "Café sync in München — 5 €")
+    }
+
     func testHTMLStripConvertsBlockTagsToNewlines() {
         let stripped = htmlTagsStrippedForMeetingLinks("<p>First line</p><p>Second line</p>")
 
@@ -588,7 +598,7 @@ final class MeetingLinkDetectorTests: XCTestCase {
         var namesCount: mach_msg_type_number_t = 0
         var types: mach_port_type_array_t?
         var typesCount: mach_msg_type_number_t = 0
-        guard mach_port_names(mach_task_self_, &names, &namesCount, &types, &typesCount) == KERN_SUCCESS
+        guard mach_port_names(task_self_trap(), &names, &namesCount, &types, &typesCount) == KERN_SUCCESS
         else { return -1 }
         return Int(namesCount)
     }

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -3,6 +3,7 @@
 //  MeetingBarLogicTests
 //
 
+import Darwin.Mach
 import XCTest
 
 @testable import MeetingBarLogic
@@ -530,6 +531,66 @@ final class MeetingLinkDetectorTests: XCTestCase {
 
         XCTAssertTrue(stripped.contains("https://meet.google.com/abc-defg-hij"))
         XCTAssertFalse(stripped.contains("<p>"))
+    }
+
+    func testHTMLStripReconnectsAmpEncodedURL() {
+        // The whole point of stripping notes for link detection: HTML-encoded
+        // query separators (&amp;) must decode so the URL regex sees one link.
+        let stripped = htmlTagsStrippedForMeetingLinks(
+            "<p>Join https://us02web.zoom.us/j/123?pwd=abc&amp;uname=sam</p>"
+        )
+
+        XCTAssertTrue(stripped.contains("https://us02web.zoom.us/j/123?pwd=abc&uname=sam"))
+        XCTAssertFalse(stripped.contains("&amp;"))
+    }
+
+    func testHTMLStripDecodesNamedAndNumericEntities() {
+        let stripped = htmlTagsStrippedForMeetingLinks(
+            "<div>A&nbsp;&amp;&nbsp;B &#64; &#x43;o&mdash;end</div>"
+        )
+
+        XCTAssertEqual(stripped, "A & B @ Co—end")
+    }
+
+    func testHTMLStripConvertsBlockTagsToNewlines() {
+        let stripped = htmlTagsStrippedForMeetingLinks("<p>First line</p><p>Second line</p>")
+
+        XCTAssertEqual(stripped, "First line\nSecond line")
+    }
+
+    func testHTMLStripDoesNotLeakMachPorts() {
+        // Regression guard for the EXC_GUARD mach-port exhaustion crash:
+        // NSAttributedString(html:) leaked ~2 mach ports per call via TextKit's
+        // nsattributedstringagent XPC service. The pure-Foundation strip must
+        // allocate none. Reintroducing the XPC-backed parser makes the port
+        // table grow ~800 over this loop and fails the assertion.
+        let html = "<p>Join <a href=\"https://x\">https://us02web.zoom.us/j/1?a=1&amp;b=2</a></p>"
+        _ = htmlTagsStrippedForMeetingLinks(html) // warm up any one-time caches
+
+        let before = machPortCount()
+        for _ in 0..<400 {
+            _ = htmlTagsStrippedForMeetingLinks(html)
+        }
+        let after = machPortCount()
+
+        XCTAssertGreaterThanOrEqual(before, 0, "mach_port_names failed")
+        XCTAssertGreaterThanOrEqual(after, 0, "mach_port_names failed")
+        let growth = after - before
+
+        XCTAssertLessThan(
+            growth, 100,
+            "HTML stripping leaked \(growth) mach ports over 400 calls — an XPC-backed parser was reintroduced"
+        )
+    }
+
+    private func machPortCount() -> Int {
+        var names: mach_port_name_array_t?
+        var namesCount: mach_msg_type_number_t = 0
+        var types: mach_port_type_array_t?
+        var typesCount: mach_msg_type_number_t = 0
+        guard mach_port_names(mach_task_self_, &names, &namesCount, &types, &typesCount) == KERN_SUCCESS
+        else { return -1 }
+        return Int(namesCount)
     }
 
     func testCleanupOutlookSafeLinksUnwrapsValidLink() {

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -617,7 +617,19 @@ final class MeetingLinkDetectorTests: XCTestCase {
         var typesCount: mach_msg_type_number_t = 0
         guard mach_port_names(task_self_trap(), &names, &namesCount, &types, &typesCount) == KERN_SUCCESS
         else { return -1 }
+        // mach_port_names allocates out-of-line memory for both arrays; free it
+        // so this leak-detection helper doesn't itself leak.
+        defer {
+            vmDeallocate(names, count: namesCount, stride: MemoryLayout<mach_port_name_t>.stride)
+            vmDeallocate(types, count: typesCount, stride: MemoryLayout<mach_port_type_t>.stride)
+        }
         return Int(namesCount)
+    }
+
+    private func vmDeallocate<T>(_ pointer: UnsafeMutablePointer<T>?, count: mach_msg_type_number_t, stride: Int) {
+        guard let pointer, count > 0 else { return }
+        let address = vm_address_t(UInt(bitPattern: UnsafeMutableRawPointer(pointer)))
+        _ = vm_deallocate(task_self_trap(), address, vm_size_t(Int(count) * stride))
     }
 
     func testCleanupOutlookSafeLinksUnwrapsValidLink() {

--- a/MeetingBarTests/HelpersTests.swift
+++ b/MeetingBarTests/HelpersTests.swift
@@ -47,7 +47,7 @@ class HelpersTests: XCTestCase {
         let rawNotes = "<p>description</p>"
 
         let result = cleanUpNotes(rawNotes)
-        XCTAssertEqual(result, "description\n")
+        XCTAssertEqual(result, "description")
     }
 
     func test_cleanUpNotes_inputMeetDivider_returnClean() throws {


### PR DESCRIPTION
### Status
**READY**

### Description

Fixes a mach-port leak that gets MeetingBar force-killed after long uptime.

`htmlTagsStrippedForMeetingLinks` (link detection) and `String.htmlTagsStripped()` (notes display) both turned HTML notes into plain text with `NSAttributedString(html:)`. That initializer spins up TextKit's `com.apple.textkit.nsattributedstringagent` XPC service and leaks ~2 mach ports per call that are never reclaimed. Link detection runs it for every event with HTML notes on every calendar refresh, so the process port table grows unbounded until the kernel kills the app with `EXC_GUARD` — "allocating too many mach ports" (I caught one at 305,834 ports; unified-log shows the `nsattributedstringagent` connection flood right after each EventKit `CADEventPredicate`).

The HTML strip dates back to #144 and still exists in the 5.0 codebase, so the 4.11 rewrite didn't remove it.

Replaced both call sites with `HTMLPlainText`, a pure-Foundation strip (in `MeetingLinkDetector.swift` so the logic target and app share it): block-level tags become newlines, other tags are removed, and entities are decoded — all numeric forms (`&#123;`/`&#x7B;`) plus a named table covering the five XML names, common symbols, and the full Latin-1 accented-letter set (café, München). No XPC, nothing to leak. Named entities outside the table are left as written (documented in the code); numeric coverage is total.

Provenance:
- `d646f98` — replace `NSAttributedString(html:)` with `HTMLPlainText`; add the regression + behavioral tests.
- `a35af58` — flesh out the named-entity table (the first cut narrowed the old full decoding); also swap `mach_task_self_` → `task_self_trap()` in the port test so it builds under `-strict-concurrency=complete`.

Likely the cause behind #872 (same `nsattributedstringagent` signature), and probably #716 / #721 / #888.

No breaking changes to external interfaces. One behavior note: the notes-display path now decodes numeric + Latin-1/common named entities rather than the full HTML named set; anything rarer shows as written instead of decoded.

### Steps to Test or Reproduce
1. **Observe the XPC churn (before):** with `NSAttributedString(html:)` in the strip, add a calendar event whose notes contain HTML (Google/Outlook invites do) and let it refresh over time. `log stream --predicate 'process == "MeetingBar"'` shows repeated `activating connection … com.apple.textkit.nsattributedstringagent` right after each EventKit `CADEventPredicate`.
2. **Measure the leak (before):** sample the process mach-port count (`mach_port_names` on the task, or the harness in `testHTMLStripDoesNotLeakMachPorts`) across many strip calls — it climbs ~2 ports/call and never drops. Left running, the port table fills and the kernel kills the app with `EXC_GUARD` / port-space exhaustion (seen at 305,834 ports).
3. **The fix (after):** same scenario — no `nsattributedstringagent` connections in the log, and the mach-port count stays flat across calls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting link detection in HTML-formatted content, including Google Calendar redirect links.
  * Enhanced HTML-to-plain-text conversion by decoding common entities, removing script and style content, preserving block-level line breaks, and normalizing whitespace.
  * Reduced resource growth during repeated HTML processing.
  * Removed an unwanted trailing newline from cleaned notes.

* **Tests**
  * Added coverage for HTML conversion, redirect handling, entity decoding, line breaks, and resource cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->