### PR TITLE
fix: render stacked status title with native tinting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 For next releases info look here: <https://github.com/leits/MeetingBar/releases>
 
+## Unreleased
+
+* Fixed the status-bar title and time alignment when time is displayed below
+  the title, including inactive menu bars on secondary displays.
+
 ## 5.0.0 (2026-06-19)
 
 MeetingBar 5 is an architecture and product refresh. It improves the

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -48,6 +48,7 @@ struct StatusBarDependencies {
 final class StatusBarItemController {
     var statusItem: NSStatusItem!
     var statusItemMenu: NSMenu!
+    private var stackedTitleItem: NSStatusItem?
 
     /// Current event list, driven by the AppModel state.
     /// A non-nil `_eventsOverride` takes precedence (used by tests to inject
@@ -237,12 +238,44 @@ final class StatusBarItemController {
         }
         button.imagePosition = button.image?.name() == "no_online_session" ? .noImage : .imageLeft
 
-        if presentation.mode == .nextEvent {
+        if presentation.mode == .nextEvent, presentation.layout == .stacked {
+            renderStackedTitle(presentation)
+            button.toolTip = presentation.tooltip
+        } else {
+            removeStackedTitle()
+        }
+
+        if presentation.mode == .nextEvent, presentation.layout != .stacked {
             button.attributedTitle = StatusBarTitleRenderer.attributedTitle(for: presentation)
             button.toolTip = presentation.tooltip
         }
 
-        ensureStatusBarButtonIsVisible(button)
+        if presentation.layout != .stacked {
+            ensureStatusBarButtonIsVisible(button)
+        }
+    }
+
+    private func renderStackedTitle(_ presentation: StatusBarPresentation) {
+        let titleItem = stackedTitleItem ?? NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        stackedTitleItem = titleItem
+
+        guard let button = titleItem.button else { return }
+        button.target = self
+        button.action = #selector(statusMenuBarAction)
+        button.sendAction(on: [
+            NSEvent.EventTypeMask.rightMouseDown, NSEvent.EventTypeMask.leftMouseUp,
+            NSEvent.EventTypeMask.leftMouseDown
+        ])
+        button.image = StatusBarTitleRenderer.stackedTitleImage(for: presentation)
+        button.imagePosition = .imageOnly
+        button.toolTip = presentation.tooltip
+        button.setAccessibilityLabel("\(presentation.title) \(presentation.time)")
+    }
+
+    private func removeStackedTitle() {
+        guard let stackedTitleItem else { return }
+        NSStatusBar.system.removeStatusItem(stackedTitleItem)
+        self.stackedTitleItem = nil
     }
 
     private func ensureStatusBarButtonIsVisible(_ button: NSStatusBarButton) {
@@ -521,49 +554,66 @@ enum StatusBarTitleRenderer {
                 )
             )
         case .stacked:
-            return stackedTitle(for: presentation)
+            return NSAttributedString(string: "")
         }
     }
 
