### PR TITLE
Fix Google Calendar events silently not refreshing

### DIFF
--- a/MeetingBar/App/AppDelegate.swift
+++ b/MeetingBar/App/AppDelegate.swift
@@ -183,6 +183,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         lifecycleObserver.onDidWake = { [weak self] in
             self?.appModel?.handleWake()
         }
+        lifecycleObserver.onNetworkBecameReachable = { [weak self] in
+            self?.appModel?.handleNetworkBecameReachable()
+        }
         lifecycleObserver.onSystemClockChanged = { [weak self] in
             self?.handleSystemClockChange()
         }

--- a/MeetingBar/App/AppModel.swift
+++ b/MeetingBar/App/AppModel.swift
@@ -90,6 +90,7 @@ enum AppAction {
     case systemClockChanged
     case timezoneChanged
     case dayChanged
+    case networkBecameReachable
 
     // Calendar
     case calendarStoreChanged
@@ -331,7 +332,8 @@ final class AppModel: ObservableObject {
     func send(_ action: AppAction) {
         switch action {
         case .launched, .willTerminate, .screenLocked, .screenUnlocked,
-             .didWake, .systemClockChanged, .timezoneChanged, .dayChanged:
+             .didWake, .systemClockChanged, .timezoneChanged, .dayChanged,
+             .networkBecameReachable:
             handleLifecycleAction(action)
         case .calendarStoreChanged, .refreshCalendars, .calendarsLoaded,
              .eventsLoaded, .selectedCalendarsChanged, .providerHealthChanged,
@@ -363,6 +365,7 @@ final class AppModel: ObservableObject {
     func handleSystemClockChange() { send(.systemClockChanged) }
     func handleTimezoneChange() { send(.timezoneChanged) }
     func handleDayChange() { send(.dayChanged) }
+    func handleNetworkBecameReachable() { send(.networkBecameReachable) }
     func handleCalendarStoreChange() { send(.calendarStoreChanged) }
     func requestRefresh() { send(.refreshCalendars) }
     func reconcileNotifications() { send(.reconcileNotifications) }
@@ -425,7 +428,7 @@ final class AppModel: ObservableObject {
             state.timeContextRevision += 1
             reconcileNotificationsFromState()
             scheduleRefresh()
-        case .didWake, .dayChanged:
+        case .didWake, .dayChanged, .networkBecameReachable:
             scheduleRefresh()
         default:
             break

--- a/MeetingBar/App/LifecycleObserver.swift
+++ b/MeetingBar/App/LifecycleObserver.swift
@@ -36,6 +36,12 @@ final class LifecycleObserver {
     /// `nil` until the first path update, so becoming reachable at launch does
     /// not duplicate the refresh that launch already triggers.
     private var isNetworkReachable: Bool?
+    private var lastReachabilityCallback: Date?
+    /// Floor between reachability-driven refreshes. A roaming Wi-Fi link or a
+    /// reconnecting VPN can flap through several satisfied transitions in a
+    /// row, and each one would otherwise cost a full calendarList plus a
+    /// per-calendar events fetch.
+    private static let reachabilityRefreshInterval: TimeInterval = 60
 
     func start() {
         startNetworkMonitor()
@@ -110,9 +116,14 @@ final class LifecycleObserver {
     }
 
     func stop() {
+        // Clear the handler before cancelling: a path update already dispatched
+        // on the monitor queue would otherwise still enqueue its main-actor hop
+        // and fire a refresh during teardown.
+        pathMonitor?.pathUpdateHandler = nil
         pathMonitor?.cancel()
         pathMonitor = nil
         isNetworkReachable = nil
+        lastReachabilityCallback = nil
 
         let dnc = DistributedNotificationCenter.default()
         for observer in observers {
@@ -133,6 +144,12 @@ final class LifecycleObserver {
                 let wasReachable = self.isNetworkReachable
                 self.isNetworkReachable = reachable
                 guard reachable, wasReachable == false else { return }
+                let now = Date()
+                if let last = self.lastReachabilityCallback,
+                   now.timeIntervalSince(last) < Self.reachabilityRefreshInterval {
+                    return
+                }
+                self.lastReachabilityCallback = now
                 self.onNetworkBecameReachable()
             }
         }

--- a/MeetingBar/App/LifecycleObserver.swift
+++ b/MeetingBar/App/LifecycleObserver.swift
@@ -37,6 +37,12 @@ final class LifecycleObserver {
     /// not duplicate the refresh that launch already triggers.
     private var isNetworkReachable: Bool?
     private var lastReachabilityCallback: Date?
+    private var trailingReachabilityTask: Task<Void, Never>?
+    /// Invalidates path updates from a superseded or stopped monitor. Clearing
+    /// `pathUpdateHandler` cannot recall a handler invocation that already
+    /// enqueued its main-actor hop, and two such updates (unsatisfied then
+    /// satisfied) would otherwise reconstruct a transition after `stop()`.
+    private var monitorGeneration = 0
     /// Floor between reachability-driven refreshes. A roaming Wi-Fi link or a
     /// reconnecting VPN can flap through several satisfied transitions in a
     /// row, and each one would otherwise cost a full calendarList plus a
@@ -122,8 +128,11 @@ final class LifecycleObserver {
         pathMonitor?.pathUpdateHandler = nil
         pathMonitor?.cancel()
         pathMonitor = nil
+        monitorGeneration += 1
         isNetworkReachable = nil
         lastReachabilityCallback = nil
+        trailingReachabilityTask?.cancel()
+        trailingReachabilityTask = nil
 
         let dnc = DistributedNotificationCenter.default()
         for observer in observers {
@@ -135,25 +144,62 @@ final class LifecycleObserver {
     }
 
     private func startNetworkMonitor() {
+        pathMonitor?.pathUpdateHandler = nil
         pathMonitor?.cancel()
+        trailingReachabilityTask?.cancel()
+        trailingReachabilityTask = nil
+        monitorGeneration += 1
+        let generation = monitorGeneration
         let monitor = NWPathMonitor()
         monitor.pathUpdateHandler = { [weak self] path in
             let reachable = path.status == .satisfied
             Task { @MainActor [weak self] in
-                guard let self else { return }
+                guard let self, generation == self.monitorGeneration else { return }
                 let wasReachable = self.isNetworkReachable
                 self.isNetworkReachable = reachable
                 guard reachable, wasReachable == false else { return }
-                let now = Date()
-                if let last = self.lastReachabilityCallback,
-                   now.timeIntervalSince(last) < Self.reachabilityRefreshInterval {
-                    return
-                }
-                self.lastReachabilityCallback = now
-                self.onNetworkBecameReachable()
+                self.handleReachableTransition(generation: generation)
             }
         }
         monitor.start(queue: .global(qos: .utility))
         pathMonitor = monitor
+    }
+
+    /// Fires the refresh immediately outside the throttle window, otherwise
+    /// defers it to the end of that window.
+    ///
+    /// A flapping link must not cost one full fetch per transition, but it must
+    /// also not swallow the transition that finally restored the connection —
+    /// dropping that one strands the app on stale events until the periodic
+    /// timer comes round, which is the delay this trigger exists to avoid.
+    /// Deferring keeps at most one refresh in flight per window and always acts
+    /// on the most recent transition.
+    private func handleReachableTransition(generation: Int) {
+        let now = Date()
+        guard let last = lastReachabilityCallback else {
+            lastReachabilityCallback = now
+            onNetworkBecameReachable()
+            return
+        }
+
+        let elapsed = now.timeIntervalSince(last)
+        guard elapsed < Self.reachabilityRefreshInterval else {
+            lastReachabilityCallback = now
+            onNetworkBecameReachable()
+            return
+        }
+
+        let remaining = Self.reachabilityRefreshInterval - elapsed
+        trailingReachabilityTask?.cancel()
+        trailingReachabilityTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(remaining * Double(NSEC_PER_SEC)))
+            guard let self,
+                  !Task.isCancelled,
+                  generation == self.monitorGeneration,
+                  self.isNetworkReachable == true else { return }
+            self.trailingReachabilityTask = nil
+            self.lastReachabilityCallback = Date()
+            self.onNetworkBecameReachable()
+        }
     }
 }

--- a/MeetingBar/App/LifecycleObserver.swift
+++ b/MeetingBar/App/LifecycleObserver.swift
@@ -176,14 +176,16 @@ final class LifecycleObserver {
     /// on the most recent transition.
     private func handleReachableTransition(generation: Int) {
         let now = Date()
-        guard let last = lastReachabilityCallback else {
-            lastReachabilityCallback = now
-            onNetworkBecameReachable()
-            return
-        }
+        let elapsed = lastReachabilityCallback.map { now.timeIntervalSince($0) }
 
-        let elapsed = now.timeIntervalSince(last)
-        guard elapsed < Self.reachabilityRefreshInterval else {
+        // Refreshing now makes any deferred refresh redundant, and it has to be
+        // dropped rather than left to fire: `Task.sleep` runs on a clock that
+        // does not advance while the system sleeps, so a trailing task queued
+        // before a long sleep is still pending when the wake transition arrives
+        // and takes this branch — and would then fire a second, duplicate fetch.
+        guard let elapsed, elapsed < Self.reachabilityRefreshInterval else {
+            trailingReachabilityTask?.cancel()
+            trailingReachabilityTask = nil
             lastReachabilityCallback = now
             onNetworkBecameReachable()
             return

--- a/MeetingBar/App/LifecycleObserver.swift
+++ b/MeetingBar/App/LifecycleObserver.swift
@@ -5,12 +5,15 @@
 
 import AppKit
 import Foundation
+import Network
 
 /// Registers for macOS system notifications (screen lock/unlock, wake,
-/// clock/timezone change, calendar day change) and forwards them as callbacks.
+/// clock/timezone change, calendar day change, network reachability) and
+/// forwards them as callbacks.
 ///
 /// Owned by `AppDelegate`; keeps `AppDelegate` thin by concentrating all
-/// `DistributedNotificationCenter` / `NSWorkspace` wiring here.
+/// `DistributedNotificationCenter` / `NSWorkspace` / `NWPathMonitor` wiring
+/// here.
 @MainActor
 final class LifecycleObserver {
     var onScreenLocked: () -> Void = {}
@@ -20,9 +23,23 @@ final class LifecycleObserver {
     var onTimezoneChanged: () -> Void = {}
     var onDayChanged: () -> Void = {}
 
+    /// Fires on the transition from unusable to usable network.
+    ///
+    /// Wake fires before Wi-Fi reassociates or a VPN finishes connecting, so a
+    /// wake-triggered refresh routinely runs with no route to the provider.
+    /// Without this trigger the next attempt waits for the periodic timer, and
+    /// the menu bar keeps showing the previous day's events in the meantime.
+    var onNetworkBecameReachable: () -> Void = {}
+
     private var observers: [Any] = []
+    private var pathMonitor: NWPathMonitor?
+    /// `nil` until the first path update, so becoming reachable at launch does
+    /// not duplicate the refresh that launch already triggers.
+    private var isNetworkReachable: Bool?
 
     func start() {
+        startNetworkMonitor()
+
         let dnc = DistributedNotificationCenter.default()
 
         observers.append(
@@ -93,6 +110,10 @@ final class LifecycleObserver {
     }
 
     func stop() {
+        pathMonitor?.cancel()
+        pathMonitor = nil
+        isNetworkReachable = nil
+
         let dnc = DistributedNotificationCenter.default()
         for observer in observers {
             dnc.removeObserver(observer)
@@ -100,5 +121,22 @@ final class LifecycleObserver {
             NotificationCenter.default.removeObserver(observer)
         }
         observers.removeAll()
+    }
+
+    private func startNetworkMonitor() {
+        pathMonitor?.cancel()
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            let reachable = path.status == .satisfied
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                let wasReachable = self.isNetworkReachable
+                self.isNetworkReachable = reachable
+                guard reachable, wasReachable == false else { return }
+                self.onNetworkBecameReachable()
+            }
+        }
+        monitor.start(queue: .global(qos: .utility))
+        pathMonitor = monitor
     }
 }

--- a/MeetingBar/Calendar/CalendarSync.swift
+++ b/MeetingBar/Calendar/CalendarSync.swift
@@ -170,10 +170,14 @@ public class CalendarSync: ObservableObject {
 
     /// Runs `operation` under `refreshTimeout`, cancelling it on expiry.
     ///
-    /// Providers are expected to bound their own network work, but this is the
-    /// backstop that lets the serialized refresh pipeline assume a cycle always
-    /// terminates — including for hangs that never surface as a network error,
-    /// such as an authorization callback that is never delivered.
+    /// Providers are expected to bound their own network work; this is the
+    /// backstop that lets the serialized refresh pipeline assume a cycle
+    /// terminates. Note the bound only covers work that *responds* to
+    /// cancellation: a task group awaits its remaining children before
+    /// unwinding, so an operation that ignores cancellation still holds this
+    /// call open. That is sufficient here because every provider path bottoms
+    /// out in a cancellation-aware `URLSession` call under an explicit request
+    /// timeout — it is not a guard against an arbitrary non-cancellable hang.
     private func withRefreshTimeout<T: Sendable>(
         _ operation: @escaping @Sendable @MainActor () async throws -> T
     ) async throws -> T {

--- a/MeetingBar/Calendar/CalendarSync.swift
+++ b/MeetingBar/Calendar/CalendarSync.swift
@@ -15,6 +15,7 @@ public enum CalendarSyncError: LocalizedError {
     case eventStoreNotAvailable
     case calendarAccessFailed(Error)
     case eventFetchFailed(Error)
+    case refreshTimedOut(TimeInterval)
 
     public var errorDescription: String? {
         switch self {
@@ -22,6 +23,8 @@ public enum CalendarSyncError: LocalizedError {
             return "Event store is not available"
         case let .calendarAccessFailed(error), let .eventFetchFailed(error):
             return error.localizedDescription
+        case let .refreshTimedOut(seconds):
+            return "Calendar refresh did not finish within \(Int(seconds)) seconds"
         }
     }
 }
@@ -50,6 +53,16 @@ public class CalendarSync: ObservableObject {
     private var refreshCycleTask: Task<Void, Never>?
     private var providerGeneration = 0
     let refreshSubject = PassthroughSubject<Void, Never>()
+
+    /// Upper bound on a single refresh cycle.
+    ///
+    /// `flatMap(maxPublishers: .max(1))` below serializes fetches, which means
+    /// a cycle that never finishes stops *every* later trigger — the periodic
+    /// timer, settings changes and the Refresh button alike — for as long as
+    /// the app runs. Bounding the cycle keeps that serialization safe: the
+    /// pipeline always gets its value back, the failure is reported as stale
+    /// data, and the next trigger starts a clean attempt.
+    private static let refreshTimeout: TimeInterval = 120
 
     // MARK: - Initialization
 
@@ -103,7 +116,7 @@ public class CalendarSync: ObservableObject {
                 return .cancelled
             case .notSignedIn:
                 return .authRequired(error.localizedDescription)
-            case .refreshFailed:
+            case .refreshFailed, .temporarilyUnavailable:
                 return .failed(error.localizedDescription)
             }
         }
@@ -153,6 +166,30 @@ public class CalendarSync: ObservableObject {
     public func refreshSources() async throws {
         await repository.refreshSources()
         refreshSubject.send()
+    }
+
+    /// Runs `operation` under `refreshTimeout`, cancelling it on expiry.
+    ///
+    /// Providers are expected to bound their own network work, but this is the
+    /// backstop that lets the serialized refresh pipeline assume a cycle always
+    /// terminates — including for hangs that never surface as a network error,
+    /// such as an authorization callback that is never delivered.
+    private func withRefreshTimeout<T: Sendable>(
+        _ operation: @escaping @Sendable @MainActor () async throws -> T
+    ) async throws -> T {
+        let timeout = Self.refreshTimeout
+        return try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask { try await operation() }
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(timeout * Double(NSEC_PER_SEC)))
+                throw CalendarSyncError.refreshTimedOut(timeout)
+            }
+            defer { group.cancelAll() }
+            guard let result = try await group.next() else {
+                throw CalendarSyncError.refreshTimedOut(timeout)
+            }
+            return result
+        }
     }
 
     /// Fetches events for the selected calendars within the specified date range
@@ -234,12 +271,27 @@ public class CalendarSync: ObservableObject {
                 return Deferred {
                     Future<RefreshResult, Never> { promise in
                         self.refreshCycleTask = Task { [weak self] in
-                            guard let self else { return }
                             let attempted = Date()
+                            // Every exit path below must fulfil `promise`,
+                            // including this one: an unfulfilled Future stalls
+                            // the serialized pipeline permanently.
+                            guard let self else {
+                                promise(.success(RefreshResult(
+                                    calendars: preservedCalendars,
+                                    events: preservedEvents,
+                                    health: previousHealth,
+                                    providerGeneration: providerGeneration
+                                )))
+                                return
+                            }
                             do {
-                                let cals = try await self.repository.fetchAllCalendars()
+                                let cals = try await self.withRefreshTimeout {
+                                    try await self.repository.fetchAllCalendars()
+                                }
                                 try Task.checkCancellation()
-                                let evts = try await self.fetchEvents(fromCalendars: cals)
+                                let evts = try await self.withRefreshTimeout {
+                                    try await self.fetchEvents(fromCalendars: cals)
+                                }
                                 let health = ProviderHealth.success(attempted: attempted)
                                 promise(.success(RefreshResult(
                                     calendars: cals,

--- a/MeetingBar/Calendar/ProviderHealth.swift
+++ b/MeetingBar/Calendar/ProviderHealth.swift
@@ -67,7 +67,9 @@ extension ProviderHealth {
             switch authError {
             case .notSignedIn:
                 return true
-            case .cancelled, .refreshFailed:
+            // A refresh that could not reach Google says nothing about the
+            // grant, so it must not push the UI into a reconnect state.
+            case .cancelled, .refreshFailed, .temporarilyUnavailable:
                 return false
             }
         }

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
@@ -381,7 +381,16 @@ final class GCEventStore: NSObject,
                     MeetingBarLogger.calendar.error(
                         "Google token refresh did not return within \(Int(Self.tokenRefreshTimeout))s"
                     )
-                    self.discardStuckAuthState()
+                    // Only the refresh that still owns the slot may do this. A
+                    // superseded ordinary refresh timing out after a forced one
+                    // took over would otherwise swap in a stale state while the
+                    // forced refresh is still driving the old object — and when
+                    // that object later succeeds, `didChange` persists whatever
+                    // `authState` now holds, so the fresh token is dropped from
+                    // memory and the keychain both.
+                    if self.refreshTaskGeneration == generation {
+                        self.discardStuckAuthState()
+                    }
                     cont.resume(
                         throwing: AuthError.temporarilyUnavailable(
                             underlying: URLError(.timedOut)
@@ -474,6 +483,12 @@ final class GCEventStore: NSObject,
     /// leaves the stuck queue behind while keeping the user signed in.
     private func discardStuckAuthState() {
         guard let restored = restoreAuthState() else { return }
+        // Detach the object we are walking away from. It still holds a pending
+        // AppAuth request, and `didChange` persists `authState` rather than the
+        // instance that changed, so a late callback on an abandoned state would
+        // otherwise write over the session we just restored.
+        authState?.stateChangeDelegate = nil
+        authState?.errorDelegate = nil
         authState = restored
     }
 

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
@@ -64,14 +64,22 @@ final class GCEventStore: NSObject,
         }
     }
 
-    private var signInTask: Task<Void, Error>?
     private var refreshTask: Task<String, Error>?
 
     // Shared URLSession to leverage connection reuse
     private static let session: URLSession = {
         let cfg = URLSessionConfiguration.default
         cfg.httpMaximumConnectionsPerHost = 6
-        cfg.waitsForConnectivity          = true
+        // Every request must fail within a bounded time so the next refresh
+        // cycle can retry. `waitsForConnectivity` suppresses
+        // `timeoutIntervalForRequest` entirely and lets a request issued while
+        // offline (wake from sleep before Wi-Fi/VPN is up) park for
+        // `timeoutIntervalForResource` — seven days by default. That is not a
+        // slow refresh, it is a refresh that never reports back, which leaves
+        // the menu bar showing yesterday's events indefinitely.
+        cfg.waitsForConnectivity          = false
+        cfg.timeoutIntervalForRequest     = 30
+        cfg.timeoutIntervalForResource    = 90
         return URLSession(configuration: cfg)
     }()
     private var urlSession: URLSession { Self.session }
@@ -175,8 +183,6 @@ final class GCEventStore: NSObject,
     }
 
     func cancelPendingOperations() {
-        signInTask?.cancel()
-        signInTask = nil
         refreshTask?.cancel()
         refreshTask = nil
 
@@ -188,7 +194,7 @@ final class GCEventStore: NSObject,
     func refreshSources() async {}
 
     func fetchAllCalendars() async throws -> [MBCalendar] {
-        try await ensureSignedIn()
+        try requireReusableSession()
 
         let url = URL(string: "https://www.googleapis.com/calendar/v3/users/me/calendarList?maxResults=250&showHidden=true")!
         let items = try await fetchJSON(url)
@@ -248,7 +254,7 @@ final class GCEventStore: NSObject,
     func fetchEventsForDateRange(for calendars: [MBCalendar],
                                  from: Date,
                                  to: Date) async throws -> [MBEvent] {
-        try await ensureSignedIn()
+        try requireReusableSession()
         var result: [MBEvent] = []
         var forbiddenErrors: [Error] = []
         var successfulCalendars = 0
@@ -280,20 +286,21 @@ final class GCEventStore: NSObject,
     }
 
     // MARK: - Private helpers
-    private func ensureSignedIn() async throws {
-        if Self.hasReusableSession(authState) {
-            return
-        }
 
-        let forceConsent = authState?.refreshToken == nil
-        if let running = signInTask { return try await running.value }
-
-        let task = Task {
-            try await signIn(forcePrompt: forceConsent)
+    /// Gate for fetches, which always originate from an unattended refresh
+    /// cycle (timer, wake, day change) rather than from a user gesture.
+    ///
+    /// This deliberately never starts an interactive sign-in. Doing so from a
+    /// background refresh opened a browser tab nobody was watching and then
+    /// awaited its callback forever, so the refresh never completed and every
+    /// later one queued behind it. Interactive authorization belongs to the
+    /// explicit `signIn(forcePrompt:)` entry point that provider selection and
+    /// the Reconnect button call; here we surface "reconnect required" and let
+    /// the user act on it.
+    private func requireReusableSession() throws {
+        guard Self.hasReusableSession(authState) else {
+            throw AuthError.notSignedIn
         }
-        signInTask = task
-        defer { signInTask = nil }
-        try await task.value
     }
 
     nonisolated static func hasReusableSession(_ state: OIDAuthState?) -> Bool {
@@ -316,25 +323,42 @@ final class GCEventStore: NSObject,
             return token
         }
 
-        if let running = refreshTask { return try await running.value }
+        // A forced refresh is only ever requested because the token we just
+        // used was rejected, so it must not be answered by an in-flight
+        // ordinary refresh — that task can only hand back the same bad token.
+        if !forceRefresh, let running = refreshTask { return try await running.value }
 
         let task = Task<String, Error> {
             defer { refreshTask = nil }
             return try await withCheckedThrowingContinuation { cont in
                 if forceRefresh { state.setNeedsTokenRefresh() }
 
-                state.performAction { [weak self] accessToken, _, error in
-                    guard let self else { return }
-                    if let token = accessToken {
-                        cont.resume(returning: token) // stateChangeDelegate persists new tokens
-                    } else if let error {
+                state.performAction { accessToken, _, error in
+                    // `error` must be inspected before `accessToken`. When the
+                    // token endpoint is unreachable, AppAuth reports the failure
+                    // as a transient error but still passes back the *previous*,
+                    // already-expired access token (OIDAuthState only nils it out
+                    // once the grant itself is rejected). Treating that as a
+                    // success sends a known-expired token to Google, which
+                    // answers 401 → forced refresh → 401 again → "sign the user
+                    // out", so a few seconds without network destroyed the
+                    // stored refresh token and forced a full re-consent.
+                    if let error {
                         let nsError = error as NSError
                         if nsError.domain == OIDOAuthTokenErrorDomain {
-                            self.clearAuthState()
+                            // Google rejected the refresh token itself. Clearing
+                            // the session is handled by the errorDelegate.
                             cont.resume(throwing: AuthError.notSignedIn)
                         } else {
-                            cont.resume(throwing: error)
+                            cont.resume(
+                                throwing: AuthError.temporarilyUnavailable(underlying: error)
+                            )
                         }
+                        return
+                    }
+
+                    if let token = accessToken {
+                        cont.resume(returning: token) // stateChangeDelegate persists new tokens
                     } else {
                         cont.resume(throwing: AuthError.refreshFailed)
                     }
@@ -406,8 +430,12 @@ final class GCEventStore: NSObject,
             case .retryWithForcedTokenRefresh:
                 _ = try await validAccessToken(forceRefresh: true)
                 return try await fetchJSON(url, calendarID: calendarID, retrying: true)
-            case .clearAuthAndThrowAuthRequired:
-                clearAuthState()
+            case .throwAuthRequired:
+                // Deliberately keeps the stored session. A 401 from the
+                // Calendar API only proves this access token was refused, and
+                // a proxy or captive portal can produce one against a healthy
+                // grant. The session is discarded only when the token endpoint
+                // rejects the refresh token, via the errorDelegate below.
                 throw AuthError.notSignedIn
             case let .throwError(error):
                 throw error

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
@@ -71,6 +71,10 @@ final class GCEventStore: NSObject,
     /// under its replacement — losing the handle `cancelPendingOperations` needs
     /// and letting the next caller start a third refresh instead of joining.
     private var refreshTaskGeneration = 0
+    /// Upper bound on one AppAuth token refresh. Comfortably longer than the
+    /// 60s request timeout of the session AppAuth uses, so this only fires when
+    /// the callback genuinely never arrives.
+    private static let tokenRefreshTimeout: TimeInterval = 90
 
     // Shared URLSession to leverage connection reuse
     private static let session: URLSession = {
@@ -356,9 +360,35 @@ final class GCEventStore: NSObject,
         let task = Task<String, Error> {
             defer { if refreshTaskGeneration == generation { refreshTask = nil } }
             return try await withCheckedThrowingContinuation { cont in
+                // `performAction` owns its URLSession task internally and offers
+                // no way to cancel it, and this is an unstructured Task, so
+                // cancelling whoever awaits it does not reach in here. A
+                // continuation that AppAuth never resumes would therefore
+                // outlive every timeout the refresh cycle can apply and strand
+                // the serialized pipeline — the exact failure this change set
+                // exists to remove. Settle the wait on our own deadline instead
+                // and let a late callback find the resume already claimed.
+                let resumeGuard = SingleResumeGuard()
+                let deadline = Task {
+                    try? await Task.sleep(
+                        nanoseconds: UInt64(Self.tokenRefreshTimeout * Double(NSEC_PER_SEC))
+                    )
+                    guard !Task.isCancelled, resumeGuard.claim() else { return }
+                    MeetingBarLogger.calendar.error(
+                        "Google token refresh did not return within \(Int(Self.tokenRefreshTimeout))s"
+                    )
+                    cont.resume(
+                        throwing: AuthError.temporarilyUnavailable(
+                            underlying: URLError(.timedOut)
+                        )
+                    )
+                }
+
                 if forceRefresh { state.setNeedsTokenRefresh() }
 
                 state.performAction { accessToken, _, error in
+                    guard resumeGuard.claim() else { return }
+                    deadline.cancel()
                     // `error` must be inspected before `accessToken`. When the
                     // token endpoint is unreachable, AppAuth reports the failure
                     // as a transient error but still passes back the *previous*,

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
@@ -65,6 +65,12 @@ final class GCEventStore: NSObject,
     }
 
     private var refreshTask: Task<String, Error>?
+    /// Identifies which task currently owns `refreshTask`. A forced refresh
+    /// replaces the slot while an ordinary refresh may still be running, and
+    /// without this the finishing ordinary task would clear the slot out from
+    /// under its replacement — losing the handle `cancelPendingOperations` needs
+    /// and letting the next caller start a third refresh instead of joining.
+    private var refreshTaskGeneration = 0
 
     // Shared URLSession to leverage connection reuse
     private static let session: URLSession = {
@@ -103,6 +109,23 @@ final class GCEventStore: NSObject,
             return
         }
 
+        try await performAuthorization(forcePrompt: forcePrompt)
+
+        // Google only issues a refresh token when the user actually walks
+        // through the consent screen. An account that still holds a grant from
+        // a previous install authorizes silently and returns none, which leaves
+        // `hasReusableSession` false forever: no unattended refresh can run, and
+        // because the provider switch fails before the active provider is set,
+        // Preferences hides the Reconnect button that would otherwise recover.
+        // Re-run the flow once demanding consent so the refresh token comes back.
+        guard !forcePrompt, authState?.refreshToken == nil else { return }
+        MeetingBarLogger.calendar.warning(
+            "Google authorization returned no refresh token; retrying with forced consent"
+        )
+        try await performAuthorization(forcePrompt: true)
+    }
+
+    private func performAuthorization(forcePrompt: Bool) async throws {
         // discover configuration for Google issuer
         let config = try await withCheckedThrowingContinuation { cont in
             OIDAuthorizationService.discoverConfiguration(forIssuer: URL(string: Self.kIssuer)!) { cfg, err in
@@ -328,8 +351,10 @@ final class GCEventStore: NSObject,
         // ordinary refresh — that task can only hand back the same bad token.
         if !forceRefresh, let running = refreshTask { return try await running.value }
 
+        refreshTaskGeneration += 1
+        let generation = refreshTaskGeneration
         let task = Task<String, Error> {
-            defer { refreshTask = nil }
+            defer { if refreshTaskGeneration == generation { refreshTask = nil } }
             return try await withCheckedThrowingContinuation { cont in
                 if forceRefresh { state.setNeedsTokenRefresh() }
 

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
@@ -64,13 +64,23 @@ final class GCEventStore: NSObject,
         }
     }
 
-    private var refreshTask: Task<String, Error>?
-    /// Identifies which task currently owns `refreshTask`. A forced refresh
-    /// replaces the slot while an ordinary refresh may still be running, and
-    /// without this the finishing ordinary task would clear the slot out from
-    /// under its replacement — losing the handle `cancelPendingOperations` needs
-    /// and letting the next caller start a third refresh instead of joining.
-    private var refreshTaskGeneration = 0
+    /// The refresh currently occupying the slot, and what it is refreshing.
+    ///
+    /// Two things have to be distinguished, and neither implies the other.
+    /// `state` identity says *which account*: re-authorization installs a new
+    /// `OIDAuthState`, and a refresh started for the previous one can only ever
+    /// return the previous account's token. `generation` says *which attempt*:
+    /// a forced refresh takes the slot from an ordinary refresh of the same
+    /// state, and the superseded task must not then clear or discard on behalf
+    /// of its replacement.
+    private struct PendingRefresh {
+        let task: Task<String, Error>
+        let state: OIDAuthState
+        let generation: Int
+    }
+
+    private var pendingRefresh: PendingRefresh?
+    private var refreshGeneration = 0
     /// Upper bound on one AppAuth token refresh.
     ///
     /// AppAuth issues token requests on `OIDURLSessionProvider.session`, which
@@ -214,8 +224,8 @@ final class GCEventStore: NSObject,
     }
 
     func cancelPendingOperations() {
-        refreshTask?.cancel()
-        refreshTask = nil
+        pendingRefresh?.task.cancel()
+        pendingRefresh = nil
 
         let flow = currentAuthorizationFlow
         currentAuthorizationFlow = nil
@@ -354,15 +364,19 @@ final class GCEventStore: NSObject,
             return token
         }
 
-        // A forced refresh is only ever requested because the token we just
-        // used was rejected, so it must not be answered by an in-flight
-        // ordinary refresh — that task can only hand back the same bad token.
-        if !forceRefresh, let running = refreshTask { return try await running.value }
+        // Join an in-flight refresh only when it is refreshing this very state.
+        // A forced refresh never joins: it exists because the token the pending
+        // refresh will return was already rejected. A refresh belonging to a
+        // superseded `OIDAuthState` never joins either, or re-authorizing to a
+        // different account would hand that account's caller the old one's token.
+        if !forceRefresh, let pending = pendingRefresh, pending.state === state {
+            return try await pending.task.value
+        }
 
-        refreshTaskGeneration += 1
-        let generation = refreshTaskGeneration
+        refreshGeneration += 1
+        let generation = refreshGeneration
         let task = Task<String, Error> {
-            defer { if refreshTaskGeneration == generation { refreshTask = nil } }
+            defer { if pendingRefresh?.generation == generation { pendingRefresh = nil } }
             return try await withCheckedThrowingContinuation { cont in
                 // `performAction` owns its URLSession task internally and offers
                 // no way to cancel it, and this is an unstructured Task, so
@@ -388,7 +402,7 @@ final class GCEventStore: NSObject,
                     // that object later succeeds, `didChange` persists whatever
                     // `authState` now holds, so the fresh token is dropped from
                     // memory and the keychain both.
-                    if self.refreshTaskGeneration == generation {
+                    if self.pendingRefresh?.generation == generation, state === self.authState {
                         self.discardStuckAuthState()
                     }
                     cont.resume(
@@ -435,17 +449,18 @@ final class GCEventStore: NSObject,
             }
         }
 
-        refreshTask = task
+        pendingRefresh = PendingRefresh(task: task, state: state, generation: generation)
         return try await task.value
     }
 
     // MARK: Keychain persistence
 
     private func persistAuthState() {
-        guard let state = authState else {
-            Keychain.delete(for: Self.kKeychainName)
-            return
-        }
+        // Only save here. Deleting the persisted session is an explicit act
+        // (`clearAuthState`), never a side effect of dropping the in-memory
+        // state — `discardStuckAuthState` relies on being able to do the latter
+        // without the former.
+        guard let state = authState else { return }
         do {
             let data = try NSKeyedArchiver.archivedData(withRootObject: state, requiringSecureCoding: true)
             Keychain.save(data: data, for: Self.kKeychainName)
@@ -482,11 +497,15 @@ final class GCEventStore: NSObject,
     /// once to failing slowly forever. Rebuilding from the persisted session
     /// leaves the stuck queue behind while keeping the user signed in.
     private func discardStuckAuthState() {
-        guard let restored = restoreAuthState() else { return }
-        // Detach the object we are walking away from. It still holds a pending
-        // AppAuth request, and `didChange` persists `authState` rather than the
-        // instance that changed, so a late callback on an abandoned state would
-        // otherwise write over the session we just restored.
+        // Retiring the stuck object must not depend on the restore succeeding.
+        // Keeping it installed because the keychain read failed would park every
+        // later refresh behind the same dead request — the failure this exists to
+        // end. With no state installed, `requireReusableSession` reports
+        // "reconnect required" and the next sign-in builds a clean one. The
+        // persisted session is deliberately left alone: only an explicit sign-out
+        // deletes it, so a transient restore failure cannot cost the user
+        // their grant.
+        let restored = restoreAuthState()
         authState?.stateChangeDelegate = nil
         authState?.errorDelegate = nil
         authState = restored
@@ -552,11 +571,19 @@ final class GCEventStore: NSObject,
 
     // MARK: - OIDAuthState Delegates
     func didChange(_ state: OIDAuthState) {
+        // An abandoned state can still complete its pending request. Persisting
+        // then would write out whatever `authState` currently holds, discarding
+        // the very token that just arrived, so only the installed state counts.
+        guard state === authState else { return }
         // persist every change (e.g., refreshed token)
         persistAuthState()
     }
 
     func authState(_ state: OIDAuthState, didEncounterAuthorizationError error: Error) {
+        // A failure reported by a state we have already replaced says nothing
+        // about the session in use, and signing the user out over it would end
+        // an account because a different one failed.
+        guard state === authState else { return }
         let nsErr = error as NSError
         if nsErr.domain == OIDOAuthTokenErrorDomain {
             // refresh token invalid → clean state & notify

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarEventStore.swift
@@ -71,9 +71,13 @@ final class GCEventStore: NSObject,
     /// under its replacement — losing the handle `cancelPendingOperations` needs
     /// and letting the next caller start a third refresh instead of joining.
     private var refreshTaskGeneration = 0
-    /// Upper bound on one AppAuth token refresh. Comfortably longer than the
-    /// 60s request timeout of the session AppAuth uses, so this only fires when
-    /// the callback genuinely never arrives.
+    /// Upper bound on one AppAuth token refresh.
+    ///
+    /// AppAuth issues token requests on `OIDURLSessionProvider.session`, which
+    /// defaults to `URLSession.shared` — *not* the hardened session below, so
+    /// none of its configuration applies to the refresh path. `URLSession`'s
+    /// own 60s default request timeout still bounds that call, so this deadline
+    /// sits beyond it and fires only when the callback never arrives at all.
     private static let tokenRefreshTimeout: TimeInterval = 90
 
     // Shared URLSession to leverage connection reuse
@@ -377,6 +381,7 @@ final class GCEventStore: NSObject,
                     MeetingBarLogger.calendar.error(
                         "Google token refresh did not return within \(Int(Self.tokenRefreshTimeout))s"
                     )
+                    self.discardStuckAuthState()
                     cont.resume(
                         throwing: AuthError.temporarilyUnavailable(
                             underlying: URLError(.timedOut)
@@ -456,6 +461,20 @@ final class GCEventStore: NSObject,
             )
             return nil
         }
+    }
+
+    /// Replaces the `OIDAuthState` whose token request never came back.
+    ///
+    /// AppAuth serializes refreshes through `_pendingActions`, which only that
+    /// request's own callback clears. A request that never completes therefore
+    /// parks every later refresh behind it for the lifetime of the state
+    /// object: each one enqueues, is never called back, and waits out its own
+    /// deadline. Timing out alone would only downgrade the failure from hanging
+    /// once to failing slowly forever. Rebuilding from the persisted session
+    /// leaves the stuck queue behind while keeping the user signed in.
+    private func discardStuckAuthState() {
+        guard let restored = restoreAuthState() else { return }
+        authState = restored
     }
 
     private func clearAuthState() {

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
@@ -9,6 +9,10 @@ enum AuthError: LocalizedError {
     case cancelled
     case notSignedIn
     case refreshFailed
+    /// The token endpoint could not be reached (offline, VPN still connecting,
+    /// captive portal). The stored refresh token is still presumed valid, so
+    /// callers must retry later rather than signing the user out.
+    case temporarilyUnavailable(underlying: Error)
 
     var errorDescription: String? {
         switch self {
@@ -18,6 +22,8 @@ enum AuthError: LocalizedError {
             return "Google Calendar authorization is required"
         case .refreshFailed:
             return "Google Calendar token refresh failed"
+        case let .temporarilyUnavailable(underlying):
+            return "Google Calendar is temporarily unreachable: \(underlying.localizedDescription)"
         }
     }
 }
@@ -48,7 +54,13 @@ enum GoogleCalendarError: LocalizedError, Equatable {
 enum GoogleHTTPDecision: Equatable {
     case proceed
     case retryWithForcedTokenRefresh
-    case clearAuthAndThrowAuthRequired
+    /// Surface "reconnect required" to the user without discarding the stored
+    /// session. A 401 from the Calendar API only proves the *access* token was
+    /// rejected; it says nothing about the refresh token, and a proxy or
+    /// captive portal can produce one while the grant is perfectly valid.
+    /// Only the token endpoint rejecting the refresh token (which AppAuth
+    /// reports through `didEncounterAuthorizationError`) may clear the session.
+    case throwAuthRequired
     case throwError(GoogleCalendarError)
 }
 
@@ -63,7 +75,7 @@ enum GoogleHTTPStatusPolicy {
         case 200...299:
             return .proceed
         case 401:
-            return retrying ? .clearAuthAndThrowAuthRequired : .retryWithForcedTokenRefresh
+            return retrying ? .throwAuthRequired : .retryWithForcedTokenRefresh
         case 403:
             return retrying
                 ? .throwError(.forbiddenCalendar(calendarID: calendarID, url: url))

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
@@ -5,6 +5,27 @@
 
 import Foundation
 
+/// Arbitrates a single resume between two racing callbacks.
+///
+/// A continuation must be resumed exactly once. When a wait is settled by
+/// whichever of two independent callbacks arrives first — a library completion
+/// handler and a timeout — the loser has to know to stay silent, and neither
+/// side can assume which one that is. `claim()` returns `true` to the first
+/// caller and `false` to every caller after it.
+final class SingleResumeGuard: @unchecked Sendable {
+    private let lock = NSLock()
+    private var isClaimed = false
+
+    /// `true` for the first caller only; every later caller gets `false`.
+    func claim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if isClaimed { return false }
+        isClaimed = true
+        return true
+    }
+}
+
 enum AuthError: LocalizedError {
     case cancelled
     case notSignedIn

--- a/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
+++ b/MeetingBar/Calendar/Providers/Google/GoogleCalendarPolicy.swift
@@ -12,6 +12,11 @@ import Foundation
 /// handler and a timeout — the loser has to know to stay silent, and neither
 /// side can assume which one that is. `claim()` returns `true` to the first
 /// caller and `false` to every caller after it.
+///
+/// It lives in this file, rather than a utilities module, because only the
+/// sources listed in `Package.swift` are reachable from `MeetingBarLogicTests`,
+/// and a primitive whose whole job is to be correct under contention is worth
+/// keeping under test.
 final class SingleResumeGuard: @unchecked Sendable {
     private let lock = NSLock()
     private var isClaimed = false

--- a/MeetingBarLogicTests/GoogleCalendarPolicyTests.swift
+++ b/MeetingBarLogicTests/GoogleCalendarPolicyTests.swift
@@ -187,3 +187,32 @@ final class GoogleCalendarPolicyTests: XCTestCase {
         )
     }
 }
+
+final class SingleResumeGuardTests: XCTestCase {
+    func testFirstClaimSucceedsAndEveryLaterClaimFails() {
+        let guardBox = SingleResumeGuard()
+
+        XCTAssertTrue(guardBox.claim())
+        XCTAssertFalse(guardBox.claim())
+        XCTAssertFalse(guardBox.claim())
+    }
+
+    /// The guard exists to arbitrate a token-refresh completion racing its
+    /// timeout, and those two callbacks are not guaranteed to share a queue.
+    /// Exactly one contender may ever resume the continuation.
+    func testExactlyOneClaimWinsUnderConcurrentContention() {
+        let contenders = 500
+        let guardBox = SingleResumeGuard()
+        let winners = NSCountedSet()
+        let winnersLock = NSLock()
+
+        DispatchQueue.concurrentPerform(iterations: contenders) { _ in
+            guard guardBox.claim() else { return }
+            winnersLock.lock()
+            winners.add("won")
+            winnersLock.unlock()
+        }
+
+        XCTAssertEqual(winners.count(for: "won"), 1)
+    }
+}

--- a/MeetingBarLogicTests/GoogleCalendarPolicyTests.swift
+++ b/MeetingBarLogicTests/GoogleCalendarPolicyTests.swift
@@ -58,7 +58,11 @@ final class GoogleCalendarPolicyTests: XCTestCase {
         )
     }
 
-    func testHTTP401AfterRetryClearsAuthAndThrowsAuthRequired() {
+    /// A 401 from the Calendar API proves only that this access token was
+    /// refused. Discarding the stored session here turned a proxy or captive
+    /// portal into a forced re-consent, so the decision must stay "ask the user
+    /// to reconnect" and leave the refresh token alone.
+    func testHTTP401AfterRetryAsksForAuthWithoutClearingSession() {
         let decision = GoogleHTTPStatusPolicy.classify(
             statusCode: 401,
             url: calendarListURL,
@@ -66,7 +70,7 @@ final class GoogleCalendarPolicyTests: XCTestCase {
             retrying: true
         )
 
-        XCTAssertEqual(decision, .clearAuthAndThrowAuthRequired)
+        XCTAssertEqual(decision, .throwAuthRequired)
     }
 
     func testHTTP403AfterRetryWithCalendarIDIsForbiddenCalendar() {
@@ -149,6 +153,15 @@ final class GoogleCalendarPolicyTests: XCTestCase {
     func testAuthErrorDescriptionsExplainRequiredAction() {
         XCTAssertEqual(AuthError.notSignedIn.errorDescription, "Google Calendar authorization is required")
         XCTAssertEqual(AuthError.refreshFailed.errorDescription, "Google Calendar token refresh failed")
+    }
+
+    func testTemporarilyUnavailableDescriptionNamesTheUnderlyingFailure() {
+        let underlying = URLError(.notConnectedToInternet)
+
+        XCTAssertEqual(
+            AuthError.temporarilyUnavailable(underlying: underlying).errorDescription,
+            "Google Calendar is temporarily unreachable: \(underlying.localizedDescription)"
+        )
     }
 
     func testGoogleCalendarErrorDescriptionsIncludeUsefulContext() {

--- a/MeetingBarTests/GoogleCalendarParserTests.swift
+++ b/MeetingBarTests/GoogleCalendarParserTests.swift
@@ -196,7 +196,7 @@ final class GoogleCalendarParserTests: XCTestCase {
         )
     }
 
-    func testHTTP401AfterRetryRequiresAuthClear() {
+    func testHTTP401AfterRetryRequiresAuthWithoutClearingSession() {
         let url = URL(string: "https://www.googleapis.com/calendar/v3/users/me/calendarList")!
 
         let decision = GoogleHTTPStatusPolicy.classify(
@@ -206,7 +206,7 @@ final class GoogleCalendarParserTests: XCTestCase {
             retrying: true
         )
 
-        XCTAssertEqual(decision, .clearAuthAndThrowAuthRequired)
+        XCTAssertEqual(decision, .throwAuthRequired)
     }
 
     func testHTTP403AfterRetryIsForbiddenCalendarWithoutAuthClear() {


### PR DESCRIPTION
Fixes #869 (and the same root causes behind #832 / #836).

MeetingBar silently stops refreshing Google Calendar events — typically overnight or after a commute — and only recovers when the user presses Refresh, switches providers, or signs in again.

There is no single trigger. **Every failure mode on the Google path is unbounded: it either hangs forever or destroys the stored session.** Nothing times out, nothing retries with backoff, and nothing reacts to the network coming back. That's why the symptoms differ so much between reporters ("re-authenticate every day", "logged out after a commute", "Zscaler not up yet", "stale events until Refresh Sources").

## Root causes

### 1. A transient token-refresh failure destroys the saved session

`GCEventStore.validAccessToken` checked the token before the error. But AppAuth, on a **transient** (network) refresh failure, invokes the action with the *previous, already-expired* access token alongside the error — [`OIDAuthState.m`](https://github.com/openid/AppAuth-iOS/blob/master/Sources/AppAuthCore/OIDAuthState.m):

```objc
} else {
  if (error.domain == OIDOAuthTokenErrorDomain) { ... }   // grant rejected
  else { ...didEncounterTransientError... }               // network failure
}
...
actionToProcess.action(self.accessToken, self.idToken, error);
```

`-accessToken` only returns `nil` once `_authorizationError` is set, which a network error does not do. So the expired token came back and the error was dropped:

1. Expired token → Google returns **401**
2. `classify` → `.retryWithForcedTokenRefresh`
3. `validAccessToken(forceRefresh: true)` → still offline → **same expired token again**
4. Retry → **401** → `.clearAuthAndThrowAuthRequired`
5. `clearAuthState()` → `Keychain.delete` → **refresh token gone, full re-consent**

A laptop waking before Wi-Fi or a VPN is up was enough to wipe the OAuth grant.

### 2. Requests never failed — they hung for up to 7 days

`waitsForConnectivity = true` suppresses `timeoutIntervalForRequest`; only `timeoutIntervalForResource` applies, defaulting to **604800 s**. A fetch started while offline didn't error, it parked.

### 3. A background refresh could open an OAuth browser tab and await it forever

`ensureSignedIn()` → `signIn()` opened a browser and awaited a callback that only arrives if the user finishes. If they didn't, the fetch never completed — and `signInTask` was never cleared, so every later refresh awaited that dead task.

### 4. `flatMap(maxPublishers: .max(1))` turned one hung fetch into a total deadlock

Serializing fetches is only safe if the inner publisher always completes. Harness output for the exact pipeline shape:

```
=== healthy ===                       === first fetch hangs ===
[0.51s] fetch #1 STARTED              [0.50s] fetch #1 STARTED
[0.56s] fetch #1 DELIVERED            [2.00s] >>> user presses Refresh
...                                   RESULT: started=1 delivered=0
RESULT: started=9 delivered=8
```

A single never-completing fetch killed the 180 s timer, settings-change triggers **and the Refresh button** for the life of the process. `changeEventStoreProvider` is the only thing that cancels `refreshCycleTask` — which is exactly why "switch to Apple Calendar and back" is the workaround people keep finding.

### 5. No network-recovery trigger

Wake fires *before* Wi-Fi reassociates or a VPN connects — the worst possible moment given 1 and 2.

## Changes

- `validAccessToken` inspects `error` **before** `accessToken`; new retryable `AuthError.temporarilyUnavailable`. A forced refresh no longer reuses an in-flight ordinary refresh (which could only return the same rejected token).
- An API 401 surfaces `.throwAuthRequired` (visible Reconnect) instead of deleting the keychain entry. Session clearing stays with the token endpoint rejecting the refresh token, which AppAuth already reports via `didEncounterAuthorizationError`.
- `waitsForConnectivity = false` plus explicit 30 s / 90 s timeouts, so failures are bounded and the next cycle self-heals.
- Fetches use a non-interactive session gate; interactive authorization stays on the explicit sign-in entry point used by provider selection and Reconnect. `signIn` retries once with forced consent when the completed flow yielded no refresh token, preserving the recovery path `ensureSignedIn` used to provide.
- A timeout around the refresh cycle so the `Future` always completes and `.max(1)` cannot deadlock.
- An `NWPathMonitor` trigger on the unreachable → reachable transition, with a 60 s floor so a flapping VPN can't cause repeated full fetches.

## Testing

Unit tests updated for the renamed HTTP decision case in both suites, plus coverage for the transient-error description.

**Please note:** I developed this on a machine without Xcode (Command Line Tools only), so I could not run `make test` or build the app target locally. I type-checked the isolated logic file and the new concurrency shapes under `-swift-version 6 -strict-concurrency=complete`, and verified the deadlock fix with the harness above. **CI is the first real build of this branch** — happy to fix anything it turns up promptly.

One caveat on scope: none of this can eliminate a genuine Google-side revocation (user revokes access, or an OAuth client in "Testing" publishing status expiring refresh tokens after 7 days). That legitimately needs re-consent — but it now surfaces as an actionable Reconnect state rather than silence plus stale data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BruYnzM3jxEovNQYCdnhmd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Calendar data now refreshes automatically when the network becomes available again.
  - Google Calendar sign-in better handles temporary service interruptions while preserving valid sessions after authorization errors.

- **Bug Fixes**
  - Calendar refreshes now time out after two minutes instead of waiting indefinitely.
  - Google token refreshes now time out after 90 seconds, preventing stalled synchronization.
  - Reduced unnecessary interactive sign-in prompts during calendar and event fetching.
  - Improved handling of temporary authorization service interruptions without unnecessarily clearing stored sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->