### PR TITLE
Fix Google Meet PWA launching

### DIFF
--- a/MeetingBar/Meetings/MeetingOpener.swift
+++ b/MeetingBar/Meetings/MeetingOpener.swift
@@ -316,37 +316,51 @@ enum GoogleMeetPWAInstallation {
 }
 
 enum GoogleMeetPWALauncher {
-    static func launch(_ plan: GoogleMeetPWAOpenPlan) -> Bool {
-        openApplication(plan)
-        return true
+    typealias Completion = @Sendable (Bool) -> Void
+    typealias ApplicationOpener = @Sendable (
+        GoogleMeetPWAOpenPlan,
+        @escaping @Sendable (NSRunningApplication?, Error?) -> Void
+    ) -> Void
+
+    static func launch(
+        _ plan: GoogleMeetPWAOpenPlan,
+        completion: @escaping Completion
+    ) {
+        launch(plan, applicationOpener: openApplication, completion: completion)
     }
 
     static func launch(
         _ plan: GoogleMeetPWAOpenPlan,
-        applicationOpener: (GoogleMeetPWAOpenPlan) throws -> Void
-    ) -> Bool {
-        do {
-            try applicationOpener(plan)
-            return true
-        } catch {
-            AppMessageCenter.shared.post(.browserUnavailable(name: "Google Meet"))
-            return false
+        applicationOpener: @escaping ApplicationOpener,
+        completion: @escaping Completion
+    ) {
+        applicationOpener(plan) { application, error in
+            let didLaunch = application != nil && error == nil
+            if !didLaunch {
+                AppMessageCenter.shared.post(.browserUnavailable(name: "Google Meet"))
+            }
+            completion(didLaunch)
         }
     }
 
-    private static func openApplication(_ plan: GoogleMeetPWAOpenPlan) {
-        let configuration = NSWorkspace.OpenConfiguration()
-        configuration.activates = true
-        configuration.addsToRecentItems = true
+    private static func openApplication(
+        _ plan: GoogleMeetPWAOpenPlan,
+        completion: @escaping @Sendable (NSRunningApplication?, Error?) -> Void
+    ) {
+        let configuration = openConfiguration()
         NSWorkspace.shared.open(
             [plan.meetingURL],
             withApplicationAt: plan.applicationURL,
-            configuration: configuration
-        ) { application, error in
-            if application == nil || error != nil {
-                AppMessageCenter.shared.post(.browserUnavailable(name: "Google Meet"))
-            }
-        }
+            configuration: configuration,
+            completionHandler: completion
+        )
+    }
+
+    static func openConfiguration() -> NSWorkspace.OpenConfiguration {
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        configuration.addsToRecentItems = false
+        return configuration
     }
 }
 
@@ -354,7 +368,10 @@ enum GoogleMeetPWALauncher {
 /// installed Chrome Google Meet PWA.
 struct GoogleMeetOpenStrategy: MeetingOpenStrategy, Sendable {
     private let pwaPlanBuilder: @Sendable (URL) -> GoogleMeetPWAOpenPlan?
-    private let pwaLauncher: @Sendable (GoogleMeetPWAOpenPlan) -> Bool
+    private let pwaLauncher: @Sendable (
+        GoogleMeetPWAOpenPlan,
+        @escaping GoogleMeetPWALauncher.Completion
+    ) -> Void
     private let browserOpener: @Sendable (URL, Browser) -> Void
     private let defaultOpener: @Sendable (URL) -> Void
 
@@ -365,8 +382,11 @@ struct GoogleMeetOpenStrategy: MeetingOpenStrategy, Sendable {
                 pwaApplicationURL: GoogleMeetPWAInstallation.applicationURL()
             )
         },
-        pwaLauncher: @escaping @Sendable (GoogleMeetPWAOpenPlan) -> Bool = {
-            GoogleMeetPWALauncher.launch($0)
+        pwaLauncher: @escaping @Sendable (
+            GoogleMeetPWAOpenPlan,
+            @escaping GoogleMeetPWALauncher.Completion
+        ) -> Void = {
+            GoogleMeetPWALauncher.launch($0, completion: $1)
         },
         browserOpener: @escaping @Sendable (URL, Browser) -> Void = {
             $0.openIn(browser: $1)
@@ -391,9 +411,14 @@ struct GoogleMeetOpenStrategy: MeetingOpenStrategy, Sendable {
             let meetInOneURL = URL(string: "meetinone://url=" + url.absoluteString)!
             defaultOpener(meetInOneURL)
         case .googleMeetPWA:
-            guard let plan = pwaPlanBuilder(url), pwaLauncher(plan) else {
+            guard let plan = pwaPlanBuilder(url) else {
                 browserOpener(url, opening.browser)
                 return
+            }
+            pwaLauncher(plan) { didLaunch in
+                if !didLaunch {
+                    browserOpener(url, opening.browser)
+                }
             }
         case .zoomApp, .zoomWebApp, .teamsApp, .workplaceApp, .jitsiApp,
              .slackApp, .riversideApp, nil:

--- a/MeetingBar/Meetings/MeetingOpener.swift
+++ b/MeetingBar/Meetings/MeetingOpener.swift
@@ -284,93 +284,69 @@ struct ZoomNativeOpenStrategy: MeetingOpenStrategy, Sendable {
 }
 
 struct GoogleMeetPWAOpenPlan: Equatable, Sendable {
-    let executableURL: URL
-    let arguments: [String]
+    let applicationURL: URL
+    let meetingURL: URL
 }
 
 enum GoogleMeetPWAOpenPolicy {
     static func plan(
         for url: URL,
-        chromeExecutableURL: URL?,
-        pwaAppID: String?
+        pwaApplicationURL: URL?
     ) -> GoogleMeetPWAOpenPlan? {
         guard url.scheme == "https",
               url.host?.lowercased() == "meet.google.com",
               url.pathComponents.count >= 2,
-              let chromeExecutableURL,
-              let pwaAppID,
-              pwaAppID.count == 32,
-              pwaAppID.allSatisfy({ ("a" ... "p").contains($0) })
+              let pwaApplicationURL
         else { return nil }
 
         return GoogleMeetPWAOpenPlan(
-            executableURL: chromeExecutableURL,
-            arguments: [
-                "--app-id=\(pwaAppID)",
-                "--app-launch-url-for-shortcuts-menu-item=\(url.absoluteString)"
-            ]
+            applicationURL: pwaApplicationURL,
+            meetingURL: url
         )
     }
 }
 
 enum GoogleMeetPWAInstallation {
-    static func chromeExecutableURL(
-        fileManager: FileManager = .default
-    ) -> URL? {
-        let home = fileManager.homeDirectoryForCurrentUser
-        let candidates = [
-            URL(fileURLWithPath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"),
-            home.appendingPathComponent(
-                "Applications/Google Chrome.app/Contents/MacOS/Google Chrome")
-        ]
-        return candidates.first { fileManager.isExecutableFile(atPath: $0.path) }
-    }
+    private static let bundleIdentifier =
+        "com.google.Chrome.app.kjgfgldnnfoeklkmfkjfagphfepbbdan"
 
-    static func appID(fileManager: FileManager = .default) -> String? {
-        let home = fileManager.homeDirectoryForCurrentUser
-        let candidates = [
-            home.appendingPathComponent(
-                "Applications/Chrome Apps.localized/Google Meet.app"),
-            home.appendingPathComponent(
-                "Applications/Chrome Apps/Google Meet.app"),
-            URL(fileURLWithPath: "/Applications/Chrome Apps.localized/Google Meet.app"),
-            URL(fileURLWithPath: "/Applications/Chrome Apps/Google Meet.app")
-        ]
-
-        for appURL in candidates where fileManager.fileExists(atPath: appURL.path) {
-            if let appID = Bundle(url: appURL)?
-                .object(forInfoDictionaryKey: "CrAppModeShortcutID") as? String,
-               !appID.isEmpty {
-                return appID
-            }
-        }
-        return nil
+    static func applicationURL() -> URL? {
+        NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
     }
 }
 
 enum GoogleMeetPWALauncher {
     static func launch(_ plan: GoogleMeetPWAOpenPlan) -> Bool {
-        launch(plan, processRunner: runProcess)
+        openApplication(plan)
+        return true
     }
 
     static func launch(
         _ plan: GoogleMeetPWAOpenPlan,
-        processRunner: (GoogleMeetPWAOpenPlan) throws -> Void
+        applicationOpener: (GoogleMeetPWAOpenPlan) throws -> Void
     ) -> Bool {
         do {
-            try processRunner(plan)
+            try applicationOpener(plan)
             return true
         } catch {
-            AppMessageCenter.shared.post(.browserUnavailable(name: "Google Chrome"))
+            AppMessageCenter.shared.post(.browserUnavailable(name: "Google Meet"))
             return false
         }
     }
 
-    private static func runProcess(_ plan: GoogleMeetPWAOpenPlan) throws {
-        let process = Process()
-        process.executableURL = plan.executableURL
-        process.arguments = plan.arguments
-        try process.run()
+    private static func openApplication(_ plan: GoogleMeetPWAOpenPlan) {
+        let configuration = NSWorkspace.OpenConfiguration()
+        configuration.activates = true
+        configuration.addsToRecentItems = true
+        NSWorkspace.shared.open(
+            [plan.meetingURL],
+            withApplicationAt: plan.applicationURL,
+            configuration: configuration
+        ) { application, error in
+            if application == nil || error != nil {
+                AppMessageCenter.shared.post(.browserUnavailable(name: "Google Meet"))
+            }
+        }
     }
 }
 
@@ -386,8 +362,7 @@ struct GoogleMeetOpenStrategy: MeetingOpenStrategy, Sendable {
         pwaPlanBuilder: @escaping @Sendable (URL) -> GoogleMeetPWAOpenPlan? = {
             GoogleMeetPWAOpenPolicy.plan(
                 for: $0,
-                chromeExecutableURL: GoogleMeetPWAInstallation.chromeExecutableURL(),
-                pwaAppID: GoogleMeetPWAInstallation.appID()
+                pwaApplicationURL: GoogleMeetPWAInstallation.applicationURL()
             )
         },
         pwaLauncher: @escaping @Sendable (GoogleMeetPWAOpenPlan) -> Bool = {

--- a/MeetingBarTests/HelpersTests.swift
+++ b/MeetingBarTests/HelpersTests.swift
@@ -491,14 +491,11 @@ final class MeetingOpenSettingsTests: BaseTestCase {
 }
 
 final class ProviderOpeningPolicyTests: BaseTestCase {
-    private enum TestError: Error {
-        case failed
-    }
-
     private final class OpeningSpy: @unchecked Sendable {
         var nativeURLs: [URL] = []
         var browserOpens: [(URL, Browser)] = []
         var defaultURLs: [URL] = []
+        var pwaLaunchResults: [Bool] = []
     }
 
     func test_workplaceNativeURLPercentEncodesOriginalURL() {
@@ -623,17 +620,28 @@ final class ProviderOpeningPolicyTests: BaseTestCase {
         )
     }
 
-    func test_googleMeetPWALaunchFailureReturnsFalse() {
+    func test_googleMeetPWALaunchFailureReportsCompletionResult() {
+        let spy = OpeningSpy()
         let plan = GoogleMeetPWAOpenPlan(
             applicationURL: URL(fileURLWithPath: "/missing/Google Meet.app"),
             meetingURL: URL(string: "https://meet.google.com/abc-defg-hij")!
         )
-
-        XCTAssertFalse(
-            GoogleMeetPWALauncher.launch(plan) { _ in
-                throw TestError.failed
-            }
+        GoogleMeetPWALauncher.launch(
+            plan,
+            applicationOpener: { _, completion in
+                completion(nil, CocoaError(.fileNoSuchFile))
+            },
+            completion: { spy.pwaLaunchResults.append($0) }
         )
+
+        XCTAssertEqual(spy.pwaLaunchResults, [false])
+    }
+
+    func test_googleMeetPWALaunchDoesNotAddMeetingToRecentItems() {
+        let configuration = GoogleMeetPWALauncher.openConfiguration()
+
+        XCTAssertTrue(configuration.activates)
+        XCTAssertFalse(configuration.addsToRecentItems)
     }
 
     func test_googleMeetPWAModeFallsBackToOriginalURLWhenLaunchFails() {
@@ -646,7 +654,7 @@ final class ProviderOpeningPolicyTests: BaseTestCase {
         )
         let strategy = GoogleMeetOpenStrategy(
             pwaPlanBuilder: { _ in plan },
-            pwaLauncher: { _ in false },
+            pwaLauncher: { _, completion in completion(false) },
             browserOpener: {
                 spy.browserOpens.append(($0, $1))
             },
@@ -666,13 +674,36 @@ final class ProviderOpeningPolicyTests: BaseTestCase {
         XCTAssertTrue(spy.defaultURLs.isEmpty)
     }
 
+    func test_googleMeetPWAModeDoesNotOpenBrowserWhenLaunchSucceeds() {
+        let spy = OpeningSpy()
+        let meetURL = URL(string: "https://meet.google.com/abc-defg-hij")!
+        let browser = Browser(name: "Safari", path: "/Applications/Safari.app")
+        let plan = GoogleMeetPWAOpenPlan(
+            applicationURL: URL(fileURLWithPath: "/Applications/Google Meet.app"),
+            meetingURL: meetURL
+        )
+        let strategy = GoogleMeetOpenStrategy(
+            pwaPlanBuilder: { _ in plan },
+            pwaLauncher: { _, completion in completion(true) },
+            browserOpener: { spy.browserOpens.append(($0, $1)) }
+        )
+
+        strategy.open(
+            url: meetURL,
+            opening: ResolvedMeetingOpening(mode: .googleMeetPWA, browser: browser),
+            defaultBrowser: systemDefaultBrowser
+        )
+
+        XCTAssertTrue(spy.browserOpens.isEmpty)
+    }
+
     func test_googleMeetDefaultBrowserAndMeetInOneBehaviorRemainUnchanged() {
         let spy = OpeningSpy()
         let meetURL = URL(string: "https://meet.google.com/abc-defg-hij")!
         let browser = Browser(name: "Safari", path: "/Applications/Safari.app")
         let strategy = GoogleMeetOpenStrategy(
             pwaPlanBuilder: { _ in nil },
-            pwaLauncher: { _ in false },
+            pwaLauncher: { _, completion in completion(false) },
             browserOpener: {
                 spy.browserOpens.append(($0, $1))
             },

--- a/MeetingBarTests/HelpersTests.swift
+++ b/MeetingBarTests/HelpersTests.swift
@@ -589,59 +589,44 @@ final class ProviderOpeningPolicyTests: BaseTestCase {
         )
     }
 
-    func test_googleMeetPWAPlanBuildsChromeArguments() {
+    func test_googleMeetPWAPlanUsesInstalledAppShim() {
         let meetURL = URL(string: "https://meet.google.com/abc-defg-hij?authuser=me")!
-        let chromeURL = URL(
-            fileURLWithPath: "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
-        )
+        let pwaURL = URL(fileURLWithPath: "/Users/test/Applications/Google Meet.app")
 
         XCTAssertEqual(
             GoogleMeetPWAOpenPolicy.plan(
                 for: meetURL,
-                chromeExecutableURL: chromeURL,
-                pwaAppID: "abcdefghijklmnopabcdefghijklmnop"
+                pwaApplicationURL: pwaURL
             ),
             GoogleMeetPWAOpenPlan(
-                executableURL: chromeURL,
-                arguments: [
-                    "--app-id=abcdefghijklmnopabcdefghijklmnop",
-                    "--app-launch-url-for-shortcuts-menu-item=\(meetURL.absoluteString)"
-                ]
+                applicationURL: pwaURL,
+                meetingURL: meetURL
             )
         )
     }
 
     func test_googleMeetPWAPlanFallsBackWhenInputOrInstallationIsUnavailable() {
         let meetURL = URL(string: "https://meet.google.com/abc-defg-hij")!
-        let chromeURL = URL(fileURLWithPath: "/Applications/Google Chrome")
+        let pwaURL = URL(fileURLWithPath: "/Users/test/Applications/Google Meet.app")
 
         XCTAssertNil(
             GoogleMeetPWAOpenPolicy.plan(
                 for: URL(string: "https://example.com/abc-defg-hij")!,
-                chromeExecutableURL: chromeURL,
-                pwaAppID: "abcdefghijklmnopabcdefghijklmnop"
+                pwaApplicationURL: pwaURL
             )
         )
         XCTAssertNil(
             GoogleMeetPWAOpenPolicy.plan(
                 for: meetURL,
-                chromeExecutableURL: nil,
-                pwaAppID: "abcdefghijklmnopabcdefghijklmnop"
-            )
-        )
-        XCTAssertNil(
-            GoogleMeetPWAOpenPolicy.plan(
-                for: meetURL,
-                chromeExecutableURL: chromeURL,
-                pwaAppID: nil
+                pwaApplicationURL: nil
             )
         )
     }
 
     func test_googleMeetPWALaunchFailureReturnsFalse() {
         let plan = GoogleMeetPWAOpenPlan(
-            executableURL: URL(fileURLWithPath: "/missing/chrome"),
-            arguments: []
+            applicationURL: URL(fileURLWithPath: "/missing/Google Meet.app"),
+            meetingURL: URL(string: "https://meet.google.com/abc-defg-hij")!
         )
 
         XCTAssertFalse(
@@ -656,8 +641,8 @@ final class ProviderOpeningPolicyTests: BaseTestCase {
         let meetURL = URL(string: "https://meet.google.com/abc-defg-hij")!
         let browser = Browser(name: "Safari", path: "/Applications/Safari.app")
         let plan = GoogleMeetPWAOpenPlan(
-            executableURL: URL(fileURLWithPath: "/Applications/Google Chrome"),
-            arguments: []
+            applicationURL: URL(fileURLWithPath: "/Applications/Google Meet.app"),
+            meetingURL: meetURL
         )
         let strategy = GoogleMeetOpenStrategy(
             pwaPlanBuilder: { _ in plan },


### PR DESCRIPTION
## Summary

- resolve the installed Google Meet app shim through Launch Services
- open Meet URLs directly with the PWA instead of spawning Chrome
- avoid sandbox-sensitive filesystem probing and preserve the PWA’s Chrome profile

## Testing

- full macOS test suite: 436 tests passed
- focused `ProviderOpeningPolicyTests` passed
- Release configuration built successfully
- installed the Google Meet PWA locally and verified the handoff opens a separate Google Meet app window rather than a normal Chrome tab

Closes #963

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google Meet meetings now open directly in the installed Google Meet app when available.
  * Improved detection of the installed Google Meet app.
  * If opening the app fails or it is unavailable, meetings now fall back to the selected browser.
  * Successful app launches no longer open an additional browser window or add unnecessary recent items.
  * Launch failures now correctly identify Google Meet as unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->