### PR TITLE
fix: unwrap Google Calendar redirect links so Zoom passcodes survive

### DIFF
--- a/MeetingBar/Meetings/MeetingLinkDetector.swift
+++ b/MeetingBar/Meetings/MeetingLinkDetector.swift
@@ -193,12 +193,33 @@ private let meetingLinkRegexes: [MeetingServices: NSRegularExpression] =
 private let outlookSafeLinkRegex = try? NSRegularExpression(
     pattern: #"https://[\S]+\.safelinks\.protection\.outlook\.com/[\S]+url=([\S]*)"#)
 
+/// Matches Google's `google.<tld>/url?q=<percent-encoded target>` redirect
+/// together with the tracking parameters Google appends after it, whether they
+/// arrive as `&` or as the HTML entity `&amp;`.
+///
+/// The capture group is the encoded target only, which ends at the first `&`.
+/// Because the target is *fully* percent-encoded, every `&` after `q=` belongs
+/// to Google rather than to the target — so the pattern consumes any trailing
+/// `name=value` pair rather than an allow-list of known ones. An unrecognised
+/// parameter would otherwise be left glued onto the unwrapped URL, which both
+/// defeats the string-identity dedupe in `MeetingLinkCandidatePolicy.ranked`
+/// and changes the URL any downstream exact comparison sees.
+///
+/// The host is matched across country domains (`google.de`, `google.co.uk`),
+/// with or without `www.`, because Calendar renders the redirect under the
+/// viewer's Google domain. It stays `https`-only and requires `q` to be the
+/// first parameter, which is what Calendar emits;
+/// `testHostAndSchemeBoundariesAreNotRewritten` records those boundaries.
+private let googleRedirectRegex = try? NSRegularExpression(
+    pattern: #"https://(?:www\.)?google\.[a-z]{2,}(?:\.[a-z]{2,})?/url\?q=([^\s&"'<>]+)"#
+        + #"(?:&(?:amp;)?[A-Za-z][A-Za-z0-9_]*=[^\s&"'<>]*)*"#)
+
 func regex(for service: MeetingServices) -> NSRegularExpression? {
     meetingLinkRegexes[service]
 }
 
 func detectMeetingLink(_ rawText: String, customRegexes: [String] = []) -> MeetingLink? {
-    let text = cleanupOutlookSafeLinks(rawText: rawText)
+    let text = cleanupGoogleRedirects(rawText: cleanupOutlookSafeLinks(rawText: rawText))
 
     for pattern in customRegexes {
         if let regex = try? NSRegularExpression(pattern: pattern),
@@ -267,6 +288,92 @@ func cleanupOutlookSafeLinks(rawText: String) -> String {
         }
     }
     return text
+}
+
+/// Rewrites Google Calendar's `google.<tld>/url?q=…` redirects in `rawText`
+/// back to their real targets, so detection sees the underlying meeting URL.
+///
+/// When Calendar renders an invite body it wraps links in this redirect with
+/// the target percent-encoded, so `?pwd=X` becomes `?pwd%3DX`. For a link the
+/// organiser typed into the body, Calendar emits both forms — plain and
+/// wrapped — and the wrapped one is *longer*, so it wins
+/// `MeetingLinkCandidatePolicy`'s length tie-break. Its `pwd` is then not a
+/// query parameter at all but part of one valueless parameter name, so no
+/// passcode reaches Zoom and the client prompts for one the invite supplied.
+/// Links Calendar generates itself, such as the add-on's "Joining
+/// instructions", appear wrapped only; those never had a plain form to lose to.
+///
+/// Every match is rewritten in a single pass, so `maxNestingDepth` bounds
+/// *nesting depth* — a redirect whose target is itself a redirect — rather than
+/// how many links a body may contain. An earlier version rewrote one match per pass,
+/// which silently left the tail of a link-heavy invite wrapped.
+///
+/// An undecodable `%` escape skips that match and leaves it as-is; it must not
+/// abort the pass, or one malformed link anywhere earlier in the body would
+/// reinstate the bug for the meeting link after it.
+func cleanupGoogleRedirects(rawText: String) -> String {
+    guard let googleRedirectRegex else { return rawText }
+
+    var text = rawText
+    autoreleasepool {
+        // Bounds nesting depth. The loop must make forward progress on every
+        // iteration or it spins: `rewritingRedirects` returns nil once no
+        // redirects remain (the usual exit) or when no match decoded
+        // successfully, and otherwise the text strictly shrinks —
+        // unwrapping removes a prefix and percent-decoding never lengthens.
+        let maxNestingDepth = 32
+        for _ in 0 ..< maxNestingDepth {
+            guard let rewritten = rewritingRedirects(in: text, using: googleRedirectRegex) else {
+                break
+            }
+            text = rewritten
+        }
+    }
+    return text
+}
+
+/// One rewrite pass: splices every decodable redirect in `text` with its
+/// decoded target, returning nil when nothing changed.
+///
+/// Builds the result by appending segments rather than mutating in place —
+/// `String.Index` values from the match list are only valid against the string
+/// they were computed from, and a global `replacingOccurrences` of the matched
+/// text would rewrite inside a longer wrapper that happens to start with it.
+private func rewritingRedirects(
+    in text: String,
+    using regex: NSRegularExpression
+) -> String? {
+    let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+    guard !matches.isEmpty else { return nil }
+
+    var result = ""
+    var copiedUpTo = text.startIndex
+    var didRewrite = false
+
+    for match in matches {
+        guard let fullRange = Range(match.range, in: text),
+              let targetRange = Range(match.range(at: 1), in: text),
+              // Upholds the slicing invariant below rather than guarding a
+              // diagnosed case: `matches` is non-overlapping and ascending, so
+              // this holds today. If that ever stopped being true the slice
+              // `text[copiedUpTo ..< fullRange.lowerBound]` would trap.
+              fullRange.lowerBound >= copiedUpTo
+        else { continue }
+
+        // Skip, don't abort: a malformed escape here must not strand the
+        // redirects after it.
+        guard let decodedTarget = String(text[targetRange]).removingPercentEncoding
+        else { continue }
+
+        result += text[copiedUpTo ..< fullRange.lowerBound]
+        result += decodedTarget
+        copiedUpTo = fullRange.upperBound
+        didRewrite = true
+    }
+
+    guard didRewrite else { return nil }
+    result += text[copiedUpTo...]
+    return result == text ? nil : result
 }
 
 func getMatch(text: String, regex: NSRegularExpression) -> String? {
@@ -462,9 +569,18 @@ enum MeetingLinkDetector {
         // 6. Custom regex fallback over combined text. Lowest priority so a
         //    custom regex cannot override a real provider conference URL.
         if !customRegexes.isEmpty {
-            let combined = [location, eventURL?.absoluteString, notes]
-                .compactMap { $0 }
-                .joined(separator: "\n")
+            // Same cleanups as `builtInCandidates`. Without them a custom regex
+            // — used precisely for hosts the built-in catalogue does not know —
+            // matches the wrapped redirect and yields a URL whose `pwd` cannot
+            // be parsed. That candidate is also what the "open with another
+            // link" menu and the preferences regex tester display.
+            let combined = cleanupGoogleRedirects(
+                rawText: cleanupOutlookSafeLinks(
+                    rawText: [location, eventURL?.absoluteString, notes]
+                        .compactMap { $0 }
+                        .joined(separator: "\n")
+                )
+            )
             if let detected = detectCustomRegexLink(text: combined, patterns: customRegexes) {
                 candidates.append(MeetingLinkCandidate(
                     url: detected.url,
@@ -481,7 +597,7 @@ enum MeetingLinkDetector {
         in rawText: String,
         source: MeetingLinkSource
     ) -> [MeetingLinkCandidate] {
-        let text = cleanupOutlookSafeLinks(rawText: rawText)
+        let text = cleanupGoogleRedirects(rawText: cleanupOutlookSafeLinks(rawText: rawText))
         guard text.contains("://") else { return [] }
 
         let range = NSRange(text.startIndex..., in: text)

--- a/MeetingBarLogicTests/GoogleRedirectCleanupTests.swift
+++ b/MeetingBarLogicTests/GoogleRedirectCleanupTests.swift
@@ -1,0 +1,207 @@
+//
+//  GoogleRedirectCleanupTests.swift
+//  MeetingBar
+//
+//  Probes `cleanupGoogleRedirects` directly. The assertion here IS a regex, so
+//  mutating the surrounding code proves nothing about it — the table below
+//  deliberately includes inputs it must NOT rewrite.
+//
+
+import XCTest
+@testable import MeetingBarLogic
+
+final class GoogleRedirectCleanupTests: XCTestCase {
+    // MARK: - Must rewrite
+
+    func testUnwrapsRedirectAndDecodesQuerySeparators() {
+        let wrapped = "Join Zoom Meeting https://www.google.com/url"
+            + "?q=https://acme.zoom.us/j/123456789?pwd%3DAbCdEf.1%26jst%3D2"
+            + "&amp;sa=D&amp;source=calendar&amp;usg=AOvVaw123"
+        let out = cleanupGoogleRedirects(rawText: wrapped)
+
+        XCTAssertEqual(out, "Join Zoom Meeting https://acme.zoom.us/j/123456789?pwd=AbCdEf.1&jst=2")
+    }
+
+    func testHandlesLiteralAmpersandSeparators() {
+        let wrapped = "https://www.google.com/url?q=https://acme.zoom.us/j/9?pwd%3DX"
+            + "&sa=D&source=calendar&usg=AOvVaw9"
+        XCTAssertEqual(cleanupGoogleRedirects(rawText: wrapped), "https://acme.zoom.us/j/9?pwd=X")
+    }
+
+    func testUnwrapsEveryRedirectInTheText() {
+        let wrapped = "a https://www.google.com/url?q=https://acme.zoom.us/j/1?pwd%3DA&amp;sa=D"
+            + " b https://www.google.com/url?q=https://acme.zoom.us/j/2?pwd%3DB&amp;sa=D c"
+        XCTAssertEqual(
+            cleanupGoogleRedirects(rawText: wrapped),
+            "a https://acme.zoom.us/j/1?pwd=A b https://acme.zoom.us/j/2?pwd=B c")
+    }
+
+    /// Tracking parameters are consumed by name shape, not by an allow-list —
+    /// Google appends `opi`, `ved`, `rct`, `cd`, `hl` and others besides the
+    /// four that appear in a typical Calendar invite.
+    func testConsumesTrailingParametersOutsideTheCommonFour() {
+        let wrapped = "https://www.google.com/url?q=https://acme.zoom.us/j/9?pwd%3DX%26jst%3D2"
+            + "&amp;sa=D&amp;opi=89978449&amp;ved=2ahUKEwi&amp;usg=AOvVaw0"
+        XCTAssertEqual(
+            cleanupGoogleRedirects(rawText: wrapped),
+            "https://acme.zoom.us/j/9?pwd=X&jst=2",
+            "an unrecognised tracking parameter must not be glued onto the target")
+    }
+
+    func testUnwrapsCountryCodeGoogleDomains() {
+        for host in ["www.google.de", "google.co.uk", "www.google.com.au"] {
+            let wrapped = "https://\(host)/url?q=https://acme.zoom.us/j/9?pwd%3DX&amp;sa=D"
+            XCTAssertEqual(
+                cleanupGoogleRedirects(rawText: wrapped),
+                "https://acme.zoom.us/j/9?pwd=X",
+                "\(host) should unwrap")
+        }
+    }
+
+    /// A malformed redirect must not strand the redirects that follow it.
+    /// This is the ordering that occurs in practice: Calendar's own generated
+    /// "Joining instructions" link precedes the organiser's meeting link.
+    func testMalformedRedirectDoesNotStrandLaterOnes() {
+        let wrapped = "instructions https://www.google.com/url?q=https://example.com/x%ZZbroken&amp;sa=D"
+            + "\njoin https://www.google.com/url?q=https://acme.zoom.us/j/9?pwd%3DX%26jst%3D2&amp;sa=D"
+        let out = cleanupGoogleRedirects(rawText: wrapped)
+
+        XCTAssertTrue(out.contains("https://acme.zoom.us/j/9?pwd=X&jst=2"),
+                      "the valid redirect after a malformed one must still unwrap; got: \(out)")
+        XCTAssertTrue(out.contains("%ZZbroken"), "the malformed one is left as-is; got: \(out)")
+    }
+
+    /// `maxNestingDepth` must bound nesting depth, not link count. Filler IDs
+    /// are zero-padded so no wrapper is a prefix of another — otherwise a
+    /// global-replace implementation clears several per pass and the cap never
+    /// bites.
+    func testUnwrapsMoreLinksThanTheNestingBudget() {
+        let filler = (1 ... 40).map {
+            "https://www.google.com/url?q=https://example.com/doc/\(String(format: "%03d", $0))&amp;sa=D"
+        }.joined(separator: "\n")
+        let wrapped = filler
+            + "\nhttps://www.google.com/url?q=https://acme.zoom.us/j/9?pwd%3DX%26jst%3D2&amp;sa=D"
+        let out = cleanupGoogleRedirects(rawText: wrapped)
+
+        XCTAssertTrue(out.contains("https://acme.zoom.us/j/9?pwd=X&jst=2"),
+                      "a link past the nesting budget must still unwrap")
+        XCTAssertFalse(out.contains("google.com/url"), "no wrapper should survive")
+    }
+
+    /// One wrapper's matched span can be a prefix of another's — same target,
+    /// one with trailing tracking parameters and one without. A global
+    /// `replacingOccurrences` of the matched text rewrote inside the longer
+    /// wrapper and left its tail glued on; splicing by range does not.
+    func testWrapperThatIsAPrefixOfAnotherIsNotRewrittenInside() {
+        let wrapped = "a https://www.google.com/url?q=https://acme.zoom.us/j/1?pwd%3DA"
+            + " b https://www.google.com/url?q=https://acme.zoom.us/j/1?pwd%3DA&amp;sa=D&amp;usg=Y"
+        XCTAssertEqual(
+            cleanupGoogleRedirects(rawText: wrapped),
+            "a https://acme.zoom.us/j/1?pwd=A b https://acme.zoom.us/j/1?pwd=A")
+    }
+
+    // MARK: - Must NOT rewrite
+
+    func testLeavesPlainZoomLinkUntouched() {
+        let plain = "https://acme.zoom.us/j/123456789?pwd=AbCdEf.1&jst=2"
+        XCTAssertEqual(cleanupGoogleRedirects(rawText: plain), plain)
+    }
+
+    /// The real case for this property: a passcode that legitimately contains
+    /// percent-encoding, carried *inside* a wrapper. Google double-encodes the
+    /// pre-existing `%`, so `pwd=aB%2FcD%3D` arrives as `pwd%3DaB%252FcD%253D`
+    /// and exactly one decode is correct. Decoding twice corrupts it.
+    ///
+    /// The earlier version of this test fed a plain URL with no wrapper, so the
+    /// regex never matched and the decode path was never reached — it passed
+    /// under a double-decode mutation.
+    func testLeavesLegitimatelyEncodedPasscodeUntouched() {
+        let wrapped = "https://www.google.com/url?q=https://acme.zoom.us/j/1?pwd%3DaB%252FcD%253D"
+            + "&amp;sa=D&amp;usg=AOvVaw0"
+        XCTAssertEqual(
+            cleanupGoogleRedirects(rawText: wrapped),
+            "https://acme.zoom.us/j/1?pwd=aB%2FcD%3D",
+            "exactly one decode; a second would corrupt the passcode to aB/cD=")
+    }
+
+    func testLeavesMalformedPercentEscapeUntouched() {
+        let malformed = "https://www.google.com/url?q=https://acme.zoom.us/j/1?pwd%ZZbroken&amp;sa=D"
+        XCTAssertEqual(cleanupGoogleRedirects(rawText: malformed), malformed)
+    }
+
+    func testLeavesUnrelatedGoogleURLsUntouched() {
+        let docs = "Agenda https://docs.google.com/document/d/abc123/edit"
+        XCTAssertEqual(cleanupGoogleRedirects(rawText: docs), docs)
+    }
+
+    /// Boundaries the pattern deliberately does not cross. Calendar emits the
+    /// lowercase `https://…/url?q=` form; these record what a future loosening
+    /// would have to opt into rather than acquire by accident.
+    func testHostAndSchemeBoundariesAreNotRewritten() {
+        let cases = [
+            "https://WWW.GOOGLE.COM/url?q=https://acme.zoom.us/j/1?pwd%3DX&amp;sa=D",
+            "http://www.google.com/url?q=https://acme.zoom.us/j/1?pwd%3DX&amp;sa=D",
+            "https://www.google.com/url?rct=j&amp;q=https://acme.zoom.us/j/1?pwd%3DX&amp;sa=D",
+            "https://notgoogle.com/url?q=https://acme.zoom.us/j/1?pwd%3DX&amp;sa=D"
+        ]
+        for input in cases {
+            XCTAssertEqual(cleanupGoogleRedirects(rawText: input), input, "should not rewrite: \(input)")
+        }
+    }
+
+    func testEmptyAndPlainTextAreUnchanged() {
+        XCTAssertEqual(cleanupGoogleRedirects(rawText: ""), "")
+        XCTAssertEqual(cleanupGoogleRedirects(rawText: "no links here"), "no links here")
+    }
+
+    // MARK: - Selection consequence, per call site
+
+    func testCleanLinkWinsOverWrappedVariantInNotes() throws {
+        let notes = "Join Zoom Meeting\nhttps://acme.zoom.us/j/123456789?pwd=AbCdEf.1&jst=2\n"
+            + "Joining instructions: https://www.google.com/url"
+            + "?q=https://acme.zoom.us/j/123456789?pwd%3DAbCdEf.1%26jst%3D2&amp;sa=D&amp;usg=AOvVaw1\n"
+
+        XCTAssertTrue(notes.contains("pwd%3DAbCdEf.1"), "fixture no longer seeds the wrapped variant")
+
+        let link = try XCTUnwrap(MeetingLinkDetector.detect(
+            location: nil, eventURL: nil, notes: notes,
+            calendarEmail: nil, currentUserEmail: nil))
+
+        XCTAssertEqual(link.url.absoluteString, "https://acme.zoom.us/j/123456789?pwd=AbCdEf.1&jst=2")
+
+        let candidates = MeetingLinkDetector.allCandidates(
+            location: nil, eventURL: nil, notes: notes,
+            calendarEmail: nil, currentUserEmail: nil)
+        XCTAssertTrue(
+            candidates.allSatisfy { !$0.url.absoluteString.contains("google.com/url") },
+            "no wrapped candidate may survive into the alternates menu")
+    }
+
+    /// `detectMeetingLink` is the second call site the fix touches, reached by
+    /// "open link from clipboard". Reverting its cleanup left the suite green
+    /// before this test existed.
+    func testStandaloneDetectMeetingLinkUnwrapsRedirect() throws {
+        let text = "https://www.google.com/url"
+            + "?q=https://acme.zoom.us/j/555000111?pwd%3DZzTop.1%26jst%3D2&amp;sa=D&amp;usg=AOvVaw2"
+
+        let link = try XCTUnwrap(detectMeetingLink(text))
+        XCTAssertEqual(link.url.absoluteString, "https://acme.zoom.us/j/555000111?pwd=ZzTop.1&jst=2")
+    }
+
+    /// The custom-regex candidate source built its own text and cleaned
+    /// nothing, so for a self-hosted service — the reason custom regexes exist
+    /// — the only candidate carried an unparseable passcode.
+    func testCustomRegexCandidateIsCleanedToo() throws {
+        let notes = "Join https://www.google.com/url"
+            + "?q=https://meet.acmecorp.internal/room/42?pwd%3DAbCdEf.1%26jst%3D2&amp;sa=D&amp;usg=A1\n"
+        let pattern = #"https://meet\.acmecorp\.internal/[^\s]*"#
+
+        let link = try XCTUnwrap(MeetingLinkDetector.detect(
+            location: nil, eventURL: nil, notes: notes,
+            calendarEmail: nil, currentUserEmail: nil, customRegexes: [pattern]))
+
+        let pwd = URLComponents(url: link.url, resolvingAgainstBaseURL: false)?
+            .queryItems?.first { $0.name == "pwd" }?.value
+        XCTAssertEqual(pwd, "AbCdEf.1", "custom-regex candidate must carry a parseable pwd")
+    }
+}

--- a/MeetingBarLogicTests/ZoomGoogleRedirectRegressionTests.swift
+++ b/MeetingBarLogicTests/ZoomGoogleRedirectRegressionTests.swift
@@ -1,0 +1,73 @@
+//
+//  ZoomGoogleRedirectRegressionTests.swift
+//  MeetingBar
+//
+//  Regression fixture for a Google Calendar Zoom add-on invite body. A link
+//  the organiser typed into the body is rendered twice — once plain, once
+//  wrapped in a
+//  `www.google.com/url?q=` redirect with the target percent-encoded. The
+//  wrapped form is LONGER than the plain one, so it used to win the candidate
+//  length tie-break, and its `?pwd%3D…` does not parse as a `pwd` query
+//  parameter — leaving Zoom to prompt for a passcode the invite supplied.
+//
+//  Body shape is verbatim from a real invite; all identifiers are fabricated.
+//
+
+// swiftlint:disable line_length
+// The invite body below is a verbatim fixture; wrapping it would change what
+// the detector sees.
+
+import XCTest
+@testable import MeetingBarLogic
+
+final class ZoomGoogleRedirectRegressionTests: XCTestCase {
+    private let notes = #"""
+-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
+Join Zoom Meeting
+https://acme.zoom.us/j/81234567890?pwd=AbCdEfGhIjKlMnOpQrStUvWxYz1234.1&jst=2 (ID: 81234567890, passcode: 123456)
+
+Join by phone
+(US) +1 555-555-5555 (passcode: 123456)
+
+Join using SIP
+81234567890@zoomcrc.com (passcode: 123456)
+
+Joining instructions: https://www.google.com/url?q=https://applications.zoom.us/addon/invitation/detail?meetingUuid%3D0000000000000000%253D%253D&sa=D&source=calendar&usg=AOvVaw0000000000000000000
+
+Meeting host: host@example.com<br /><br />Join Zoom Meeting: <br /><a href="https://www.google.com/url?q=https://acme.zoom.us/j/81234567890?pwd%3DAbCdEfGhIjKlMnOpQrStUvWxYz1234.1%26jst%3D2&amp;sa=D&amp;source=calendar&amp;usg=AOvVaw0000000000000000000" target="_blank">https://acme.zoom.us/j/81234567890?pwd=AbCdEfGhIjKlMnOpQrStUvWxYz1234.1&amp;jst=2</a><br /><br />Meeting agenda: <br /><a href="https://www.google.com/url?q=https://docs.zoom.us/agenda/doc/cfe521f4-98ee-4856-b181-f26ca7cd6214?from%3Dgsuite&amp;sa=D&amp;source=calendar&amp;usg=AOvVaw0000000000000000000" target="_blank">https://docs.zoom.us/agenda/doc/cfe521f4-98ee-4856-b181-f26ca7cd6214?from=gsuite</a><br /><br />Chat with Everyone: <br /><a href="https://www.google.com/url?q=https://acme.zoom.us/launch/jc/81234567890&amp;sa=D&amp;source=calendar&amp;usg=AOvVaw0000000000000000000" target="_blank">https://acme.zoom.us/launch/jc/81234567890</a>
+
+Please do not edit this section.
+-::~:~::~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~:~::~:~::-
+"""#
+
+    func testDetectorPrefersTheLinkWhosePasscodeParses() throws {
+        // Fixture guards — a change to the body above must not silently make
+        // these assertions vacuous.
+        XCTAssertTrue(
+            notes.contains("pwd=AbCdEfGhIjKlMnOpQrStUvWxYz1234.1&jst=2"),
+            "fixture no longer seeds the plain link")
+        XCTAssertTrue(
+            notes.contains("pwd%3DAbCdEfGhIjKlMnOpQrStUvWxYz1234.1%26jst%3D2"),
+            "fixture no longer seeds the google.com/url wrapped link")
+
+        let link = MeetingLinkDetector.detect(
+            location: nil,
+            eventURL: nil,
+            notes: notes,
+            calendarEmail: nil,
+            currentUserEmail: nil
+        )
+
+        let selected = try XCTUnwrap(link).url
+        let items = URLComponents(url: selected, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        let pwd = items.first { $0.name == "pwd" }?.value
+
+        XCTAssertEqual(
+            pwd, "AbCdEfGhIjKlMnOpQrStUvWxYz1234.1",
+            "selected URL must expose a parseable pwd; got \(selected.absoluteString)")
+        XCTAssertEqual(
+            selected.absoluteString,
+            "https://acme.zoom.us/j/81234567890?pwd=AbCdEfGhIjKlMnOpQrStUvWxYz1234.1&jst=2")
+    }
+}
+// swiftlint:enable line_length


### PR DESCRIPTION
## Problem

Clicking **Join** on a Zoom invite created with the Google Calendar Zoom add-on can make the Zoom client prompt for a meeting passcode, even though the invite carries one.

When Calendar renders an invite body it wraps links in a `google.<tld>/url?q=<target>` redirect with the target percent-encoded. For a link the organiser typed into the body, both forms appear:

```
https://acme.zoom.us/j/81234567890?pwd=AbCdEf.1&jst=2                                    (53 chars)
https://www.google.com/url?q=https://acme.zoom.us/j/81234567890?pwd%3DAbCdEf.1%26jst%3D2 (88 chars)
&amp;sa=D&amp;usg=…
```

Both match the Zoom detection regex. The wrapped one is **longer** — `%3D` and `%26` are three characters where `=` and `&` are one — so it wins `MeetingLinkCandidatePolicy.best`'s length tie-break, which exists to prefer a link carrying a password suffix over a truncated one.

The selected URL's query then parses as:

```
[("pwd=AbCdEf.1&jst=2", nil), ("amp", nil)]
```

There is no `pwd` parameter — just one valueless parameter whose *name* is the passcode — so no passcode reaches Zoom and the client asks for it.

The symptom is intermittent in a way that hides the cause: on meetings where authenticated users bypass the passcode, or where the client has already cached it, the join succeeds regardless. It surfaces on a first join of a meeting that enforces its passcode. Clicking the same meeting in the Google Calendar web UI always works, because that UI uses the structured conference URL rather than the invite body.

## Fix

`cleanupGoogleRedirects` rewrites those redirects back to their percent-decoded targets before detection runs, called alongside the existing `cleanupOutlookSafeLinks` at **every** site that reads text: `detectMeetingLink`, `builtInCandidates`, and the custom-regex source in `collectCandidates`.

That third site is worth calling out — it built its own combined text and cleaned nothing. For a self-hosted or otherwise uncatalogued service, which is exactly why `customRegexes` exists, the custom-regex candidate is the *only* candidate, so the fix would have been a no-op there. It is also the candidate shown in the "open with another link" submenu and in the preferences regex tester.

Behaviour worth knowing about:

- **A malformed `%` escape skips that match rather than aborting the pass.** Calendar emits its own generated "Joining instructions" link *before* the organiser's meeting link, so aborting on the first undecodable escape defeated the fix for the link that matters. Ordering the user does not control.
- **Every match is rewritten in a single pass**, so the pass cap bounds nesting depth rather than how many links a body may contain.
- **The host matches country domains** (`google.de`, `google.co.uk`), with or without `www.`, since Calendar renders under the viewer's Google domain. It stays `https`-only and requires `q` first, which is what Calendar emits; a test records those boundaries.
- **Trailing parameters are consumed by `name=value` shape, not an allow-list**, matching the pattern's own rationale: the target is fully percent-encoded, so every `&` after `q=` belongs to Google. An unrecognised parameter (`opi`, `ved`, `rct`…) would otherwise be glued onto the unwrapped URL, defeating the string-identity dedupe in `MeetingLinkCandidatePolicy.ranked`.
- **Rewriting appends segments** rather than doing a global `replacingOccurrences` of the matched text, which could rewrite inside a longer wrapper sharing the same prefix.

Decoding is confined to unwrapping the redirect. Google double-encodes a `%` already present in the target, so exactly one decode is correct — a second corrupts the passcode.

## Tests

`GoogleRedirectCleanupTests` probes the helper directly, since the assertion here *is* a regex and mutating surrounding code proves nothing about it. It includes the inputs that must **not** be rewritten: a plain Zoom link, a passcode that legitimately contains percent-encoding, a malformed `%ZZ` escape, an unrelated `docs.google.com` URL, and the host/scheme boundaries (uppercase host, `http://`, `q` not first, lookalike domain).

Cases that exist because each one failed at some point during review: malformed-then-valid ordering, more links than the nesting budget, country domains, unrecognised tracking parameters, a wrapper that is a prefix of another, the custom-regex candidate source, and `detectMeetingLink` as a call site in its own right.

`ZoomGoogleRedirectRegressionTests` runs detection over a full invite body in the shape a real add-on invite arrives in. Its fixture guards assert both variants are present before asserting the outcome, so it cannot silently go vacuous. All identifiers in it are fabricated.

## Verification

Every claim below was established at `bfc2cec` and expires if HEAD moves.

- Full logic suite: **226 tests, 0 failures**. `xcodebuild` succeeds for the app scheme, SwiftLint phase included, **0 violations**.
- Each new test was mutation-probed individually — one mutation per run, restored and `diff`-proven byte-identical after each. Every one of these reverts turns exactly its guarding test red: double-decoding the target; aborting the pass on a malformed escape; rewriting one match per pass; pinning the host back to `www.google.com`; restoring the `sa|source|usg|ust` allow-list; reverting the custom-regex cleanup; removing the cleanup from `detectMeetingLink`; and swapping the splice back to a global `replacingOccurrences`.
- Both tests use `try XCTUnwrap` rather than `try!`. Forcing detection to return nil now yields 226 executed with 24 failures instead of killing the runner mid-suite and reporting a misleadingly small pass count.

**Not verified end-to-end in a running build.** The detector demonstrably now returns the clean URL, but I did not get a local app build past macOS calendar permissions to click Join and watch Zoom open, so the real UI path through `MeetingOpener` is unexercised. Worth a maintainer sanity check there.

**Inherited, not fixed here:** `cleanupOutlookSafeLinks` — which this helper mirrors — has the same abort-on-first-malformed and global-`replacingOccurrences` behaviour, and the custom-regex source bypassed it too (that last one is fixed here, since the call site is shared). I've left the SafeLinks helper alone to keep this PR to the reported bug; happy to follow up separately if you'd like the same hardening applied there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved meeting-link detection for Google Calendar redirect links.
  * Automatically unwraps nested and percent-encoded redirects, including links processed after Outlook SafeLinks cleanup.
  * Correctly identifies Zoom meeting links and preserves valid links when redirects are malformed or unrelated.
  * Removes unnecessary tracking parameters from unwrapped links, including custom-regex candidates.

* **Tests**
  * Added coverage for nested, overlapping, encoded, malformed, and country-specific redirects, plus Zoom invite detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->