### PR TITLE
Fix dismissed meeting notification state

### DIFF
--- a/MeetingBar/App/AppModel.swift
+++ b/MeetingBar/App/AppModel.swift
@@ -493,15 +493,19 @@ final class AppModel: ObservableObject {
         case .dismissMeeting(let eventID):
             performWithEvent(id: eventID) { event in
                 environment.dismissEvent(event)
+                reconcileNotificationsFromState()
             }
         case .dismissNearestMeeting:
             if let event = state.nextEvent(now: environment.clock.now()) {
                 environment.dismissEvent(event)
+                reconcileNotificationsFromState()
             }
         case .undismissMeeting(let eventID):
             environment.undismissEvent(eventID)
+            reconcileNotificationsFromState()
         case .clearDismissedMeetings:
             environment.clearDismissedEvents()
+            reconcileNotificationsFromState()
         case .snoozeMeeting(let eventID, let action):
             scheduleSnooze(eventID: eventID, action: action)
         default:

--- a/MeetingBarTests/AppModelTests.swift
+++ b/MeetingBarTests/AppModelTests.swift
@@ -277,6 +277,57 @@ final class AppModelTests: BaseTestCase {
         ])
     }
 
+    func testDismissMeetingImmediatelyReconcilesNotifications() async {
+        let harness = AppModelTestHarness()
+        let event = makeFakeEvent(
+            id: "dismiss",
+            start: harness.fixedNow,
+            end: harness.fixedNow.addingTimeInterval(1800)
+        )
+        harness.model.send(.eventsLoaded([event]))
+        await harness.flushAsyncActions()
+
+        harness.model.send(.dismissMeeting(eventID: event.id))
+        await harness.flushAsyncActions()
+
+        XCTAssertEqual(harness.dismissedEventIDs, [event.id])
+        XCTAssertEqual(harness.reconciledEventIDs, [[event.id], [event.id]])
+    }
+
+    func testUndismissMeetingImmediatelyReconcilesNotifications() async {
+        let harness = AppModelTestHarness()
+        let event = makeFakeEvent(
+            id: "undismiss",
+            start: harness.fixedNow,
+            end: harness.fixedNow.addingTimeInterval(1800)
+        )
+        harness.model.send(.eventsLoaded([event]))
+        await harness.flushAsyncActions()
+
+        harness.model.send(.undismissMeeting(eventID: event.id))
+        await harness.flushAsyncActions()
+
+        XCTAssertEqual(harness.undismissedEventIDs, [event.id])
+        XCTAssertEqual(harness.reconciledEventIDs, [[event.id], [event.id]])
+    }
+
+    func testClearDismissedMeetingsImmediatelyReconcilesNotifications() async {
+        let harness = AppModelTestHarness()
+        let event = makeFakeEvent(
+            id: "clear-dismissals",
+            start: harness.fixedNow,
+            end: harness.fixedNow.addingTimeInterval(1800)
+        )
+        harness.model.send(.eventsLoaded([event]))
+        await harness.flushAsyncActions()
+
+        harness.model.send(.clearDismissedMeetings)
+        await harness.flushAsyncActions()
+
+        XCTAssertEqual(harness.clearDismissedEventsCallCount, 1)
+        XCTAssertEqual(harness.reconciledEventIDs, [[event.id], [event.id]])
+    }
+
     func testNotificationResponsesRouteThroughMeetingActions() async {
         let harness = AppModelTestHarness()
         let event = makeFakeEvent(


### PR DESCRIPTION
## Summary

Fixes #958 by reconciling notifications immediately whenever dismissal state changes.

## Root cause

Dismiss, undismiss, and clear-dismissals updated `AppSettings`, but `AppModel` did not immediately reconcile the notification plan. Pending alerts could therefore remain active until a later calendar refresh or settings-driven reconciliation made the state catch up.

## Changes

- reconcile notifications immediately after dismissing a specific meeting
- do the same for dismiss-nearest, undismiss, and clear-dismissals
- add regression coverage for dismiss, undismiss, and clearing dismissals

The change intentionally stays in `AppModel` so all dismissal entry points, including notification responses, get the same behavior without adding UI-specific workarounds.

## Validation

Added deterministic `AppModelTests` asserting each dismissal-state mutation triggers an immediate notification reconciliation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Notifications now update immediately after dismissing, undismissing, or clearing dismissed meetings.
  * Notification state is also reconciled when meeting events finish loading.

* **Tests**
  * Added coverage for notification updates following all dismissal-related meeting actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->