-    private static func stackedTitle(for presentation: StatusBarPresentation) -> NSAttributedString {
-        let title = NSMutableAttributedString(
+    static func stackedTitleImage(for presentation: StatusBarPresentation) -> NSImage {
+        let title = NSAttributedString(
             string: presentation.title,
-            attributes: titleAttributes(
+            attributes: templateAttributes(
                 style: presentation.titleStyle,
-                font: NSFont.systemFont(ofSize: 12),
-                baselineOffset: -3
+                font: NSFont.systemFont(ofSize: 12)
             )
         )
-        title.append(
-            NSAttributedString(
-                string: "\n" + presentation.time,
-                attributes: [
-                    NSAttributedString.Key.font: NSFont.systemFont(ofSize: 9),
-                    NSAttributedString.Key.foregroundColor: NSColor.lightGray
-                ]
-            ))
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.lineHeightMultiple = 0.7
-        paragraphStyle.alignment = .center
-        title.addAttributes(
-            [NSAttributedString.Key.paragraphStyle: paragraphStyle],
-            range: NSRange(location: 0, length: title.length)
+        let time = NSAttributedString(
+            string: presentation.time,
+            attributes: [
+                .font: NSFont.systemFont(ofSize: 9),
+                .foregroundColor: NSColor.black.withAlphaComponent(0.65)
+            ]
         )
-        return title
+        let titleLine = CTLineCreateWithAttributedString(title)
+        let timeLine = CTLineCreateWithAttributedString(time)
+        let titleBounds = CTLineGetBoundsWithOptions(titleLine, .useGlyphPathBounds)
+        let timeBounds = CTLineGetBoundsWithOptions(timeLine, .useGlyphPathBounds)
+        let titleWidth = CTLineGetTypographicBounds(titleLine, nil, nil, nil)
+        let timeWidth = CTLineGetTypographicBounds(timeLine, nil, nil, nil)
+        let titleBaseline = timeBounds.maxY - titleBounds.minY
+        let contentBounds = timeBounds.union(titleBounds.offsetBy(dx: 0, dy: titleBaseline))
+        let image = NSImage(size: NSSize(
+            width: ceil(max(titleWidth, timeWidth)),
+            height: ceil(contentBounds.height)
+        ))
+        image.lockFocus()
+        guard let context = NSGraphicsContext.current?.cgContext else {
+            image.unlockFocus()
+            return image
+        }
+
+        context.textPosition = CGPoint(
+            x: (image.size.width - titleWidth) / 2,
+            y: titleBaseline - contentBounds.minY
+        )
+        CTLineDraw(titleLine, context)
+        context.textPosition = CGPoint(
+            x: (image.size.width - timeWidth) / 2,
+            y: -contentBounds.minY
+        )
+        CTLineDraw(timeLine, context)
+        image.unlockFocus()
+        // AppKit applies the appropriate contrast and inactive-display dimming to template images.
+        image.isTemplate = true
+        return image
     }
 
     private static func titleAttributes(
         style: StatusBarTitleStyle,
-        font: NSFont,
-        baselineOffset: CGFloat? = nil
+        font: NSFont
     ) -> [NSAttributedString.Key: Any] {
         var attributes: [NSAttributedString.Key: Any] = [
             .font: font
         ]
-        if let baselineOffset {
-            attributes[.baselineOffset] = baselineOffset
-        }
         switch style {
         case .normal:
             break
@@ -575,6 +625,17 @@ enum StatusBarTitleRenderer {
                 | NSUnderlineStyle.patternDot.rawValue
                 | NSUnderlineStyle.byWord.rawValue
         }
+        return attributes
+    }
+
+    private static func templateAttributes(
+        style: StatusBarTitleStyle,
+        font: NSFont
+    ) -> [NSAttributedString.Key: Any] {
+        var attributes = titleAttributes(style: style, font: font)
+        attributes[.foregroundColor] = NSColor.black.withAlphaComponent(
+            style == .inactive ? 0.55 : 1
+        )
         return attributes
     }
 }

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -574,7 +574,9 @@ enum StatusBarTitleRenderer {
             string: presentation.time,
             attributes: [
                 .font: NSFont.systemFont(ofSize: 9),
-                .foregroundColor: NSColor.black.withAlphaComponent(0.65)
+                .foregroundColor: NSColor.black.withAlphaComponent(
+                    templateOpacity(for: presentation.titleStyle, defaultOpacity: 0.65)
+                )
             ]
         )
         let titleLine = CTLineCreateWithAttributedString(title)
@@ -622,6 +624,13 @@ enum StatusBarTitleRenderer {
         timeAscent + titleDescent + 1
     }
 
+    static func templateOpacity(
+        for style: StatusBarTitleStyle,
+        defaultOpacity: CGFloat
+    ) -> CGFloat {
+        style == .inactive ? 0.55 : defaultOpacity
+    }
+
     private static func titleAttributes(
         style: StatusBarTitleStyle,
         font: NSFont
@@ -649,7 +658,7 @@ enum StatusBarTitleRenderer {
     ) -> [NSAttributedString.Key: Any] {
         var attributes = titleAttributes(style: style, font: font)
         attributes[.foregroundColor] = NSColor.black.withAlphaComponent(
-            style == .inactive ? 0.55 : 1
+            templateOpacity(for: style, defaultOpacity: 1)
         )
         return attributes
     }

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -48,7 +48,7 @@ struct StatusBarDependencies {
 final class StatusBarItemController {
     var statusItem: NSStatusItem!
     var statusItemMenu: NSMenu!
-    private var stackedTitleItem: NSStatusItem?
+    private(set) var stackedTitleItem: NSStatusItem?
 
     /// Current event list, driven by the AppModel state.
     /// A non-nil `_eventsOverride` takes precedence (used by tests to inject
@@ -220,6 +220,7 @@ final class StatusBarItemController {
     func renderStatusBar(_ presentation: StatusBarPresentation) {
         guard let button = statusItem.button else { return }
 
+        statusItem.length = NSStatusItem.variableLength
         button.image = nil
         button.title = ""
         button.attributedTitle = NSAttributedString(string: "")
@@ -239,6 +240,9 @@ final class StatusBarItemController {
         button.imagePosition = button.image?.name() == "no_online_session" ? .noImage : .imageLeft
 
         if presentation.mode == .nextEvent, presentation.layout == .stacked {
+            if button.image == nil || button.imagePosition == .noImage {
+                statusItem.length = 0
+            }
             renderStackedTitle(presentation)
             button.toolTip = presentation.tooltip
         } else {

--- a/MeetingBar/UI/StatusBar/StatusBarItemController.swift
+++ b/MeetingBar/UI/StatusBar/StatusBarItemController.swift
@@ -583,7 +583,14 @@ enum StatusBarTitleRenderer {
         let timeBounds = CTLineGetBoundsWithOptions(timeLine, .useGlyphPathBounds)
         let titleWidth = CTLineGetTypographicBounds(titleLine, nil, nil, nil)
         let timeWidth = CTLineGetTypographicBounds(timeLine, nil, nil, nil)
-        let titleBaseline = timeBounds.maxY - titleBounds.minY
+        var timeAscent: CGFloat = 0
+        var titleDescent: CGFloat = 0
+        CTLineGetTypographicBounds(timeLine, &timeAscent, nil, nil)
+        CTLineGetTypographicBounds(titleLine, nil, &titleDescent, nil)
+        let titleBaseline = stackedTitleBaseline(
+            timeAscent: timeAscent,
+            titleDescent: titleDescent
+        )
         let contentBounds = timeBounds.union(titleBounds.offsetBy(dx: 0, dy: titleBaseline))
         let image = NSImage(size: NSSize(
             width: ceil(max(titleWidth, timeWidth)),
@@ -609,6 +616,10 @@ enum StatusBarTitleRenderer {
         // AppKit applies the appropriate contrast and inactive-display dimming to template images.
         image.isTemplate = true
         return image
+    }
+
+    static func stackedTitleBaseline(timeAscent: CGFloat, titleDescent: CGFloat) -> CGFloat {
+        timeAscent + titleDescent + 1
     }
 
     private static func titleAttributes(

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -1339,6 +1339,20 @@ final class StatusBarTitleRendererTests: BaseTestCase {
         XCTAssertGreaterThan(image.size.height, 0)
     }
 
+    func test_stackedTitleMaintainsFixedGapAcrossFontMetrics() {
+        let shallowTitleBaseline = StatusBarTitleRenderer.stackedTitleBaseline(
+            timeAscent: 7,
+            titleDescent: 1
+        )
+        let deepTitleBaseline = StatusBarTitleRenderer.stackedTitleBaseline(
+            timeAscent: 7,
+            titleDescent: 4
+        )
+
+        XCTAssertEqual(shallowTitleBaseline - 1 - 7, 1, accuracy: 0.001)
+        XCTAssertEqual(deepTitleBaseline - 4 - 7, 1, accuracy: 0.001)
+    }
+
     func test_inlineTitleIncludesTimeAndUnderlineStyle() {
         let title = StatusBarTitleRenderer.attributedTitle(
             for: makePresentation(

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -1496,26 +1496,56 @@ final class StatusBarItemControllerPresentationTests: BaseTestCase {
         XCTAssertNotNil(button.image)
     }
 
-    func test_updateTitleUsesCenteredStackedTimeUnderTitle() throws {
+    func test_updateTitleUsesNativeTemplateImageForStackedTimeUnderTitle() throws {
         configureStatusBarDefaults()
         Defaults[.eventTimeFormat] = .show_under_title
 
         let controller = StatusBarItemController()
-        defer { NSStatusBar.system.removeStatusItem(controller.statusItem) }
+        defer {
+            controller.renderStatusBar(makePresentation(layout: .inline(showTime: false)))
+            NSStatusBar.system.removeStatusItem(controller.statusItem)
+        }
         controller.events = [makeStatusEvent()]
         controller.updateTitle()
 
-        let button = try XCTUnwrap(controller.statusItem.button)
-        XCTAssertTrue(button.attributedTitle.string.contains("\n"))
+        let titleItem = try XCTUnwrap(controller.stackedTitleItem)
+        let titleButton = try XCTUnwrap(titleItem.button)
+        XCTAssertTrue(titleButton.image?.isTemplate ?? false)
+        XCTAssertEqual(titleButton.imagePosition, .imageOnly)
+        let tooltip = try XCTUnwrap(titleButton.toolTip)
+        XCTAssertTrue(titleButton.accessibilityLabel()?.contains(tooltip) ?? false)
+        XCTAssertTrue(try XCTUnwrap(controller.statusItem.button).attributedTitle.string.isEmpty)
+    }
 
-        let paragraphStyle =
-            button.attributedTitle.attribute(
-                .paragraphStyle,
-                at: 0,
-                effectiveRange: nil
-            ) as? NSParagraphStyle
-        XCTAssertEqual(paragraphStyle?.alignment, .center)
-        XCTAssertEqual(paragraphStyle?.lineHeightMultiple ?? 0, 0.7, accuracy: 0.001)
+    func test_renderStatusBarRemovesStackedTitleWhenUsingInlineLayout() {
+        let controller = StatusBarItemController()
+        defer { NSStatusBar.system.removeStatusItem(controller.statusItem) }
+
+        controller.renderStatusBar(makePresentation(
+            title: "Weekly sync",
+            time: "now",
+            layout: .stacked
+        ))
+        XCTAssertNotNil(controller.stackedTitleItem)
+
+        controller.renderStatusBar(makePresentation(layout: .inline(showTime: false)))
+        XCTAssertNil(controller.stackedTitleItem)
+    }
+
+    func test_renderStatusBarDoesNotLeaveSpaceForMissingStackedIcon() {
+        let controller = StatusBarItemController()
+        defer {
+            controller.renderStatusBar(makePresentation(layout: .inline(showTime: false)))
+            NSStatusBar.system.removeStatusItem(controller.statusItem)
+        }
+
+        controller.renderStatusBar(makePresentation(
+            title: "Weekly sync",
+            time: "now",
+            layout: .stacked
+        ))
+
+        XCTAssertEqual(controller.statusItem.length, 0)
     }
 
     func test_actionsUseInjectedAppActionSender() {
@@ -1625,13 +1655,14 @@ final class StatusBarItemControllerPresentationTests: BaseTestCase {
     private func makePresentation(
         mode: StatusBarTitleMode = .nextEvent,
         title: String = "",
+        time: String = "",
         icon: StatusBarIcon = .none,
         layout: StatusBarTitleLayout = .none
     ) -> StatusBarPresentation {
         StatusBarPresentation(
             mode: mode,
             title: title,
-            time: "",
+            time: time,
             tooltip: nil,
             icon: icon,
             layout: layout,

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -1329,31 +1329,14 @@ final class MenuBuilderQuickActionsTests: BaseTestCase {
 @MainActor
 final class StatusBarTitleRendererTests: BaseTestCase {
 
-    func test_stackedTitleCentersBothLinesAndUsesCompactFonts() {
-        let title = StatusBarTitleRenderer.attributedTitle(
+    func test_stackedTitleUsesCenteredTemplateImage() {
+        let image = StatusBarTitleRenderer.stackedTitleImage(
             for: makePresentation(layout: .stacked)
         )
 
-        XCTAssertEqual(title.string, "Weekly sync\nnow")
-
-        let paragraphStyle =
-            title.attribute(
-                .paragraphStyle,
-                at: 0,
-                effectiveRange: nil
-            ) as? NSParagraphStyle
-        XCTAssertEqual(paragraphStyle?.alignment, .center)
-        XCTAssertEqual(paragraphStyle?.lineHeightMultiple ?? 0, 0.7, accuracy: 0.001)
-
-        let titleFont = title.attribute(.font, at: 0, effectiveRange: nil) as? NSFont
-        let timeFont =
-            title.attribute(
-                .font,
-                at: title.length - 1,
-                effectiveRange: nil
-            ) as? NSFont
-        XCTAssertEqual(titleFont?.pointSize ?? 0, 12, accuracy: 0.001)
-        XCTAssertEqual(timeFont?.pointSize ?? 0, 9, accuracy: 0.001)
+        XCTAssertTrue(image.isTemplate)
+        XCTAssertGreaterThan(image.size.width, 0)
+        XCTAssertGreaterThan(image.size.height, 0)
     }
 
     func test_inlineTitleIncludesTimeAndUnderlineStyle() {

--- a/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
+++ b/MeetingBarTests/StatusBarItem/MenuBuilderTests.swift
@@ -1353,6 +1353,19 @@ final class StatusBarTitleRendererTests: BaseTestCase {
         XCTAssertEqual(deepTitleBaseline - 4 - 7, 1, accuracy: 0.001)
     }
 
+    func test_stackedTitleSubduesBothLinesForInactiveStyle() {
+        XCTAssertEqual(
+            StatusBarTitleRenderer.templateOpacity(for: .inactive, defaultOpacity: 1),
+            0.55,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            StatusBarTitleRenderer.templateOpacity(for: .inactive, defaultOpacity: 0.65),
+            0.55,
+            accuracy: 0.001
+        )
+    }
+
     func test_inlineTitleIncludesTimeAndUnderlineStyle() {
         let title = StatusBarTitleRenderer.attributedTitle(
             for: makePresentation(


### PR DESCRIPTION
### Status
**READY**

### Motivation
The `Show under title` appearance option gave `NSStatusBarButton` a two-line attributed title. AppKit does not lay out that unsupported form consistently: the title could be vertically clipped or misaligned, and the gap to the time varied with the title’s glyph bounds. Rendering the text outside the native status-item path also loses macOS’s per-display contrast and inactive-display dimming.

### Approach
The primary status item continues to render the meeting icon. For the stacked layout, this PR renders the title and time into a compact template image in a companion native status item. This keeps the image on AppKit’s status-item rendering path, so macOS selects the correct contrast and dimming for each display. The title baseline is calculated from the fonts’ ascent and descent with a fixed one-point inter-line gap, rather than the rendered glyph bounds, so text such as `Test Event` cannot overlap its time.

The companion item is removed when MeetingBar returns to an inline layout, and the primary item collapses when the user has disabled status-bar icons to avoid leaving an empty gap.

### Visual validation
The following captures verify centered non-overlapping text and native tinting across light, colored, and inactive menu bars:

![Colored menu bar](https://github.com/user-attachments/assets/7f6cd588-efd8-4bdb-9eb9-b191e9acfaf6)

![Light menu bar](https://github.com/user-attachments/assets/43590e58-3e07-4add-8048-064823d6bff0)

![Inactive menu bar](https://github.com/user-attachments/assets/d7713ba4-73d2-46f2-a450-0a7c8cf1ba6c)

![Alternate colored menu bar](https://github.com/user-attachments/assets/e8ed6f04-d9e4-4062-b0a5-dc98348a8122)

### Automated validation
- `make validate-strings`
- `make test-logic-quiet`
- `make test-app-quiet`

## Checklist
- [x] Localized (no new user-facing strings)
- [x] Added to changelog:
  - [ ] Changelog View (release-specific content is added when a release version is assigned)
  - [x] CHANGELOG.md


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alignment of the status-bar title and time when the time appears below the title.
  * Improved stacked title rendering across primary and secondary displays, including inactive menu bars.
  * Preserved consistent spacing between the time and title across font styles.
  * Prevented unused spacing when a stacked status icon is unavailable.
  * Ensured stacked titles are removed when switching to an inline layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->