### PR TITLE
fix: capture full ZoomGov password in meeting link detection

### DIFF
--- a/MeetingBar/Meetings/MeetingProvider.swift
+++ b/MeetingBar/Meetings/MeetingProvider.swift
@@ -227,11 +227,14 @@ extension MeetingProvider {
                     #"zoommtg://([a-z0-9-.]+)?zoom(-x)?\.(?:us|com|com\.cn|de)/join[-a-zA-Z0-9()@:%_\+.~#?&=\/]*"#
             ),
 
-            // ZoomGov
+            // ZoomGov (Zoom for Government — same product and join-URL shape as
+            // zoom.us, so the `/j/<id>?pwd=<hash>` path uses the same permissive
+            // character class as the main Zoom regex above). The previous class
+            // `[a-zA-Z0-9?&=]+` truncated `?pwd=` on `-`, `_`, `.`, `+`, `/`.
             make(
                 .zoomgov,
                 icon: "zoom_icon",
-                pattern: #"https?://([a-z0-9.]+)?zoomgov\.com/j/[a-zA-Z0-9?&=]+"#),
+                pattern: #"https?://([a-z0-9.]+)?zoomgov\.com/j/[-a-zA-Z0-9()@:%_\+.~#?&=/]+"#),
 
             // Reclaim.ai (uses Zoom links)
             make(

--- a/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
+++ b/MeetingBarLogicTests/MeetingLinkDetectorTests.swift
@@ -156,6 +156,44 @@ final class MeetingLinkDetectorTests: XCTestCase {
         }
     }
 
+    func testDetectsZoomGovLinkWithPassword() {
+        // ZoomGov (`zoomgov.com`) is the same Zoom product hosted for government
+        // accounts, so its join URL has Zoom's `/j/<meetingID>?pwd=<hash>` shape
+        // and password encoding. The hash commonly carries `-`, `_`, `.`, `+`,
+        // and `/`; the original path class `[a-zA-Z0-9?&=]+` stopped at the first
+        // such character, handing the browser a truncated `pwd=` that Zoom
+        // rejected as a wrong/missing password.
+        let urls = [
+            "https://www.zoomgov.com/j/16111111111?pwd=abc-DEF123-GHI",
+            "https://www.zoomgov.com/j/16111111111?pwd=abc_DEF.123",
+            "https://www.zoomgov.com/j/16111111111?pwd=abc+DEF/123",
+            "https://www.zoomgov.com/j/16111111111?pwd=abcdef123"
+        ]
+
+        for url in urls {
+            let link = detectMeetingLink(url)
+
+            XCTAssertEqual(link?.service, .zoomgov, url)
+            XCTAssertEqual(link?.url.absoluteString, url, url)
+        }
+    }
+
+    func testDetectsZoomGovLinkWithoutPassword() {
+        let url = "https://www.zoomgov.com/j/1234567890"
+        let link = detectMeetingLink(url)
+
+        XCTAssertEqual(link?.service, .zoomgov)
+        XCTAssertEqual(link?.url.absoluteString, url)
+    }
+
+    func testDoesNotMatchNonMeetingZoomGovPages() {
+        // A bare `/j/` with no meeting id is not a real join link and must not
+        // match — mirrors the Zhumu guard in testDoesNotMatchNonMeetingZhumuPages.
+        let url = "https://www.zoomgov.com/j/"
+
+        XCTAssertNil(detectMeetingLink(url), url)
+    }
+
     func testDetectsCustomRegexLinkFromNotes() {
         let link = MeetingLinkDetector.detect(
             location: nil,


### PR DESCRIPTION
## Summary
ZoomGov (`zoomgov.com`) meeting links whose `?pwd=` password contained `-`, `_`, `.`, `+`, or `/` were detected only up to the first such character, so clicking the event opened a truncated join URL and Zoom rejected the password.

## Root cause
The ZoomGov regex used the restricted character class `[a-zA-Z0-9?&=]+`. ZoomGov is the same Zoom product as `zoom.us` with the identical `/j/<id>?pwd=<hash>` URL shape, and the main Zoom regex (above it) already uses the permissive class `[-a-zA-Z0-9()@:%_\+.~#?&=/]*` — the ZoomGov branch was the anomaly.

## Fix
Use the same permissive character class the main Zoom regex uses, so a `?pwd=` hash carrying `-`, `_`, `.`, `+`, or `/` is captured in full.

## Tests
New `testDetectsZoomGovLinkWithPassword` cases cover hyphen, underscore, dot, plus, and slash in the password. The existing Zoom/GoogleMeet/etc. detection tests are unchanged. Full `MeetingLinkDetectorTests` suite: 48 passed, 0 failed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of ZoomGov meeting links with a wider range of valid URL characters.
  * Added support for ZoomGov links with or without passwords, including special characters.
  * Prevented bare ZoomGov `/j/` pages from being incorrectly detected as meetings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->