### PR TITLE
Fix blank status bar item when the no-icon sentinel is hidden

### DIFF
--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -246,7 +246,10 @@ final class StatusBarItemController {
     }
 
     private func ensureStatusBarButtonIsVisible(_ button: NSStatusBarButton) {
-        guard button.image == nil,
+        // A set-but-suppressed image (imagePosition == .noImage, e.g. the
+        // "no_online_session" sentinel) is not visible, so treat it the same as a
+        // missing image — otherwise the status item can render completely blank.
+        guard button.image == nil || button.imagePosition == .noImage,
               button.title.isEmpty,
               button.attributedTitle.string.isEmpty
         else { return }

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -1452,6 +1452,22 @@ final class StatusBarItemControllerPresentationTests: BaseTestCase {
         XCTAssertEqual(button.attributedTitle.string, "")
     }
 
+    func test_renderStatusBarUsesFallbackWhenSentinelIconIsHidden() throws {
+        let controller = StatusBarItemController()
+        defer { NSStatusBar.system.removeStatusItem(controller.statusItem) }
+
+        // A next event without a meeting service resolves to the hidden
+        // "no_online_session" sentinel (imagePosition == .noImage). With an empty
+        // title that would leave the item completely blank, so it must fall back
+        // to a visible icon instead.
+        controller.renderStatusBar(makePresentation(icon: .meetingService(nil)))
+
+        let button = try XCTUnwrap(controller.statusItem.button)
+        XCTAssertEqual(button.imagePosition, .imageLeft)
+        XCTAssertNotEqual(button.image?.name(), "no_online_session")
+        XCTAssertEqual(button.attributedTitle.string, "")
+    }
+
     func test_updateTitleCompactsLongVisibleTitleWithoutForcingFallbackIcon() throws {
         configureStatusBarDefaults()
         Defaults[.eventTitleIconFormat] = .none


### PR DESCRIPTION
### Problem

`ensureStatusBarButtonIsVisible` only restores the fallback app icon when `button.image == nil`. A next event with no meeting service resolves to the `no_online_session` sentinel icon, which is set as a **non-nil** image with `imagePosition = .noImage` (drawn-suppressed). So with an empty title the guard never fires and the status item can render **completely blank**.

Reachable configuration: *hide meeting title* + *event-specific icon* + *hide time*, when the next event has no detected meeting link.

### Fix

Treat a suppressed image (`imagePosition == .noImage`) as absent in the visibility guard, so the app-icon fallback still applies. One-line change; no effect on the common case (a visible title keeps the guard's `attributedTitle.string.isEmpty` clause false, so the fallback still doesn't fire).

### Test

Adds `test_renderStatusBarUsesFallbackWhenSentinelIconIsHidden`: renders with `.meetingService(nil)` and an empty title, then asserts the item stays visible (`imagePosition == .imageLeft`, image is not the sentinel). All existing fallback/icon tests still pass.

Follow-up to the CodeRabbit note on #942.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the status bar icon could appear blank.
  * Added a fallback to display a visible icon when no active meeting service is available.
  * Preserved the existing layout and empty title behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->