### PR TITLE
Treat all-day event range as exclusive at endDate

### DIFF
--- a/MeetingBar/Notifications/EventActionPolicy.swift
+++ b/MeetingBar/Notifications/EventActionPolicy.swift
@@ -70,7 +70,10 @@ enum EventActionPolicy {
         let timeInterval = event.startDate.timeIntervalSince(now)
         let lowerBound = config.allowsRecentlyStarted ? -15.0 : 0.0
         let withinWindow = timeInterval > lowerBound && timeInterval <= config.actionTime
-        let allDayActive = event.isAllDay && (event.startDate ... event.endDate).contains(now)
+        // All-day events carry an EXCLUSIVE endDate (midnight of the next day
+        // per EventKit / Google Calendar), so treat the range as half-open —
+        // matching cleanupExpired, which drops entries once now >= endDate.
+        let allDayActive = event.isAllDay && event.startDate <= now && now < event.endDate
         guard withinWindow || allDayActive else { return nil }
 
         let matched = processed.first { $0.id == event.id }

--- a/MeetingBarLogicTests/EventActionPolicyTests.swift
+++ b/MeetingBarLogicTests/EventActionPolicyTests.swift
@@ -148,6 +148,27 @@ final class EventActionPolicyTests: XCTestCase {
         XCTAssertNotNil(decision)
     }
 
+    func testEvaluateAllDayEventInactiveAtExclusiveEndDate() {
+        // All-day events carry an EXCLUSIVE endDate (midnight of the next day,
+        // per EventKit / Google Calendar). At that instant the event is already
+        // over, so no action should fire — matching cleanupExpired, which drops
+        // entries once now >= endDate.
+        let allDay = EventActionEvent(
+            id: "all-day-ended",
+            lastModifiedDate: nil,
+            startDate: now.addingTimeInterval(-86_400),
+            endDate: now,
+            isAllDay: true,
+            hasMeetingLink: true
+        )
+        let decision = EventActionPolicy.evaluate(
+            event: allDay, config: fullscreenLikeConfig, processed: [], now: now
+        )
+        XCTAssertNil(
+            decision,
+            "an all-day event that has reached its exclusive endDate is no longer active")
+    }
+
     func testEvaluateSkipsAlreadyProcessedEvent() {
         let event = eventStartingIn(30)
         let processed = [


### PR DESCRIPTION
**Status:** READY

## Problem

`EventActionPolicy.evaluate` could still fire a fullscreen notification / auto-join / on-start script for an all-day event that had **already ended**, at the exact instant the event's `endDate` was reached (e.g. midnight at the end of an all-day event, or the end day of a multi-day all-day event).

## Root cause

The \"event is currently active\" check for all-day events used a **closed** range:

```swift
let allDayActive = event.isAllDay && (event.startDate ... event.endDate).contains(now)
```

All-day events carry an **exclusive** `endDate` — midnight of the next day per EventKit (`EKEvent.endDate`) and the Google Calendar `end.date` field (see `EventKitEventStore` / `GoogleCalendarEventStore`). The closed range includes `endDate` itself, so at that instant the event reads as active even though it is over.

This is also inconsistent with `cleanupExpired` in the same file, which already treats `endDate` as exclusive:

```swift
processed.filter { $0.eventEndDate.timeIntervalSince(now) > 0 }   // endDate > now
```

## Changes

Replace the closed range with a half-open comparison, matching the exclusive-endDate convention used by `cleanupExpired` and the rest of the codebase:

```swift
let allDayActive = event.isAllDay && event.startDate <= now && now < event.endDate
```

## Verification

Added a regression test in `MeetingBarLogicTests/EventActionPolicyTests.swift`, red before the fix and green after:

- `testEvaluateAllDayEventInactiveAtExclusiveEndDate` — an all-day event whose `endDate == now` no longer fires.

The existing `testEvaluateAllDayEventActiveDuringRange` (clearly inside the range) still passes.

```bash
make test-logic    # 209 tests, 0 failures (was 208)
make lint          # clean
```

- [ ] Localized — no user-facing string changes.
- [ ] Changelog.swift
- [x] CHANGELOG.md — not ticked: narrow boundary-only fix with no user-visible behavior change beyond avoiding a stale all-day action; happy to add a line if preferred.

Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected all-day event handling so events become inactive at their exclusive end date.
  - Prevented actions from being triggered after an all-day event has ended.

- **Tests**
  - Added regression coverage for events ending at the current time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->