### PR TITLE
Detect Microsoft Teams personal meeting links on teams.live.com

### DIFF
--- a/MeetingBar/Meetings/MeetingProvider.swift
+++ b/MeetingBar/Meetings/MeetingProvider.swift
@@ -244,7 +244,7 @@ extension MeetingProvider {
                 .teams,
                 icon: "ms_teams_icon",
                 pattern:
-                    #"https?://(gov\.)?teams\.microsoft\.(com|us)/(l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+(?:&[^\s]+)?|meet/\d+\?p=[A-Za-z0-9_\-]+(?:&[^\s]+)?)"#,
+                    #"https?://((gov\.)?teams\.microsoft\.(com|us)|teams\.live\.com)/(l/meetup-join/[a-zA-Z0-9_%\/=\-\+\.?]+(?:&[^\s]+)?|meet/\d+\?p=[A-Za-z0-9_\-]+(?:&[^\s]+)?)"#,
                 openingModes: [.teamsApp]
             ),
 

--- a/MeetingBarLogicTests/MeetingLinkDetectionTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectionTests.swift
@@ -50,7 +50,9 @@ let meetings = [
     MeetingLink(service: .webex, url: URL(string: "https://yourmeetingsite.webex.com/yourbusinessID/j.php?MTID=aO5678eFGH")!),
     // streamyard
     MeetingLink(service: .streamyard, url: URL(string: "https://streamyard.com/jexample29t")!),
-    MeetingLink(service: .streamyard, url: URL(string: "https://streamyard.com/guest/u6qes7i8cj?utm_source=test")!)
+    MeetingLink(service: .streamyard, url: URL(string: "https://streamyard.com/guest/u6qes7i8cj?utm_source=test")!),
+    // Microsoft Teams (personal / consumer — teams.live.com)
+    MeetingLink(service: .teams, url: URL(string: "https://teams.live.com/meet/9425716001426?p=0SystrMw2goKHi8LK6")!)
 ]
 
 class MeetingLinkDetectionTests: XCTestCase {

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -95,6 +95,24 @@ final class MeetingLinkDetectorTests: XCTestCase {
         XCTAssertEqual(link?.url.absoluteString, url)
     }
 
+    func testDetectsTeamsPersonalShortURL() {
+        // Personal / consumer "Teams for Life" host (teams.live.com) uses the
+        // same `meet/{id}?p={passcode}` short-URL form as the enterprise host.
+        let url = "https://teams.live.com/meet/9425716001426?p=0SystrMw2goKHi8LK6"
+        let link = detectMeetingLink(url)
+
+        XCTAssertEqual(link?.service, .teams)
+        XCTAssertEqual(link?.url.absoluteString, url)
+    }
+
+    func testDetectsTeamsPersonalShortURLWithAdditionalQueryParameters() {
+        let url = "https://teams.live.com/meet/9425716001426?p=0SystrMw2goKHi8LK6&anon=true"
+        let link = detectMeetingLink(url)
+
+        XCTAssertEqual(link?.service, .teams)
+        XCTAssertEqual(link?.url.absoluteString, url)
+    }
+
     func testDetectsSupportedTeamsGovernmentHosts() {
         let urls = [
             "https://teams.microsoft.us/meet/1234567890123?p=Aa1Bb2Cc3Dd4Ee5",
@@ -115,6 +133,7 @@ final class MeetingLinkDetectorTests: XCTestCase {
             "https://teams.microsoft.com/",
             "https://teams.microsoft.com/l/meeting/new",
             "https://teams.microsoft.com/meet/1234567890123",
+            "https://teams.live.com/meet/9425716001426",
             "https://teams.microsoft.com/meet/channel?p=Aa1Bb2Cc3Dd4Ee5"
         ]
 


### PR DESCRIPTION
### Status
**READY**

### Description
MeetingBar detects enterprise and government Microsoft Teams meeting links (`teams.microsoft.com`, `teams.microsoft.us`, `gov.teams.microsoft.com/us`), but personal ("Teams for Life") meetings on the `teams.live.com` domain are not recognized at all — an event containing `https://teams.live.com/meet/{id}?p={passcode}` shows no meeting link.

This extends the `.teams` detection pattern in `MeetingProvider.swift` to also match the `teams.live.com` host. The personal host uses the same `meet/{id}?p={passcode}` short-URL form as the enterprise one, so it joins the existing host alternation. As with the enterprise short URL, the `?p=` passcode is required: a `teams.live.com/meet/...` link without one is not treated as a meeting link.

## Checklist
- [x] Localized — n/a, no user-facing strings changed
- [ ] Added to changelog:
  - [ ] [Changelog View](https://github.com/leits/MeetingBar/blob/master/MeetingBar/UI/Views/Changelog/Changelog.swift)
  - [ ] [CHANGELOG.md](https://github.com/leits/MeetingBar/blob/master/CHANGELOG.md)

### Steps to Test or Reproduce
- Run `make test-logic`. New cases in `MeetingLinkDetectorTests` cover a personal short URL (`testDetectsTeamsPersonalShortURL`), one with additional query parameters (`testDetectsTeamsPersonalShortURLWithAdditionalQueryParameters`), and a passcode-less `teams.live.com` URL that must not be detected; `MeetingLinkDetectionTests` gained a `teams.live.com` fixture entry alongside the existing Teams links.
- Manually: put `https://teams.live.com/meet/9425716001426?p=0SystrMw2goKHi8LK6` in a calendar event's location or notes — the event is now detected as a Teams meeting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for detecting Microsoft Teams personal meeting links hosted on `teams.live.com`, including links with additional parameters.
  * Continued support for existing Microsoft Teams and government-domain meeting links.

* **Bug Fixes**
  * Improved meeting-link detection for StreamYard guest links and Teams consumer meetings.

* **Tests**
  * Added coverage for valid and invalid Teams personal short-link formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
